### PR TITLE
Apply dojo's cache-bust to fixed up image urls if there's one specified.

### DIFF
--- a/jaggr-sample/WebContent/js/css.js
+++ b/jaggr-sample/WebContent/js/css.js
@@ -75,7 +75,7 @@ define([
 							}
 						}
 					}
-					url = parts.join("/");
+					url = require.toUrl(parts.join("/")); // Apply dojo's cache bust (if any)
 				}
 				return url;
 			};


### PR DESCRIPTION
Nifty.  I assume that the cache bust value is the one specified in djConfig and not necessarily the same as the one used in aggregator requests?

Looking at the implementation of toUrl in dojo.js, there's a lot of processing that goes on there.  Are we sure that calling toUrl won't have any unexpected side-effects with some configs?  Wouldn't it be safer to just append the value of djConfig.cacheBust to the url? 

I'm referring specifically to calling getModuleInfo which is done in toUrl.  Do we really want alias resolution, etc, to be applied to these URLs?
