### PR TITLE
Customization feature fails on Windows

### DIFF
--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/IAggregator.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/IAggregator.java
@@ -316,4 +316,29 @@ public interface IAggregator {
 	 * the variable values.
 	 */
 	public String substituteProps(String str);
+	
+	/**
+	 * Like {@link #substituteProps(String)}, but allows the caller to specify
+	 * a transformer class to process the substitution values.
+	 * 
+	 * @param str The input string
+	 * @param transformer An instance of {@link SubstitutionTransformer}
+	 * @return The transformed string
+	 */
+	public String substituteProps(String str, SubstitutionTransformer transformer);
+	
+	/**
+	 * Transformer interface used by 
+	 * {@link IAggregator#substituteProps(String, SubstitutionTransformer)}. 
+	 */
+	public interface SubstitutionTransformer {
+		/**
+		 * Transforms the string property being substituted.
+		 * 
+		 * @param name the property name
+		 * @param str the property value
+		 * @return the transformed property value
+		 */
+		String transform(String name, String value);
+	};
 }

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorImpl.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorImpl.java
@@ -750,15 +750,19 @@ public class AggregatorImpl extends HttpServlet implements IExecutableExtension,
         return getCacheManager().getCache().getLayers().getLayer(request);
     }
 	
-	/**
-	 * Substitutes patterns of the form ${system.property} with the value of 
-	 * the specified system property.  Returns the modified string.
-	 * 
-	 * @param str The input string
-	 * @return The modified string
+	/* (non-Javadoc)
+	 * @see com.ibm.servlets.amd.aggregator.IAggregator#substituteProps(java.lang.String)
 	 */
 	@Override
 	public String substituteProps(String str) {
+		return substituteProps(str, null);
+	}
+
+	/* (non-Javadoc)
+	 * @see com.ibm.servlets.amd.aggregator.IAggregator#substituteProps(java.lang.String, com.ibm.servlets.amd.aggregator.IAggregator.SubstitutionTransformer)
+	 */
+	@Override
+	public String substituteProps(String str, SubstitutionTransformer transformer) {
 		if (str == null) {
 			return null;
 		}
@@ -789,14 +793,19 @@ public class AggregatorImpl extends HttpServlet implements IExecutableExtension,
 		    		}
 	    		}
 	    	}
-	    	if (propValue != null)
-	    		matcher.appendReplacement(buf, propValue);
-	    	else
+	    	if (propValue != null) {
+	    		if (transformer != null) {
+	    			propValue = transformer.transform(propName, propValue);
+	    		}
+	    		matcher.appendReplacement(buf, propValue.replace("\\", "\\\\")); //$NON-NLS-1$ //$NON-NLS-2$
+	    	} else {
 	    		matcher.appendReplacement(buf, "\\${"+propName+"}"); //$NON-NLS-1$ //$NON-NLS-2$
+	    	}
 	    }
 	    matcher.appendTail(buf);
 	    return buf.toString();
 	}
+	
 
 	/**
 	 * Loads the {@code IConfig} for this aggregator

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/config/ConfigImpl.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/config/ConfigImpl.java
@@ -679,7 +679,14 @@ public class ConfigImpl implements IConfig, IShutdownListener, IOptionsListener 
 			Object jsConsole = Context.javaToJS(console, sharedScope);
 			ScriptableObject.putProperty(sharedScope, "console", jsConsole); //$NON-NLS-1$
 			
-			cx.evaluateString(sharedScope, "var config = " + aggregator.substituteProps(configScript), getConfigUri().toString(), 1, null); //$NON-NLS-1$
+			cx.evaluateString(sharedScope, "var config = " + 
+				aggregator.substituteProps(configScript, new IAggregator.SubstitutionTransformer() {
+					@Override
+					public String transform(String name, String value) {
+						// escape forward slashes for javascript literals
+						return value.replace("\\", "\\\\");
+					}
+				}), getConfigUri().toString(), 1, null); //$NON-NLS-1$
 			config = (Scriptable)sharedScope.get("config", sharedScope); //$NON-NLS-1$
 			if (config == Scriptable.NOT_FOUND) {
 				System.out.println("config is not defined."); //$NON-NLS-1$

--- a/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/config/ConfigTests.java
+++ b/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/config/ConfigTests.java
@@ -170,8 +170,12 @@ public class ConfigTests {
 	@Test
 	public void testVariableSubstitution() throws Exception {
 		mockAggregator = new MockAggregatorWrapper() {
-			@Override public String substituteProps(String str) {
-				return str.replace("${REPLACE_THIS}", "file:/c:/substdir/");
+			@Override public String substituteProps(String str, IAggregator.SubstitutionTransformer transformer) {
+				str = str.replace("${REPLACE_THIS}", "file:/c:/substdir/");
+				if (transformer != null) {
+					str = transformer.transform("REPLACE_THIS", str);
+				}
+				return str;
 			}
 		};
 		String config = "{paths:{subst:'${REPLACE_THIS}/resources'}}";

--- a/jaggr-service/src/test/java/com/ibm/jaggr/service/test/MockAggregatorWrapper.java
+++ b/jaggr-service/src/test/java/com/ibm/jaggr/service/test/MockAggregatorWrapper.java
@@ -175,4 +175,10 @@ public class MockAggregatorWrapper implements IAggregator {
 		return mock.substituteProps(str);
 	}
 
+	@Override
+	public String substituteProps(String str,
+			SubstitutionTransformer transformer) {
+		return mock.substituteProps(str, transformer);
+	}
+
 }

--- a/jaggr-service/src/test/java/com/ibm/jaggr/service/test/TestUtils.java
+++ b/jaggr-service/src/test/java/com/ibm/jaggr/service/test/TestUtils.java
@@ -225,6 +225,11 @@ public class TestUtils {
 				return (String)EasyMock.getCurrentArguments()[0];
 			}
 		}).anyTimes();
+		EasyMock.expect(mockAggregator.substituteProps((String)EasyMock.anyObject(), (IAggregator.SubstitutionTransformer)EasyMock.anyObject())).andAnswer(new IAnswer<String>() {
+			public String answer() throws Throwable {
+				return (String)EasyMock.getCurrentArguments()[0];
+			}
+		}).anyTimes();
 		EasyMock.expect(mockAggregator.newLayerCache()).andAnswer(new IAnswer<ILayerCache>() {
 			public ILayerCache answer() throws Throwable {
 				return new LayerCacheImpl(mockAggregator);
@@ -301,6 +306,11 @@ public class TestUtils {
 			}
 		}).anyTimes();
 		EasyMock.expect(mockAggregator.substituteProps((String)EasyMock.anyObject())).andAnswer(new IAnswer<String>() {
+			public String answer() throws Throwable {
+				return (String)EasyMock.getCurrentArguments()[0];
+			}
+		}).anyTimes();
+		EasyMock.expect(mockAggregator.substituteProps((String)EasyMock.anyObject(), (IAggregator.SubstitutionTransformer)EasyMock.anyObject())).andAnswer(new IAnswer<String>() {
 			public String answer() throws Throwable {
 				return (String)EasyMock.getCurrentArguments()[0];
 			}


### PR DESCRIPTION
Handle forward slash in windows paths when specified in config using substitution variables
