### PR TITLE
Use | instead of ; as feature string delimiter to save space in request

### DIFF
--- a/jaggr-service/WebContent/dojo/featureCookie.js
+++ b/jaggr-service/WebContent/dojo/featureCookie.js
@@ -41,11 +41,11 @@ function(has, lang, md5, cookie) {
 					return hasArg;
 				}
 			}
-			// hasArg is expected to begin with 'has=' followed by the semi-colon
+			// hasArg is expected to begin with 'has=' followed by the '|'
 			// delimited list of features
 			var haslist = null;		// clears the cookie if null
 			var ret = hasArg;
-			if (hasArg.indexOf("has=") === 0 && hasArg.indexOf(";") != -1) {
+			if (hasArg.indexOf("has=") === 0 && hasArg.indexOf("|") != -1) {
 				haslist = hasArg.substring(4);
 				ret = "hashash=" + md5(haslist, 1);
 			}

--- a/jaggr-service/WebContent/loaderExtCommon.js
+++ b/jaggr-service/WebContent/loaderExtCommon.js
@@ -206,7 +206,7 @@ var params = {
 		}
 		hasArr.sort();  // All has args must be represented in the same order for every request.
 		
-		return (hasArr.length ? ('has='+hasArr.join(";")): "");
+		return (hasArr.length ? ('has='+hasArr.join("|")): "");
 	};
 
 

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/transport/AbstractHttpTransport.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/transport/AbstractHttpTransport.java
@@ -371,7 +371,7 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 			if (log.isLoggable(Level.FINEST))
 				log.finest("Adding has parameters from request: " + has); //$NON-NLS-1$
 
-  			for (String s : has.split(";")) { //$NON-NLS-1$
+  			for (String s : has.split("[;|]")) { //$NON-NLS-1$
   				boolean value = true;
   				if (s.startsWith("!")) { //$NON-NLS-1$
   					s = s.substring(1);


### PR DESCRIPTION
since semi-colon gets encoded in URLs and cookies.
