### PR TITLE
Handle potential UnsupportedOperationException in AggregatorImpl.doGet()

### DIFF
--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/IAggregator.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/IAggregator.java
@@ -168,6 +168,10 @@ public interface IAggregator {
 	 * @param uri
 	 *            The URI for the resource
 	 * @return The newly created resource object.
+	 * 
+	 * @throws UnsupporteOperationException
+	 *             if there is no {@link IResourceFactory} registered to handle the
+	 *             specified uri.
 	 */
 	public IResource newResource(URI uri);
 

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/config/IConfig.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/config/IConfig.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.mozilla.javascript.Scriptable;
 
+import com.ibm.jaggr.service.IAggregator;
 import com.ibm.jaggr.service.InitParams;
 import com.ibm.jaggr.service.options.IOptions;
 import com.ibm.jaggr.service.resource.IResource;
@@ -311,6 +312,10 @@ public interface IConfig {
 
 	/**
 	 * Returns the URI for the config JavaScript file from which this config was read.
+	 * Note that the returned URI may specify an aggregator specific scheme such as 
+	 * namedbundleresource, so you should first use {@link IAggregator#newResource(URI)}
+	 * to convert the URI into an {@link IResource} and then use {@link IResource#getURI()}
+	 * to obtain a platform URI that you can use to open the file, etc.
 	 * 
 	 * @return The config JavaScript URI
 	 */

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorImpl.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorImpl.java
@@ -262,6 +262,13 @@ public class AggregatorImpl extends HttpServlet implements IExecutableExtension,
 				long lastModified = -1;
 				URI configUri = getConfig().getConfigUri();
 				if (configUri != null) {
+					try {
+						// try to get platform URI from IResource in case uri specifies 
+						// aggregator specific scheme like namedbundleresource
+						configUri = newResource(configUri).getURI();
+					} catch (UnsupportedOperationException e) {
+						// Not fatal.  Just use uri as specified.
+					}
 					lastModified = configUri.toURL().openConnection().getLastModified();
 				}
 				if (lastModified > getConfig().lastModified()) {


### PR DESCRIPTION
when converting configUri to IResource.
