### PR TITLE
Fix has cookie handling

### DIFF
--- a/jaggr-service/WebContent/dojo/featureCookie.js
+++ b/jaggr-service/WebContent/dojo/featureCookie.js
@@ -50,22 +50,25 @@ function(has, lang, md5, cookie) {
 				ret = "hashash=" + md5(haslist, 1);
 			}
 			var domain = window.location.hostname,
-			    numDots = domain.split(".").length;
+			    numDots = domain.split(".").length-1;
 			if (numDots === 1) {
 				// Need at least 2 dots in the cookie domain for most browsers.
 				// If there's only one, then we can add a leading dot to satisfy
 				// this requirement.
 				domain = '.' + domain;
 			} else if (numDots === 0) {
-				// If we have no dots (e.g. domain == 'localhost') then setting 
-				// the cookie domain to null works for most browsers.
+				// If we have no dots (e.g. domain == 'localhost') then don't set
+				// the domain property in the cookie.
 				domain = null;
 			}
-			cookie('has', haslist, {
+			var args = {
 				expire: haslist ? 1 : -1,
-				domain: domain,
 				path: contextPath
-			});
+			};
+			if (domain) {
+				args.domain = domain;
+			}
+			cookie('has', haslist, args);
 			return ret;
 		}
 	};


### PR DESCRIPTION
Fix dot counting logic.

If no dots in domain (e.g. localhost), then need to leave domain property out of cookie instead of setting domain with value of null.
