### PR TITLE
Mitigate the impact of require list expansion on code size by filtering using expanded layer dependencies

### DIFF
--- a/jaggr-service/pom.xml
+++ b/jaggr-service/pom.xml
@@ -269,9 +269,19 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+     <dependency>
+       <groupId>org.powermock</groupId>
+       <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+     </dependency>
   </dependencies>
 </project>

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/IRequestListener.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/IRequestListener.java
@@ -19,9 +19,12 @@ package com.ibm.jaggr.service;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.ibm.jaggr.service.layer.ILayerListener;
 import com.ibm.jaggr.service.transport.IHttpTransport;
 
 /**
+ * @deprecated as of 1.1.7, replaced by {@link ILayerListener}
+ * 
  * Listener interface for HTTP request processing.  The start method
  * is called for all registered listeners by the aggregator
  * at the start of request processing.
@@ -29,6 +32,7 @@ import com.ibm.jaggr.service.transport.IHttpTransport;
  * Listeners are registered as an OSGi service using the name of 
  * the aggregator as the name attribute of the listener object.
  */
+@Deprecated
 public interface IRequestListener {
 	/**
 	 * Called by the aggregator at the start of request processing.

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/cache/ICacheManager.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/cache/ICacheManager.java
@@ -114,6 +114,18 @@ public interface ICacheManager {
 	public void createCacheFileAsync(String fileNamePrefix, Reader content, CreateCompletionCallback callback);
 
 	/**
+	 * Utility method to externalize an object on an asynchronous thread.
+	 * 
+	 * @param filename
+	 *            The prefix to use for the generated file name
+	 * @param object
+	 *            The object to externalize
+	 * @param callback
+	 *            The completion callback
+	 */
+	public void externalizeCacheObjectAsync(String filename, Object object, CreateCompletionCallback callback);
+	
+	/**
 	 * Utility method to asynchronously delete cache files after a delay 
 	 * period specified by {@link IOptions#getDeleteDelay()}.  The idea is
 	 * to delay deleting the cache file long enough so that any threads 

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/deps/ModuleDepInfo.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/deps/ModuleDepInfo.java
@@ -16,6 +16,7 @@
 
 package com.ibm.jaggr.service.deps;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -34,8 +35,10 @@ import com.ibm.jaggr.service.util.BooleanVar;
  * has! plugin conditionals used in has! plugin branching during require list
  * expansion and optional trace comments.
  */
-public class ModuleDepInfo {
+public class ModuleDepInfo implements Serializable {
 	
+	private static final long serialVersionUID = 8798463630504113388L;
+
 	/**
 	 * Boolean formula representing the has! plugin expressions used to refer to
 	 * the module associated with this object.  If null, then the module is 
@@ -59,6 +62,10 @@ public class ModuleDepInfo {
 	 * combining instances of this class using {@link #add(ModuleDepInfo)}
 	 */
 	private boolean isPluginNameDeclared = false;
+	
+	public ModuleDepInfo() {
+		this(null, null, null);
+	}
 	
 	/**
 	 * @param pluginName

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/deps/ModuleDeps.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/deps/ModuleDeps.java
@@ -16,9 +16,6 @@
 
 package com.ibm.jaggr.service.deps;
 
-import java.io.IOException;
-import java.io.NotSerializableException;
-import java.io.ObjectOutputStream;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -29,16 +26,21 @@ import com.ibm.jaggr.service.util.BooleanTerm;
 
 /**
  * This class extends LinkedHashMap to provide additional methods for 
- * managing a map of module names to ModuleDepInfo objects 
+ * managing a map of module names to ModuleDepInfo objects.
+ * 
+ * This class is not thread safe, so external provisions for thread
+ * safety need to be made if instances of this class are to be shared
+ * by multiple threads.
  */
-@SuppressWarnings("serial")
 public class ModuleDeps extends LinkedHashMap<String, ModuleDepInfo> {
 	
+	private static final long serialVersionUID = -8057569894102155520L;
+
 	public ModuleDeps() {
 	}
 	
 	public ModuleDeps(ModuleDeps other) {
-		super(other);
+		addAll(other);
 	}
 	
 	/**
@@ -52,13 +54,16 @@ public class ModuleDeps extends LinkedHashMap<String, ModuleDepInfo> {
 	 * @return true if the map was modified
 	 */
 	public boolean add(String key, ModuleDepInfo info) {
+		if (info == null) {
+			throw new NullPointerException();
+		}
 		boolean modified = false;
 		ModuleDepInfo existing = get(key);
-		if (existing != info) {
+		if (!containsKey(key) || existing != info) {
 			if (existing != null) {
 				modified = existing.add(info);
 			} else {
-				put(key, info);
+				super.put(key, info);
 				modified = true;
 			}
 		}
@@ -209,9 +214,15 @@ public class ModuleDeps extends LinkedHashMap<String, ModuleDepInfo> {
 		return this;
 	}
 	
-	// Instances of this class are NOT serializable
-	private void writeObject(ObjectOutputStream out) throws IOException {
-		throw new NotSerializableException();
+	@Override
+	public ModuleDepInfo put(String key, ModuleDepInfo value) {
+		throw new UnsupportedOperationException();
 	}
-	
+
+	@Override
+	public void putAll(Map<? extends String, ? extends ModuleDepInfo> map) {
+		throw new UnsupportedOperationException();
+	}
+
+
 }

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorLayerListener.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorLayerListener.java
@@ -1,0 +1,72 @@
+/*
+ * (C) Copyright 2012, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ibm.jaggr.service.impl;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+
+import com.ibm.jaggr.service.IAggregator;
+import com.ibm.jaggr.service.layer.ILayerListener;
+import com.ibm.jaggr.service.module.IModule;
+import com.ibm.jaggr.service.options.IOptions;
+import com.ibm.jaggr.service.transport.IHttpTransport;
+import com.ibm.jaggr.service.util.TypeUtil;
+
+public class AggregatorLayerListener implements ILayerListener {
+
+	public static final String PREAMBLEFMT = "\n/*-------- %s --------*/\n"; //$NON-NLS-1$
+	
+	private IAggregator aggregator;
+	
+	public AggregatorLayerListener(IAggregator aggregator) {
+		this.aggregator = aggregator;
+	}
+
+	@Override
+	public String layerBeginEndNotifier(EventType type,
+			HttpServletRequest request, List<IModule> modules,
+			Set<String> dependentFeatures) {
+		if (type == EventType.BEGIN_LAYER) {
+			StringBuffer sb = new StringBuffer();
+			// Add the application specified notice to the beginning of the response
+	        String notice = aggregator.getConfig().getNotice();
+	        if (notice != null) {
+				sb.append(notice).append("\r\n"); //$NON-NLS-1$
+	        }
+	        // If development mode is enabled, say so
+	        IOptions options = aggregator.getOptions();
+			if (options.isDevelopmentMode() || options.isDebugMode()) {
+				sb.append("/* ") //$NON-NLS-1$
+				  .append(options.isDevelopmentMode() ? 
+						  com.ibm.jaggr.service.impl.layer.Messages.LayerImpl_1 : 
+				          com.ibm.jaggr.service.impl.layer.Messages.LayerImpl_2)
+				  .append(" */\r\n"); //$NON-NLS-1$ 
+			}
+			return sb.toString();
+		} else if (type == EventType.BEGIN_MODULE) {
+	        IOptions options = aggregator.getOptions();
+			// Include the filename preamble if requested.
+			if ((options.isDebugMode() || options.isDevelopmentMode()) && TypeUtil.asBoolean(request.getAttribute(IHttpTransport.SHOWFILENAMES_REQATTRNAME))) {
+				return String.format(PREAMBLEFMT, modules.get(0).getURI().toString());
+			}
+		}		
+		return null;
+	}
+
+}

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/deps/BooleanFormula.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/deps/BooleanFormula.java
@@ -16,6 +16,7 @@
 
 package com.ibm.jaggr.service.impl.deps;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -41,8 +42,10 @@ import com.ibm.jaggr.service.util.BooleanVar;
  * The group of terms that are or'ed together are the formula encapsulated
  * by this object.
  */
-public class BooleanFormula implements Set<BooleanTerm> {
+public class BooleanFormula implements Set<BooleanTerm>, Serializable {
 	
+	private static final long serialVersionUID = 1202056345279875004L;
+
 	/**
 	 * A Set of {@link BooleanTerm} objects. A BooleanTerm is a set of variable
 	 * state objects that are logically and'ed together, while instances of this

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/deps/DepTree.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/deps/DepTree.java
@@ -444,7 +444,7 @@ public class DepTree implements Serializable {
 				}
 				target.overlay(temp);
 			} else {
-				throw new IllegalStateException("Missing required resource: " + filePath);
+				throw new IllegalStateException("Missing required resource: " + filePath); //$NON-NLS-1$
 			}
 		}
 

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/deps/DependenciesImpl.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/deps/DependenciesImpl.java
@@ -179,7 +179,7 @@ public class DependenciesImpl implements IDependencies, IConfigListener, IOption
 	public synchronized void optionsUpdated(IOptions options, long sequence) {
 		String previousCacheBust = cacheBust;
 		cacheBust = options.getCacheBust();
-		if (sequence > 1 && !cacheBust.equals(previousCacheBust) && rawConfig != null) {
+		if (sequence > 1 && cacheBust != null && !cacheBust.equals(previousCacheBust) && rawConfig != null) {
 			// Cache bust property has been updated subsequent to server startup
 			processDeps(false, false, sequence);
 		}

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/layer/ModuleBuildFuture.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/layer/ModuleBuildFuture.java
@@ -22,9 +22,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import com.ibm.jaggr.service.layer.ILayer;
+import com.ibm.jaggr.service.module.IModule;
 import com.ibm.jaggr.service.module.ModuleSpecifier;
 import com.ibm.jaggr.service.readers.ModuleBuildReader;
-import com.ibm.jaggr.service.resource.IResource;
 
 /**
  * This class encapsulates a {@link Future} for a {@link ModuleBuildReader},
@@ -36,12 +36,10 @@ public class ModuleBuildFuture implements Future<ModuleBuildReader> {
 	
 	private final Future<ModuleBuildReader> future;
 	private final ModuleSpecifier moduleSpecifier;
-	private final IResource resource;
-	private final String mid;
+	private final IModule module;
 
-	public ModuleBuildFuture(String mid, IResource resource, Future<ModuleBuildReader> future, ModuleSpecifier moduleSpecifier) {
-		this.mid = mid;
-		this.resource = resource;
+	public ModuleBuildFuture(IModule module, Future<ModuleBuildReader> future, ModuleSpecifier moduleSpecifier) {
+		this.module = module;
 		this.future = future;
 		this.moduleSpecifier = moduleSpecifier;
 	}
@@ -77,11 +75,7 @@ public class ModuleBuildFuture implements Future<ModuleBuildReader> {
 		return moduleSpecifier;
 	}
 	
-	public String getModuleId() {
-		return mid;
-	}
-
-	public IResource getResource() {
-		return resource;
+	public IModule getModule() {
+		return module;
 	}
 }

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/layer/ModuleList.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/layer/ModuleList.java
@@ -16,12 +16,18 @@
 
 package com.ibm.jaggr.service.impl.layer;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
 
 import com.ibm.jaggr.service.module.IModule;
 import com.ibm.jaggr.service.module.ModuleSpecifier;
 
+// This class is not thread safe.  It is assumed that it does not
+// need to be.  If that assumption changes, then the implementation 
+// will need to be reworked.
 class ModuleList extends LinkedList<ModuleList.ModuleListEntry> {
 	private static final long serialVersionUID = -5874021341817546757L;
 	
@@ -39,12 +45,14 @@ class ModuleList extends LinkedList<ModuleList.ModuleListEntry> {
 			return module;
 		}
 	}
-	private Set<String> dependentFeatures;
-	private Set<String> requiredModules;
+	private Set<String> dependentFeatures = null;
+	private Set<String> requiredModules = null;
 	
 	ModuleList() {
-		dependentFeatures = null;
-		requiredModules = null;
+	}
+	
+	ModuleList(List<ModuleListEntry> other) {
+		super(other);
 	}
 	
 	void setDependenentFeatures(Set<String> dependentFeatures) {
@@ -56,10 +64,24 @@ class ModuleList extends LinkedList<ModuleList.ModuleListEntry> {
 	}
 	
 	Set<String> getRequiredModules() {
+		if (requiredModules == null) {
+			requiredModules = new HashSet<String>();
+		}
 		return requiredModules;
 	}
 	
 	Set<String> getDependentFeatures() {
+		if (dependentFeatures == null) {
+			dependentFeatures = new HashSet<String>();
+		}
 		return dependentFeatures;
+	}
+	
+	List<IModule> getModules() {
+		List<IModule> result = new ArrayList<IModule>(size());
+		for (ModuleListEntry entry : this) {
+			result.add(entry.getModule());
+		}
+		return result;
 	}
 }

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/modulebuilder/i18n/I18nModuleBuilder.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/modulebuilder/i18n/I18nModuleBuilder.java
@@ -139,6 +139,11 @@ extends JavaScriptModuleBuilder {
 		return result;
 	}
 
+	@Override
+	public String layerBeginEndNotifier(EventType type, HttpServletRequest request, List<IModule> modules, Set<String> dependentFeatures) {
+		return null;
+	}
+	
 	private void processLocale(IResource resource, List<IModule> result,
 			Matcher m, Collection<String> availableLocales, Set<String> added,
 			IAggregator aggr, String bundleName, String locale)

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/modulebuilder/javascript/JavaScriptBuildRenderer.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/modulebuilder/javascript/JavaScriptBuildRenderer.java
@@ -1,0 +1,133 @@
+/*
+ * (C) Copyright 2012, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ibm.jaggr.service.impl.modulebuilder.javascript;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+
+import com.ibm.jaggr.service.deps.ModuleDeps;
+import com.ibm.jaggr.service.modulebuilder.IModuleBuildRenderer;
+
+class JavaScriptBuildRenderer implements Serializable, IModuleBuildRenderer {
+	
+	/**
+	 * Format string for the place holder module name used to stand in for the
+	 * expanded require list. Note that the punctuation characters (including
+	 * space and curly braces) in the string prevents the compiler from trying
+	 * to optimize the module list array by replacing it with a single string
+	 * for the form "moduleA moduleB moduleC".split(' '), where the separator
+	 * character can be any of the punctuation characters that are included in
+	 * the place holder string.
+	 */
+	static final String REQUIRE_EXPANSION_PLACEHOLDER_FMT = "$/{jaggr expand require,%1$d};/$"; //$NON-NLS-1$
+	
+	/**
+	 * Format string for the place holder module name used to stand in for the
+	 * expanded require list in log messages.
+	 */
+	static final String REQUIRE_EXPANSION_LOG_PLACEHOLDER_FMT = "$/{jaggr expand require,%1$d}log;/$"; //$NON-NLS-1$
+
+	/**
+	 * Regular expression pattern for locating the place holder module name used
+	 * to stand in for the expanded require list.
+	 */
+	static final Pattern REQUIRE_EXPANSION_PLACEHOLDER_PAT = 
+			Pattern.compile("(,\"\\$/\\{jaggr expand require,([0-9]+)\\};/\\$\")|(\\$/\\{jaggr expand require,([0-9]+)\\}log;/\\$)", Pattern.MULTILINE); //$NON-NLS-1$
+	
+	private static final long serialVersionUID = -2475505194723490517L;
+
+	/**
+	 * The compiled module fragments.  The compiled module is split into
+	 * fragments at the points where expanded dependencies will be 
+	 * inserted into the end of require calls.
+	 */
+	private List<String> contentFragments = new ArrayList<String>();
+	
+	/**
+	 * The list of expended dependencies for require calls within the
+	 * compiled modules. 
+	 */
+	private List<ModuleDeps> expandedDeps = new ArrayList<ModuleDeps>();
+	
+	private List<Boolean> isLogOutput = null;
+	
+	public JavaScriptBuildRenderer(String content, List<ModuleDeps> depsList, boolean isReqExpLogging) {
+		if (isReqExpLogging) {
+			isLogOutput = new ArrayList<Boolean>();
+		}
+		Matcher m = REQUIRE_EXPANSION_PLACEHOLDER_PAT.matcher(content);
+		// Note that the number of matches can be less than the number of
+		// elements in depsList due to dead code removal by the optimizer
+		while (m.find()) {
+			String strIdx = m.group(2);
+			boolean isLog = false;
+			if (strIdx == null) {
+				strIdx = m.group(4);
+				isLog = true;
+			}
+			int depIdx = Integer.parseInt(strIdx);
+			StringBuffer sb = new StringBuffer();
+			m.appendReplacement(sb, ""); //$NON-NLS-1$
+			contentFragments.add(sb.toString());
+			expandedDeps.add(depsList.get(depIdx));
+			if (isReqExpLogging) {
+				isLogOutput.add(isLog);
+			}
+		}
+		StringBuffer sb = new StringBuffer();
+		m.appendTail(sb);
+		contentFragments.add(sb.toString());
+	}
+	
+	
+	public String renderBuild(HttpServletRequest request) {
+		ModuleDeps enclosingDeps = (ModuleDeps)request.getAttribute(JavaScriptModuleBuilder.EXPANDED_DEPENDENCIES);
+		if (expandedDeps == null || expandedDeps.size() == 0) {
+			return contentFragments.get(0);
+		}
+		StringBuffer sb = new StringBuffer();
+		int i;
+		for (i = 0; i < expandedDeps.size(); i++) {
+			ModuleDeps expanded = new ModuleDeps(expandedDeps.get(i));
+			if (enclosingDeps != null) {
+				expanded.subtractAll(enclosingDeps);
+			}
+			expanded.simplify();
+			Set<String> moduleIds = expanded.getModuleIds();
+			sb.append(contentFragments.get(i));
+			boolean isLog = isLogOutput != null && isLogOutput.get(i);
+			int j = 0;
+			if (!moduleIds.isEmpty()) {
+				for (String s : moduleIds) {
+					if (isLog) {
+						sb.append(j++ > 0 ? ", " : "").append(s); //$NON-NLS-1$ //$NON-NLS-2$
+					} else {
+						sb.append(",\"").append(s).append("\""); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}
+			}
+		}
+		sb.append(contentFragments.get(i));
+		return sb.toString();
+	}
+}

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/modulebuilder/javascript/Messages.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/modulebuilder/javascript/Messages.java
@@ -22,6 +22,8 @@ public class Messages extends NLS {
 	private static final String BUNDLE_NAME = "com.ibm.jaggr.service.impl.modulebuilder.javascript.messages"; //$NON-NLS-1$
 	public static String JavaScriptModuleBuilder_0;
 	public static String JavaScriptModuleBuilder_1;
+	public static String JavaScriptModuleBuilder_2;
+	public static String JavaScriptModuleBuilder_3;
 	public static String RequireExpansionCompilerPass_0;
 	public static String RequireExpansionCompilerPass_1;
 	public static String RequireExpansionCompilerPass_10;

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/modulebuilder/javascript/messages_en.properties
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/modulebuilder/javascript/messages_en.properties
@@ -22,6 +22,8 @@
 JavaScriptModuleBuilder_0=Source resource not found: {0}
 # {0} = a resource URI
 JavaScriptModuleBuilder_1=Error compiling module: {0}
+JavaScriptModuleBuilder_2=Expanded dependencies for config deps:
+JavaScriptModuleBuilder_3=Expanded dependencies for layer deps:
 # {0} = a number
 RequireExpansionCompilerPass_0=call to require function at line {0}
 # {0} = a number

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/layer/ILayerListener.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/layer/ILayerListener.java
@@ -1,0 +1,82 @@
+/*
+ * (C) Copyright 2012, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ibm.jaggr.service.layer;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+
+import com.ibm.jaggr.service.IAggregator;
+import com.ibm.jaggr.service.module.IModule;
+import com.ibm.jaggr.service.modulebuilder.ModuleBuild;
+
+/**
+ * Listener interface for Layer events. To receive notification of layer events,
+ * register an instance of the implementing class as an OSGi service. The
+ * listener registration should specify a filter using the name property with
+ * the value obtained by calling {@link IAggregator#getName()}.
+ */
+public interface ILayerListener {
+	
+	enum EventType {
+		/**
+		 * This event fires before any of the module builders for the layer are
+		 * started.
+		 */
+		BEGIN_LAYER,
+		
+		/**
+		 * This event fires after all of the module builders have completed
+		 * successfully and their output has been added to the layer.
+		 */
+		END_LAYER,
+		
+		/**
+		 * This event fires before each module is added to the layer.
+		 */
+		BEGIN_MODULE
+	}
+	
+	/**
+	 * Listener notification callback that is called for the event specified by
+	 * <code>type</code>. If the returned string is not null, then the value
+	 * will be added to the response stream either before, or after, the layer
+	 * content, depending on the event type.
+	 * 
+	 * @param type
+	 *            Indicates whether a layer is starting or finishing.
+	 * @param request
+	 *            The HTTP request object.
+	 * @param modules
+	 *            The list of modules in the layer.  Note that modules added to
+	 *            the layer by module builders using the 
+	 *            {@link ModuleBuild#addBefore(IModule)} and 
+	 *            {@link ModuleBuild#addAfter(IModule)} methods are not included
+	 *            in the list.  For the BEGIN_MODULE event, the list contains 
+	 *            only the single module that is being added to the layer.
+	 * @param dependentFeatures
+	 *            Output - If the returned value depends on any features specified
+	 *            in the request, then those features should be added to
+	 *            <code>dependentFeatures</code>.  These will be included in the
+	 *            construction of the cache key for the layer.
+	 * @return The string to be added to the response, or null.
+	 */
+	public String layerBeginEndNotifier(EventType type, HttpServletRequest request, 
+			List<IModule> modules, Set<String> dependentFeatures);
+
+}

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/modulebuilder/IModuleBuildRenderer.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/modulebuilder/IModuleBuildRenderer.java
@@ -1,0 +1,50 @@
+/*
+ * (C) Copyright 2012, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ibm.jaggr.service.modulebuilder;
+
+import javax.servlet.http.HttpServletRequest;
+
+import com.ibm.jaggr.service.cachekeygenerator.ICacheKeyGenerator;
+import com.ibm.jaggr.service.layer.ILayerListener;
+
+/**
+ * If the object returned by {@link ModuleBuild#getBuildOutput()} implements 
+ * this interface, then the object's <code>renderBuild</code> method will be
+ * called to obtain the build output string which will be included in the 
+ * layer that is being assembled.  Otherwise, the object's <code>toString</code>
+ * method is called.
+ * <p>
+ * For example, The JavaScript module builder uses this method to render 
+ * module list expansion in require calls after filtering the list using the
+ * loaded dependencies for the layer (specified in a request attribute in the 
+ * request object).
+ * <p>
+ * If the rendered build is dependent upon features specified in the request
+ * which may not be accounted for by the build's {@link ICacheKeyGenerator}, then
+ * the module builder should register an {@link ILayerListener} service so that
+ * the dependent features can be specified using the listener's notifier method. 
+ */
+public interface IModuleBuildRenderer {
+	
+	/**
+	 * Called to render the build for the specified request.  
+	 * 
+	 * @param request the request object
+	 * @return the rendered build
+	 */
+	public String renderBuild(HttpServletRequest request);
+}

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/modulebuilder/IModuleBuilder.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/modulebuilder/IModuleBuilder.java
@@ -17,14 +17,15 @@
 package com.ibm.jaggr.service.modulebuilder;
 
 import java.util.List;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
 import com.ibm.jaggr.service.IAggregator;
 import com.ibm.jaggr.service.IExtensionInitializer;
 import com.ibm.jaggr.service.IExtensionInitializer.IExtensionRegistrar;
-import com.ibm.jaggr.service.IRequestListener;
 import com.ibm.jaggr.service.cachekeygenerator.ICacheKeyGenerator;
+import com.ibm.jaggr.service.layer.ILayerListener;
 import com.ibm.jaggr.service.resource.IResource;
 import com.ibm.jaggr.service.transport.IHttpTransport;
 
@@ -122,11 +123,13 @@ public interface IModuleBuilder {
 	 * <p>
 	 * If, for some reason, a module builder is unable to provide named modules
 	 * for a request, then the module builder should register a
-	 * {@link IRequestListener} service with the OSGi service registry,
+	 * {@link ILayerListener} service with the OSGi service registry,
 	 * specifying the name of the aggregator as the {@code name} property of the
 	 * service, and then set the value of the
 	 * {@link IHttpTransport#EXPORTMODULENAMES_REQATTRNAME} request attribute to
-	 * false in the {@link IRequestListener#startRequest} method.
+	 * false in the 
+	 * {@link ILayerListener#layerBeginEndNotifier(ILayerListener.EventType, HttpServletRequest, List, Set)} 
+	 * method.
 	 * <p>
 	 * This method may choose to return a build containing multiple named
 	 * modules if the request attribute specified by

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/modulebuilder/ModuleBuild.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/modulebuilder/ModuleBuild.java
@@ -34,7 +34,7 @@ import com.ibm.jaggr.service.resource.IResource;
  * {@link IModuleBuilder#build(String, IResource, HttpServletRequest, List)}.
  */
 public final class ModuleBuild {
-	private String buildOutput;
+	private Object buildOutput;
 	private List<IModule> before;
 	private List<IModule> after;
 	private List<ICacheKeyGenerator> keyGenerators;
@@ -47,7 +47,7 @@ public final class ModuleBuild {
 	 * @param buildOutput
 	 *            The built output for the module
 	 */
-	public ModuleBuild(String buildOutput) {
+	public ModuleBuild(Object buildOutput) {
 		this(buildOutput, null, false);
 	}
 
@@ -66,7 +66,7 @@ public final class ModuleBuild {
 	 * @param error
 	 *            True if an error occurred while generating the build
 	 */
-	public ModuleBuild(String buildOutput, List<ICacheKeyGenerator> keyGens, boolean error) {
+	public ModuleBuild(Object buildOutput, List<ICacheKeyGenerator> keyGens, boolean error) {
 		this.buildOutput = buildOutput;
 		this.keyGenerators = keyGens;
 		this.before = this.after = null;
@@ -82,7 +82,7 @@ public final class ModuleBuild {
 	 * 
 	 * @return the build outupt
 	 */
-	public String getBuildOutput() {
+	public Object getBuildOutput() {
 		return buildOutput;
 	}
 

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/util/BooleanTerm.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/util/BooleanTerm.java
@@ -16,9 +16,6 @@
 
 package com.ibm.jaggr.service.util;
 
-import java.io.IOException;
-import java.io.NotSerializableException;
-import java.io.ObjectOutputStream;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
@@ -28,9 +25,10 @@ import java.util.TreeSet;
  * A collection of BooleanVar objects which are logically anded together.
  * Implements an unmodifiable set of BooleanVar objects. 
  */
-@SuppressWarnings("serial")
 public class BooleanTerm extends TreeSet<BooleanVar> {
 	
+	private static final long serialVersionUID = -2969569532410527153L;
+
 	public static BooleanTerm emptyTerm = new BooleanTerm(Collections.<BooleanVar> emptySet());
 
 	private boolean initialized = false;	// true except when the object is being constructed
@@ -145,10 +143,5 @@ public class BooleanTerm extends TreeSet<BooleanVar> {
 	@Override
 	public boolean retainAll(Collection<?> collection) {
 		throw new UnsupportedOperationException();
-	}
-	
-	// Instances of this class are NOT serializable
-	private void writeObject(ObjectOutputStream out) throws IOException {
-		throw new NotSerializableException();
 	}
 }

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/util/BooleanVar.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/util/BooleanVar.java
@@ -16,11 +16,15 @@
 
 package com.ibm.jaggr.service.util;
 
+import java.io.Serializable;
+
 /**
  *	Represents the state of a boolean variable.  Instances of this
  *	object are immutable.
  */
-public class BooleanVar implements Comparable<BooleanVar> {
+public class BooleanVar implements Comparable<BooleanVar>, Serializable {
+	private static final long serialVersionUID = 6578878301251930259L;
+
 	public final String name;
 	public final boolean state;
 	

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/util/DependencyList.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/util/DependencyList.java
@@ -119,6 +119,9 @@ public class DependencyList {
 	 * @param includeDetails
 	 *            Flag indicating if diagnostic details should be included with
 	 *            the expanded dependencies
+	 * @param performHasBranching
+	 *            Flag indicating if has branching should be performed during
+	 *            require list expansion
 	 */
 	@SuppressWarnings("unchecked")
 	public DependencyList(Iterable<String> names, IConfig config, IDependencies deps, Features features, boolean includeDetails, boolean performHasBranching) {

--- a/jaggr-service/src/test/java/com/ibm/jaggr/service/EverythingSuite.java
+++ b/jaggr-service/src/test/java/com/ibm/jaggr/service/EverythingSuite.java
@@ -22,6 +22,7 @@ import org.junit.runners.Suite;
 import com.ibm.jaggr.service.deps.ModuleDepInfoTest;
 import com.ibm.jaggr.service.deps.ModuleDepsTest;
 import com.ibm.jaggr.service.impl.AggregatorImplTest;
+import com.ibm.jaggr.service.impl.cache.CacheManagerImplTest;
 import com.ibm.jaggr.service.impl.config.ConfigTests;
 import com.ibm.jaggr.service.impl.deps.BooleanFormulaTest;
 import com.ibm.jaggr.service.impl.deps.DepTreeNodeTests;
@@ -36,7 +37,7 @@ import com.ibm.jaggr.service.impl.modulebuilder.css.CSSModuleBuilderTest;
 import com.ibm.jaggr.service.impl.modulebuilder.i18n.I18nModuleBuilderTest;
 import com.ibm.jaggr.service.impl.modulebuilder.javascript.ExportModuleNameCompilerPassTest;
 import com.ibm.jaggr.service.impl.modulebuilder.javascript.HasFilteringCompilerPassTest;
-import com.ibm.jaggr.service.impl.modulebuilder.javascript.JsModuleContentProviderTest;
+import com.ibm.jaggr.service.impl.modulebuilder.javascript.JavaScriptModuleBuilderTest;
 import com.ibm.jaggr.service.impl.modulebuilder.javascript.RequireExpansionCompilerPassTest;
 import com.ibm.jaggr.service.impl.modulebuilder.text.TxtModuleContentProviderTest;
 import com.ibm.jaggr.service.impl.resource.BundleResourceFactoryTests;
@@ -62,13 +63,14 @@ import com.ibm.jaggr.service.impl.transport.DojoHttpTransportTest;
 	I18nModuleBuilderTest.class,
 	ExportModuleNameCompilerPassTest.class,
 	HasFilteringCompilerPassTest.class,
-	JsModuleContentProviderTest.class,
+	JavaScriptModuleBuilderTest.class,
 	TxtModuleContentProviderTest.class,
 	RequireExpansionCompilerPassTest.class,
 	AbstractHttpTransportTest.class,
 	DojoHttpTransportTest.class,
 	AggregatorImplTest.class,
 	BundleResourceFactoryTests.class,
-	FileResourceTests.class
+	FileResourceTests.class,
+	CacheManagerImplTest.class
 })
 public class EverythingSuite { }

--- a/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/cache/CacheManagerImplTest.java
+++ b/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/cache/CacheManagerImplTest.java
@@ -1,0 +1,102 @@
+/*
+ * (C) Copyright 2012, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ibm.jaggr.service.impl.cache;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.regex.Pattern;
+
+import junit.framework.Assert;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.io.Files;
+import com.ibm.jaggr.service.IAggregator;
+import com.ibm.jaggr.service.cache.ICacheManager;
+import com.ibm.jaggr.service.cache.ICacheManager.CreateCompletionCallback;
+import com.ibm.jaggr.service.test.TestUtils;
+
+public class CacheManagerImplTest {
+	
+	private File tmpDir;
+	private IAggregator mockAggregator;
+	
+	private static class TestObj implements Serializable {
+		private static final long serialVersionUID = 1L;
+		private final boolean canSerialize;
+		private final String str;
+		public TestObj(String str, boolean canSerialize) { this.str = str; this.canSerialize = canSerialize;}
+		@Override public String toString() { return str; }
+		private void writeObject(ObjectOutputStream out) throws IOException {
+			if (canSerialize) {
+				out.defaultWriteObject();
+			} else {
+				throw new NotSerializableException();
+			}
+		}
+		
+		
+	}
+
+	@Before 
+	public void setup() throws Exception {
+		tmpDir = Files.createTempDir();
+		mockAggregator = TestUtils.createMockAggregator(null, tmpDir);
+		EasyMock.replay(mockAggregator);
+		
+	}
+
+	@Test
+	public void testExternalizeObjectAsync() throws Exception {
+		// mockAggregator uses a synchronous executor, so the callback
+		// executes before the externalizeObjectAsync returns.
+		final boolean[] callbackCalled = new boolean[]{false};
+		final String[] cacheFilename = new String[1];
+		final ICacheManager cacheMgr = mockAggregator.getCacheManager();
+		cacheMgr.externalizeCacheObjectAsync("testObj.", new TestObj("Hello World!", true), new CreateCompletionCallback() {
+			@Override public void completed(String filename, Exception e) {
+				cacheFilename[0] = filename;
+				Assert.assertTrue(Pattern.compile("testObj\\.[^.]+\\.cache").matcher(filename).find());
+				callbackCalled[0] = true;
+			}
+		});
+		Assert.assertTrue(callbackCalled[0]);
+		// Now deserialize the object and make sure it's valid
+		File cacheFile = new File(cacheMgr.getCacheDir(), cacheFilename[0]);
+		ObjectInputStream is = new ObjectInputStream(new FileInputStream(cacheFile));
+		TestObj cached = (TestObj) is.readObject();
+		is.close();
+		Assert.assertEquals(cached.toString(), "Hello World!");
+		
+		// Now try to serialize an object that will throw an exception
+		callbackCalled[0] = false;
+		cacheMgr.externalizeCacheObjectAsync("testObj.", new TestObj("Hello World!", false), new CreateCompletionCallback() {
+			@Override public void completed(String filename, Exception e) {
+				Assert.assertTrue(Pattern.compile("testObj\\.[^.]+\\.cache").matcher(filename).find());
+				Assert.assertEquals(e.getClass(), NotSerializableException.class);
+				callbackCalled[0] = true;
+			}
+		});
+	}
+}

--- a/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/layer/LayerBuilderTest.java
+++ b/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/layer/LayerBuilderTest.java
@@ -16,25 +16,35 @@
 
 package com.ibm.jaggr.service.impl.layer;
 
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.getCurrentArguments;
+import static org.easymock.EasyMock.isA;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.reset;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Future;
 import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
 
 import junit.framework.Assert;
+import junit.framework.AssertionFailedError;
 
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
@@ -43,17 +53,25 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
 
 import com.ibm.jaggr.service.IAggregator;
+import com.ibm.jaggr.service.cache.ICache;
 import com.ibm.jaggr.service.cachekeygenerator.ExportNamesCacheKeyGenerator;
 import com.ibm.jaggr.service.cachekeygenerator.ICacheKeyGenerator;
-import com.ibm.jaggr.service.config.IConfig;
-import com.ibm.jaggr.service.impl.resource.FileResource;
+import com.ibm.jaggr.service.impl.AggregatorLayerListener;
+import com.ibm.jaggr.service.impl.layer.ModuleList.ModuleListEntry;
+import com.ibm.jaggr.service.impl.module.ModuleImpl;
+import com.ibm.jaggr.service.layer.ILayerListener;
+import com.ibm.jaggr.service.layer.ILayerListener.EventType;
+import com.ibm.jaggr.service.module.IModule;
+import com.ibm.jaggr.service.module.IModuleCache;
 import com.ibm.jaggr.service.module.ModuleSpecifier;
 import com.ibm.jaggr.service.options.IOptions;
 import com.ibm.jaggr.service.readers.ModuleBuildReader;
+import com.ibm.jaggr.service.test.TestCacheManager;
 import com.ibm.jaggr.service.test.TestUtils;
-import com.ibm.jaggr.service.test.TestUtils.Ref;
 import com.ibm.jaggr.service.transport.IHttpTransport;
 import com.ibm.jaggr.service.transport.IHttpTransport.LayerContributionType;
 import com.ibm.jaggr.service.util.CopyUtil;
@@ -135,87 +153,64 @@ public class LayerBuilderTest {
 		EasyMock.replay(mockRequest);
 		EasyMock.replay(mockAggregator);
 		List<ICacheKeyGenerator> keyGens = new LinkedList<ICacheKeyGenerator>();
+		ModuleList moduleList;
+		Map<String, String> content = new HashMap<String, String>();
+		content.put("m1", "foo");
+		content.put("m2", "bar");
 
 		// Single module specified with 'modules' query arg
-		LayerBuilder builder = new LayerBuilder(mockRequest, keyGens, Collections.<String> emptySet());
-		ModuleBuildReader mbr = new ModuleBuildReader(new StringReader("foo"));
-		ModuleBuildFuture future = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(mbr),
-				ModuleSpecifier.MODULES
-		);
-		
-		Reader reader = builder.build(Arrays.asList(new ModuleBuildFuture[]{future}));
+		moduleList = new ModuleList(Arrays.asList(new ModuleListEntry[] {
+				new ModuleListEntry(new ModuleImpl("m1", new URI("file:/c:/m1.js")), ModuleSpecifier.MODULES)
+		}));
+		TestLayerBuilder builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content);
+		Reader reader = builder.build();
 		String output = toString(reader);
+		System.out.println(output);
 		Assert.assertEquals("[(\"<m1>foo<m1>\")]", output);
-		System.out.println(output);
-		
+
 		// Two modules specified with 'modules' query arg
-		builder = new LayerBuilder(mockRequest, keyGens, Collections.<String> emptySet());
-		ModuleBuildFuture future1 = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("foo"))),
-				ModuleSpecifier.MODULES
-		);
 		
-		ModuleBuildFuture future2 = new ModuleBuildFuture(
-				"m2", 
-				new FileResource(new URI("file:/c:/m2.js")),
-				new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"))),
-				ModuleSpecifier.MODULES
-		);
-		reader = builder.build(Arrays.asList(new ModuleBuildFuture[]{future1, future2}));
+		moduleList = new ModuleList(Arrays.asList(new ModuleListEntry[] {
+				new ModuleListEntry(new ModuleImpl("m1", new URI("file:/c:/m1.js")), ModuleSpecifier.MODULES),
+				new ModuleListEntry(new ModuleImpl("m2", new URI("file:/c:/m2.js")), ModuleSpecifier.MODULES),
+		}));
+		builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content);
+		reader = builder.build();
 		output = toString(reader);
-		Assert.assertEquals("[(\"<m1>foo<m1>\",\"<m2>bar<m2>\")]", output);
 		System.out.println(output);
+		Assert.assertEquals("[(\"<m1>foo<m1>\",\"<m2>bar<m2>\")]", output);
 		
+	
 		// Test developmentMode and showFilenames
 		IOptions options = mockAggregator.getOptions();
 		options.setOption("developmentMode", "true");
 		requestAttributes.put(IHttpTransport.SHOWFILENAMES_REQATTRNAME, Boolean.TRUE);
-		builder = new LayerBuilder(mockRequest, keyGens, Collections.<String> emptySet());
-		future = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("foo"))),
-				ModuleSpecifier.MODULES
-		);
-		reader = builder.build(Arrays.asList(new ModuleBuildFuture[]{future}));
+		moduleList = new ModuleList(Arrays.asList(new ModuleListEntry[] {
+				new ModuleListEntry(new ModuleImpl("m1", new URI("file:/c:/m1.js")), ModuleSpecifier.MODULES)
+		}));
+		builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content);
+		reader = builder.build();
 		output = toString(reader);
 		Assert.assertEquals(
-				"/* " + Messages.LayerImpl_1 + " */\r\n["+String.format(LayerBuilder.PREAMBLEFMT, "file:/c:/m1.js") + "(\"<m1>foo<m1>\")]",
+				"/* " + Messages.LayerImpl_1 + " */\r\n[("+String.format(AggregatorLayerListener.PREAMBLEFMT, "file:/c:/m1.js") + "\"<m1>foo<m1>\")]",
 				output);
 		System.out.println(output);
 
 		// debugMode and showFilenames
 		options.setOption("developmentMode", Boolean.FALSE);
 		options.setOption("debugMode", Boolean.TRUE);
-		builder = new LayerBuilder(mockRequest, keyGens, Collections.<String> emptySet());
-		future = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("foo"))),
-				ModuleSpecifier.MODULES
-		);
-		reader = builder.build(Arrays.asList(new ModuleBuildFuture[]{future}));
+		builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content);
+		reader = builder.build();
 		output = toString(reader);
 		Assert.assertEquals(
-				"/* " + Messages.LayerImpl_2 + " */\r\n["+String.format(LayerBuilder.PREAMBLEFMT, "file:/c:/m1.js") + "(\"<m1>foo<m1>\")]",
+				"/* " + Messages.LayerImpl_2 + " */\r\n[("+String.format(AggregatorLayerListener.PREAMBLEFMT, "file:/c:/m1.js") + "\"<m1>foo<m1>\")]",
 				output);
 		System.out.println(output);
 		
 		// showFilenames only (no filenames output)
 		options.setOption("debugMode", Boolean.FALSE);
-		builder = new LayerBuilder(mockRequest, keyGens, Collections.<String> emptySet());
-		future = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("foo"))),
-				ModuleSpecifier.MODULES
-		);
-		reader = builder.build(Arrays.asList(new ModuleBuildFuture[]{future}));
+		builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content);
+		reader = builder.build();
 		output = toString(reader);
 		Assert.assertEquals("[(\"<m1>foo<m1>\")]", output);
 		System.out.println(output);
@@ -223,296 +218,458 @@ public class LayerBuilderTest {
 		// debugMode only (no filenames output)
 		options.setOption("debugMode", Boolean.TRUE);
 		requestAttributes.remove(IHttpTransport.SHOWFILENAMES_REQATTRNAME);
-		builder = new LayerBuilder(mockRequest, keyGens, Collections.<String> emptySet());
-		future = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("foo"))),
-				ModuleSpecifier.MODULES
-		);
-		reader = builder.build(Arrays.asList(new ModuleBuildFuture[]{future}));
+		builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content);
+		reader = builder.build();
 		output = toString(reader);
 		Assert.assertEquals(
 				"/* " + Messages.LayerImpl_2 + " */\r\n[(\"<m1>foo<m1>\")]",
 				output);
 		System.out.println(output);
-	
+		
 		// 1 required module
 		options.setOption("debugMode", "false");
-		builder = new LayerBuilder(mockRequest, keyGens, new HashSet<String>(Arrays.asList(new String[]{"m1"})));
-		future = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("foo"))),
-				ModuleSpecifier.REQUIRED
-		);
-		reader = builder.build(Arrays.asList(new ModuleBuildFuture[]{future}));
+		moduleList = new ModuleList(Arrays.asList(new ModuleListEntry[] {
+				new ModuleListEntry(new ModuleImpl("m1", new URI("file:/c:/m1.js")), ModuleSpecifier.REQUIRED)
+		}));
+		moduleList.setRequiredModules(new HashSet<String>(Arrays.asList(new String[]{"m1"})));
+		builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content);
+		reader = builder.build();
 		output = toString(reader);
 		Assert.assertEquals("[[m1]{'<m1>foo<m1>'}[m1]]", output);
 		System.out.println(output);
 
 		// two required modules
-		builder = new LayerBuilder(mockRequest, keyGens, new LinkedHashSet<String>(Arrays.asList(new String[]{"m1", "m2"})));
-		future1 = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("foo"))),
-				ModuleSpecifier.REQUIRED
-		);
-		
-		future2 = new ModuleBuildFuture(
-				"m2", 
-				new FileResource(new URI("file:/c:/m2.js")),
-				new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"))),
-				ModuleSpecifier.REQUIRED
-		);
-		reader = builder.build(Arrays.asList(new ModuleBuildFuture[]{future1, future2}));
+		moduleList = new ModuleList(Arrays.asList(new ModuleListEntry[] {
+				new ModuleListEntry(new ModuleImpl("m1", new URI("file:/c:/m1.js")), ModuleSpecifier.REQUIRED),
+				new ModuleListEntry(new ModuleImpl("m2", new URI("file:/c:/m2.js")), ModuleSpecifier.REQUIRED),
+		}));
+		moduleList.setRequiredModules(new HashSet<String>(Arrays.asList(new String[]{"m1", "m2"})));
+		builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content);
+		reader = builder.build();
 		output = toString(reader);
 		Assert.assertEquals("[[m1, m2]{'<m1>foo<m1>','<m2>bar<m2>'}[m1, m2]]", output);
 		System.out.println(output);
-		
+	
 		// one module and one required modules
-		builder = new LayerBuilder(mockRequest, keyGens, new HashSet<String>(Arrays.asList(new String[]{"m2"})));
-		future1 = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("foo"))),
-				ModuleSpecifier.MODULES
-		);
-		
-		future2 = new ModuleBuildFuture(
-				"m2", 
-				new FileResource(new URI("file:/c:/m2.js")),
-				new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"))),
-				ModuleSpecifier.REQUIRED
-		);
-		reader = builder.build(Arrays.asList(new ModuleBuildFuture[]{future1, future2}));
+		moduleList = new ModuleList(Arrays.asList(new ModuleListEntry[] {
+				new ModuleListEntry(new ModuleImpl("m1", new URI("file:/c:/m1.js")), ModuleSpecifier.MODULES),
+				new ModuleListEntry(new ModuleImpl("m2", new URI("file:/c:/m2.js")), ModuleSpecifier.REQUIRED),
+		}));
+		moduleList.setRequiredModules(new HashSet<String>(Arrays.asList(new String[]{"m2"})));
+		builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content);
+		reader = builder.build();
 		output = toString(reader);
 		Assert.assertEquals("[(\"<m1>foo<m1>\")[m2]{'<m2>bar<m2>'}[m2]]", output);
 		System.out.println(output);
 		
 		// one required module followed by one module (throws exception)
-		builder = new LayerBuilder(mockRequest, keyGens, Collections.<String> emptySet());
-		future1 = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("foo"))),
-				ModuleSpecifier.REQUIRED
-		);
-		
-		future2 = new ModuleBuildFuture(
-				"m2", 
-				new FileResource(new URI("file:/c:/m2.js")),
-				new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"))),
-				ModuleSpecifier.MODULES
-		);
+		moduleList = new ModuleList(Arrays.asList(new ModuleListEntry[] {
+				new ModuleListEntry(new ModuleImpl("m1", new URI("file:/c:/m1.js")), ModuleSpecifier.REQUIRED),
+				new ModuleListEntry(new ModuleImpl("m2", new URI("file:/c:/m2.js")), ModuleSpecifier.MODULES),
+		}));
+		moduleList.setRequiredModules(new HashSet<String>(Arrays.asList(new String[]{"m1"})));
+		builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content);
 		boolean exceptionCaught = false;
 		try {
-			 builder.build(Arrays.asList(new ModuleBuildFuture[]{future1, future2}));
+			reader = builder.build();
 		} catch (IllegalStateException ex) {
 			exceptionCaught = true;
 		}
 		Assert.assertTrue(exceptionCaught);
 		
 		// Test addBefore with required module
-		builder = new LayerBuilder(mockRequest, keyGens, new HashSet<String>(Arrays.asList(new String[]{"m1"})));
-		mbr = new ModuleBuildReader(new StringReader("foo"));
-		mbr.addBefore(
-				new ModuleBuildFuture(
-						"mBefore", 
-						new FileResource(new URI("file:/c:/mBefore.js")),
-						new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"))),
-						ModuleSpecifier.BUILD_ADDED)	
-		);
-		
-		future = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(mbr),
-				ModuleSpecifier.REQUIRED
-		);
-		reader = builder.build(Arrays.asList(new ModuleBuildFuture[]{future}));
+		moduleList = new ModuleList(Arrays.asList(new ModuleListEntry[] {
+				new ModuleListEntry(new ModuleImpl("m1", new URI("file:/c:/m1.js")), ModuleSpecifier.REQUIRED),
+		}));
+		moduleList.setRequiredModules(new HashSet<String>(Arrays.asList(new String[]{"m1"})));
+		builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content) {
+			@Override
+			protected List<ModuleBuildFuture> collectFutures(ModuleList moduleList, HttpServletRequest request)
+					throws IOException {
+				List<ModuleBuildFuture> futures = super.collectFutures(moduleList, request);
+				try {
+					ModuleBuildReader mbr = futures.get(0).get();
+					mbr.addBefore(
+							new ModuleBuildFuture(
+									new ModuleImpl("mBefore", new URI("file:/c:/mBefore.js")),
+									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"))),
+									ModuleSpecifier.BUILD_ADDED)	
+					);
+				} catch (Exception e) {
+					throw new IOException(e.getMessage(), e);
+				}
+				return futures;
+			}
+		};
+		reader = builder.build();
 		output = toString(reader);
 		Assert.assertEquals("[[m1]{'<mBefore>bar<mBefore>','<m1>foo<m1>'}[m1]]", output);
 		System.out.println(output);
 	
 		// Test addBefore with module
-		builder = new LayerBuilder(mockRequest, keyGens, Collections.<String> emptySet());
-		mbr = new ModuleBuildReader(new StringReader("foo"));
-		mbr.addBefore(
-				new ModuleBuildFuture(
-						"mBefore", 
-						new FileResource(new URI("file:/c:/mBefore.js")),
-						new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"))),
-						ModuleSpecifier.BUILD_ADDED)	
-		);
-		
-		future = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(mbr),
-				ModuleSpecifier.MODULES
-		);
-		reader = builder.build(Arrays.asList(new ModuleBuildFuture[]{future}));
+		moduleList = new ModuleList(Arrays.asList(new ModuleListEntry[] {
+				new ModuleListEntry(new ModuleImpl("m1", new URI("file:/c:/m1.js")), ModuleSpecifier.MODULES),
+		}));
+		builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content) {
+			@Override
+			protected List<ModuleBuildFuture> collectFutures(ModuleList moduleList, HttpServletRequest request)
+					throws IOException {
+				List<ModuleBuildFuture> futures = super.collectFutures(moduleList, request);
+				try {
+					ModuleBuildReader mbr = futures.get(0).get();
+					mbr.addBefore(
+							new ModuleBuildFuture(
+									new ModuleImpl("mBefore", new URI("file:/c:/mBefore.js")),
+									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"))),
+									ModuleSpecifier.BUILD_ADDED)	
+					);
+				} catch (Exception e) {
+					throw new IOException(e.getMessage(), e);
+				}
+				return futures;
+			}
+		};
+		reader = builder.build();
 		output = toString(reader);
 		Assert.assertEquals("[(\"<mBefore>bar<mBefore>\",\"<m1>foo<m1>\")]", output);
 		System.out.println(output);
 		
 		// test addAfter with required module
-		builder = new LayerBuilder(mockRequest, keyGens, new HashSet<String>(Arrays.asList(new String[]{"m1"})));
-		mbr = new ModuleBuildReader(new StringReader("foo"));
-		mbr.addAfter(
-				new ModuleBuildFuture(
-						"mAfter", 
-						new FileResource(new URI("file:/c:/mAfter.js")),
-						new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"))),
-						ModuleSpecifier.BUILD_ADDED)	
-		);
-		
-		future = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(mbr),
-				ModuleSpecifier.REQUIRED
-		);
-		reader = builder.build(Arrays.asList(new ModuleBuildFuture[]{future}));
+		moduleList = new ModuleList(Arrays.asList(new ModuleListEntry[] {
+				new ModuleListEntry(new ModuleImpl("m1", new URI("file:/c:/m1.js")), ModuleSpecifier.REQUIRED),
+		}));
+		moduleList.setRequiredModules(new HashSet<String>(Arrays.asList(new String[]{"m1"})));
+		builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content) {
+			@Override
+			protected List<ModuleBuildFuture> collectFutures(ModuleList moduleList, HttpServletRequest request)
+					throws IOException {
+				List<ModuleBuildFuture> futures = super.collectFutures(moduleList, request);
+				try {
+					ModuleBuildReader mbr = futures.get(0).get();
+					mbr.addAfter(
+							new ModuleBuildFuture(
+									new ModuleImpl("mAfter", new URI("file:/c:/mAfter.js")),
+									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"))),
+									ModuleSpecifier.BUILD_ADDED)	
+					);
+				} catch (Exception e) {
+					throw new IOException(e.getMessage(), e);
+				}
+				return futures;
+			}
+		};
+		reader = builder.build();
 		output = toString(reader);
 		Assert.assertEquals("[[m1]{'<m1>foo<m1>','<mAfter>bar<mAfter>'}[m1]]", output);
 		System.out.println(output);
 		
 		// Test addAfter with module
-		builder = new LayerBuilder(mockRequest, keyGens, Collections.<String> emptySet());
-		mbr = new ModuleBuildReader(new StringReader("foo"));
-		mbr.addAfter(
-				new ModuleBuildFuture(
-						"mAfter", 
-						new FileResource(new URI("file:/c:/mAfter")),
-						new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"))),
-						ModuleSpecifier.BUILD_ADDED)	
-		);
-		
-		future = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(mbr),
-				ModuleSpecifier.MODULES
-		);
-		reader = builder.build(Arrays.asList(new ModuleBuildFuture[]{future}));
+		moduleList = new ModuleList(Arrays.asList(new ModuleListEntry[] {
+				new ModuleListEntry(new ModuleImpl("m1", new URI("file:/c:/m1.js")), ModuleSpecifier.MODULES)
+		}));
+		builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content) {
+			@Override
+			protected List<ModuleBuildFuture> collectFutures(ModuleList moduleList, HttpServletRequest request)
+					throws IOException {
+				List<ModuleBuildFuture> futures = super.collectFutures(moduleList, request);
+				try {
+					ModuleBuildReader mbr = futures.get(0).get();
+					mbr.addAfter(
+							new ModuleBuildFuture(
+									new ModuleImpl("mAfter", new URI("file:/c:/mAfter.js")),
+									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"))),
+									ModuleSpecifier.BUILD_ADDED)	
+					);
+				} catch (Exception e) {
+					throw new IOException(e.getMessage(), e);
+				}
+				return futures;
+			}
+		};
+		reader = builder.build();
 		output = toString(reader);
 		Assert.assertEquals("[(\"<m1>foo<m1>\",\"<mAfter>bar<mAfter>\")]", output);
 		System.out.println(output);
 		
 		// Make sure cache key generators are added to the keygen list
 		Assert.assertEquals(0, keyGens.size());
-		builder = new LayerBuilder(mockRequest, keyGens, Collections.<String> emptySet());
-		List<ICacheKeyGenerator> keyGenList = Arrays.asList(new ICacheKeyGenerator[]{new ExportNamesCacheKeyGenerator()}); 
-		mbr = new ModuleBuildReader(new StringReader("foo"), keyGenList, false);
-		future = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(mbr),
-				ModuleSpecifier.MODULES
-		);
-		builder.build(Arrays.asList(new ModuleBuildFuture[]{future}));
+		moduleList = new ModuleList(Arrays.asList(new ModuleListEntry[] {
+				new ModuleListEntry(new ModuleImpl("m1", new URI("file:/c:/m1.js")), ModuleSpecifier.MODULES),
+		}));
+		builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content);
+		Map<String, List<ICacheKeyGenerator>> keyGenMap = new HashMap<String, List<ICacheKeyGenerator>>();
+		keyGenMap.put("m1", Arrays.asList(new ICacheKeyGenerator[]{new ExportNamesCacheKeyGenerator()}));
+		builder.setKeyGens(keyGenMap);
+		builder.build();
 		Assert.assertEquals(1, keyGens.size());
 
 		// required and non-required modules with before and after modules
-		builder = new LayerBuilder(mockRequest, keyGens, new LinkedHashSet<String>(Arrays.asList(new String[]{"m2"})));
-		mbr = new ModuleBuildReader(new StringReader("foo"));
-		mbr.addAfter(
-				new ModuleBuildFuture(
-						"mAfter", 
-						new FileResource(new URI("file:/c:/mAfter.js")),
-						new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("after"))),
-						ModuleSpecifier.BUILD_ADDED)	
-		);
-		future1 = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(mbr),
-				ModuleSpecifier.MODULES
-		);
-		mbr = new ModuleBuildReader(new StringReader("bar"));
-		mbr.addBefore(
-				new ModuleBuildFuture(
-						"mBefore", 
-						new FileResource(new URI("file:/c:/mBefore.js")),
-						new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("before"))),
-						ModuleSpecifier.BUILD_ADDED)	
-		);
-		future2 = new ModuleBuildFuture(
-				"m2", 
-				new FileResource(new URI("file:/c:/m2.js")),
-				new CompletedFuture<ModuleBuildReader>(mbr),
-				ModuleSpecifier.REQUIRED
-		);
-		reader = builder.build(Arrays.asList(new ModuleBuildFuture[]{future1, future2}));
+		moduleList = new ModuleList(Arrays.asList(new ModuleListEntry[] {
+				new ModuleListEntry(new ModuleImpl("m1", new URI("file:/c:/m1.js")), ModuleSpecifier.MODULES),
+				new ModuleListEntry(new ModuleImpl("m2", new URI("file:/c:/m2.js")), ModuleSpecifier.REQUIRED)
+		}));
+		moduleList.setRequiredModules(new HashSet<String>(Arrays.asList(new String[]{"m2"})));
+		builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content) {
+			@Override
+			protected List<ModuleBuildFuture> collectFutures(ModuleList moduleList, HttpServletRequest request)
+					throws IOException {
+				List<ModuleBuildFuture> futures = super.collectFutures(moduleList, request);
+				try {
+					ModuleBuildReader mbr = futures.get(0).get();
+					mbr.addAfter(
+							new ModuleBuildFuture(
+									new ModuleImpl("mAfter", new URI("file:/c:/mAfter.js")),
+									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("after"))),
+									ModuleSpecifier.BUILD_ADDED)	
+					);
+					mbr = futures.get(1).get();
+					mbr.addBefore(
+							new ModuleBuildFuture(
+									new ModuleImpl("mBefore", new URI("file:/c:/mBefore.js")),
+									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("before"))),
+									ModuleSpecifier.BUILD_ADDED)	
+					);
+				} catch (Exception e) {
+					throw new IOException(e.getMessage(), e);
+				}
+				return futures;
+			}
+		};
+		reader = builder.build();		
 		output = toString(reader);
 		Assert.assertEquals("[(\"<m1>foo<m1>\",\"<mAfter>after<mAfter>\")[m2]{'<mBefore>before<mBefore>','<m2>bar<m2>'}[m2]]", output);
 		System.out.println(output);
 
 		// Make sure NOADDMODULES request attribute disables before and after module expansion
 		requestAttributes.put(IHttpTransport.NOADDMODULES_REQATTRNAME, Boolean.TRUE);
-		builder = new LayerBuilder(mockRequest, keyGens, new LinkedHashSet<String>(Arrays.asList(new String[]{"m2"})));
-		mbr = new ModuleBuildReader(new StringReader("foo"));
-		mbr.addAfter(
-				new ModuleBuildFuture(
-						"mAfter", 
-						new FileResource(new URI("file:/c:/mAfter.js")),
-						new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("after"))),
-						ModuleSpecifier.BUILD_ADDED)	
-		);
-		future1 = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(mbr),
-				ModuleSpecifier.MODULES
-		);
-		mbr = new ModuleBuildReader(new StringReader("bar"));
-		mbr.addBefore(
-				new ModuleBuildFuture(
-						"mBefore", 
-						new FileResource(new URI("file:/c:/mBefore.js")),
-						new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("before"))),
-						ModuleSpecifier.BUILD_ADDED)	
-		);
-		future2 = new ModuleBuildFuture(
-				"m2", 
-				new FileResource(new URI("file:/c:/m2.js")),
-				new CompletedFuture<ModuleBuildReader>(mbr),
-				ModuleSpecifier.REQUIRED
-		);
-		reader = builder.build(Arrays.asList(new ModuleBuildFuture[]{future1, future2}));
+		moduleList = new ModuleList(Arrays.asList(new ModuleListEntry[] {
+				new ModuleListEntry(new ModuleImpl("m1", new URI("file:/c:/m1.js")), ModuleSpecifier.MODULES),
+				new ModuleListEntry(new ModuleImpl("m2", new URI("file:/c:/m2.js")), ModuleSpecifier.REQUIRED)
+		}));
+		moduleList.setRequiredModules(new HashSet<String>(Arrays.asList(new String[]{"m2"})));
+		builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content) {
+			@Override
+			protected List<ModuleBuildFuture> collectFutures(ModuleList moduleList, HttpServletRequest request)
+					throws IOException {
+				List<ModuleBuildFuture> futures = super.collectFutures(moduleList, request);
+				try {
+					ModuleBuildReader mbr = futures.get(0).get();
+					mbr.addAfter(
+							new ModuleBuildFuture(
+									new ModuleImpl("mAfter", new URI("file:/c:/mAfter.js")),
+									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("after"))),
+									ModuleSpecifier.BUILD_ADDED)	
+					);
+					mbr = futures.get(1).get();
+					mbr.addBefore(
+							new ModuleBuildFuture(
+									new ModuleImpl("mBefore", new URI("file:/c:/mBefore.js")),
+									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("before"))),
+									ModuleSpecifier.BUILD_ADDED)	
+					);
+				} catch (Exception e) {
+					throw new IOException(e.getMessage(), e);
+				}
+				return futures;
+			}
+		};
+		reader = builder.build();		
 		output = toString(reader);
 		Assert.assertEquals("[(\"<m1>foo<m1>\")[m2]{'<m2>bar<m2>'}[m2]]", output);
 		System.out.println(output);
 		
 		
-		// Make sure config notice gets added
-		Ref<IConfig> configRef = new Ref<IConfig>(null);
-		IConfig mockConfig = EasyMock.createNiceMock(IConfig.class);
-		EasyMock.expect(mockConfig.getNotice()).andReturn("Hello World").once();
-		EasyMock.replay(mockConfig);
-		configRef.set(mockConfig);
-		mockAggregator = TestUtils.createMockAggregator(configRef,null,null,null,mockTransport);
-		EasyMock.replay(mockAggregator);
-		requestAttributes.put(IAggregator.AGGREGATOR_REQATTRNAME, mockAggregator);
-		builder = new LayerBuilder(mockRequest, keyGens, Collections.<String> emptySet());
-		mbr = new ModuleBuildReader(new StringReader("foo"));
-		future = new ModuleBuildFuture(
-				"m1", 
-				new FileResource(new URI("file:/c:/m1.js")),
-				new CompletedFuture<ModuleBuildReader>(mbr),
-				ModuleSpecifier.MODULES
-		);
-		
-		reader = builder.build(Arrays.asList(new ModuleBuildFuture[]{future}));
+		// Make sure listener prologue, epilogue and interlude gets added
+		requestAttributes.put(IHttpTransport.NOADDMODULES_REQATTRNAME, Boolean.TRUE);
+		moduleList = new ModuleList(Arrays.asList(new ModuleListEntry[] {
+				new ModuleListEntry(new ModuleImpl("m1", new URI("file:/c:/m1.js")), ModuleSpecifier.MODULES),
+				new ModuleListEntry(new ModuleImpl("m2", new URI("file:/c:/m2.js")), ModuleSpecifier.MODULES)
+		}));
+		builder = new TestLayerBuilder(mockRequest, keyGens, moduleList, content) {
+			@Override
+			public String notifyLayerListeners(ILayerListener.EventType type, HttpServletRequest request, IModule module) throws IOException {
+				String result = "<no type>";
+				if (type == EventType.BEGIN_LAYER) {
+					result = "prologue";
+				} else if (type == EventType.END_LAYER) {
+					result = "epilogue";
+				} else if (type == EventType.BEGIN_MODULE) {
+					result = "interlude " + module.getURI();
+				}
+				return result;
+			}
+		};
+		reader = builder.build();		
 		output = toString(reader);
-		Assert.assertEquals("Hello World\r\n[(\"<m1>foo<m1>\")]", output);
+		Assert.assertEquals("prologue[(interlude file:/c:/m1.js\"<m1>foo<m1>\"interlude file:/c:/m2.js,\"<m2>bar<m2>\")]epilogue", output);
 		System.out.println(output);
 	}
 	
-	// test notice
+	@Test
+	public void testCollectFutures() throws Exception {
+		IAggregator mockAggregator = TestUtils.createMockAggregator();
+		HttpServletRequest mockRequest = TestUtils.createMockRequest(mockAggregator);
+		ICache mockCache = createMock(ICache.class);
+		IModuleCache mockModuleCache = createMock(IModuleCache.class);
+		expect(mockCache.getModules()).andReturn(mockModuleCache).anyTimes();
+		expect(mockModuleCache.getBuild(eq(mockRequest), isA(IModule.class))).andAnswer(new IAnswer<Future<ModuleBuildReader>>() {
+			@Override public Future<ModuleBuildReader> answer() throws Throwable {
+				IModule module = (IModule)getCurrentArguments()[1];
+				return new CompletedFuture<ModuleBuildReader>(
+						new ModuleBuildReader(new StringReader(module.getModuleId() + " build"))
+				);
+			}
+		}).anyTimes();
+		replay(mockAggregator, mockRequest, mockCache, mockModuleCache);
+		((TestCacheManager)mockAggregator.getCacheManager()).setCache(mockCache);
+		ModuleList moduleList = new ModuleList();
+		IModule module1 = new ModuleImpl("module1", new URI("file://module1.js")),
+				module2 = new ModuleImpl("module2", new URI("file://module2.js"));
+		moduleList.add(new ModuleListEntry(module1, ModuleSpecifier.MODULES));
+		moduleList.add(new ModuleListEntry(module2, ModuleSpecifier.REQUIRED));
+		LayerBuilder builder = new LayerBuilder(mockRequest, null, moduleList);
+		List<ModuleBuildFuture> futures = builder.collectFutures(moduleList, mockRequest);
+		Assert.assertEquals(2, futures.size());
+		ModuleBuildFuture future = futures.get(0);
+		Assert.assertEquals("module1", future.getModule().getModuleId());
+		Assert.assertEquals(ModuleSpecifier.MODULES, future.getModuleSpecifier());
+		Assert.assertEquals("module1 build", toString(future.get()));
+		future = futures.get(1);
+		Assert.assertEquals("module2", future.getModule().getModuleId());
+		Assert.assertEquals(ModuleSpecifier.REQUIRED, future.getModuleSpecifier());
+		Assert.assertEquals("module2 build", toString(future.get()));
+		
+		// Verfity 
+	}
+
+	@Test
+	public void testNotifyLayerListeners() throws Exception {
+		IAggregator mockAggregator = TestUtils.createMockAggregator();
+		final BundleContext mockBundleContext = createMock(BundleContext.class);
+		final String[] listener1Result = new String[1], listener2Result = new String[1];
+		final List<IModule> expectedModuleList = new ArrayList<IModule>();
+		final Set<String> dependentFeatures1 = new HashSet<String>(),
+		                  dependentFeatures2 = new HashSet<String>();
+
+		expect(mockAggregator.getBundleContext()).andReturn(mockBundleContext).anyTimes();
+		HttpServletRequest mockRequest = TestUtils.createMockRequest(mockAggregator);
+		ModuleList moduleList = new ModuleList();
+		IModule module1 = new ModuleImpl("module1", new URI("file://module1.js")),
+				module2 = new ModuleImpl("module2", new URI("file://module2.js"));
+		moduleList.add(new ModuleListEntry(module1, ModuleSpecifier.MODULES));
+		moduleList.add(new ModuleListEntry(module2, ModuleSpecifier.REQUIRED));
+		ILayerListener testListener1 = new ILayerListener() {
+			@Override public String layerBeginEndNotifier(EventType type, HttpServletRequest request, List<IModule> modules, Set<String> dependentFeatures) {
+				Assert.assertEquals(expectedModuleList, modules);
+				dependentFeatures.addAll(dependentFeatures1);
+				return listener1Result[0];
+			}
+		}, testListener2 = new ILayerListener() {
+			@Override public String layerBeginEndNotifier(EventType type, HttpServletRequest request, List<IModule> modules, Set<String> dependentFeatures) {
+				Assert.assertEquals(expectedModuleList, modules);
+				dependentFeatures.addAll(dependentFeatures2);
+				return listener2Result[0];
+			}
+		};
+		ServiceReference mockServiceRef1 = createMock(ServiceReference.class),
+				         mockServiceRef2 = createMock(ServiceReference.class);
+		ServiceReference[] serviceReferences = new ServiceReference[]{mockServiceRef1, mockServiceRef2}; 
+		expect(mockBundleContext.getServiceReferences(ILayerListener.class.getName(), "(name=test)")).andReturn(serviceReferences).anyTimes();
+		expect(mockBundleContext.getService(mockServiceRef1)).andReturn(testListener1);
+		expect(mockBundleContext.getService(mockServiceRef2)).andReturn(testListener2);
+		expect(mockBundleContext.ungetService(mockServiceRef1)).andReturn(true);
+		expect(mockBundleContext.ungetService(mockServiceRef2)).andReturn(true);
+		replay(mockAggregator, mockRequest, mockBundleContext, mockServiceRef1, mockServiceRef2);
+		LayerBuilder builder = new LayerBuilder(mockRequest, null, moduleList) {
+			@Override 
+			public String notifyLayerListeners(ILayerListener.EventType type, HttpServletRequest request, IModule module) throws IOException {
+				return super.notifyLayerListeners(type, request, module);
+			}
+		};
+		listener1Result[0] = "foo";
+		listener2Result[0] = "bar";
+		expectedModuleList.addAll(moduleList.getModules());
+		
+		// Test BEGIN_LAYER with two string contributions
+		String result = builder.notifyLayerListeners(EventType.BEGIN_LAYER, mockRequest, module1);
+		EasyMock.verify(mockBundleContext);
+		Assert.assertEquals("foobar", result);
+		Assert.assertEquals(0,  moduleList.getDependentFeatures().size());
+		
+		reset(mockBundleContext);
+		expect(mockBundleContext.getServiceReferences(ILayerListener.class.getName(), "(name=test)")).andReturn(serviceReferences).anyTimes();
+		expect(mockBundleContext.getService(mockServiceRef1)).andReturn(testListener1);
+		expect(mockBundleContext.getService(mockServiceRef2)).andReturn(testListener2);
+		expect(mockBundleContext.ungetService(mockServiceRef1)).andReturn(true);
+		expect(mockBundleContext.ungetService(mockServiceRef2)).andReturn(true);
+		replay(mockBundleContext);
+		listener2Result[0] = null;
+		// Test END_LAYER with one null and one string contributions
+		result = builder.notifyLayerListeners(EventType.END_LAYER, mockRequest, module1);
+		EasyMock.verify(mockBundleContext);
+		Assert.assertEquals("foo", result);
+		Assert.assertEquals(0,  moduleList.getDependentFeatures().size());
+		
+		reset(mockBundleContext);
+		expect(mockBundleContext.getServiceReferences(ILayerListener.class.getName(), "(name=test)")).andReturn(serviceReferences).anyTimes();
+		expect(mockBundleContext.getService(mockServiceRef1)).andReturn(testListener1);
+		expect(mockBundleContext.getService(mockServiceRef2)).andReturn(testListener2);
+		expect(mockBundleContext.ungetService(mockServiceRef1)).andReturn(true);
+		expect(mockBundleContext.ungetService(mockServiceRef2)).andReturn(true);
+		replay(mockBundleContext);
+		listener1Result[0] = null;
+		// Test END_LAYER with two null contributions
+		result = builder.notifyLayerListeners(EventType.END_LAYER, mockRequest, module1);
+		EasyMock.verify(mockBundleContext);
+		Assert.assertNull(result);
+		Assert.assertEquals(0,  moduleList.getDependentFeatures().size());
+		
+		reset(mockBundleContext);
+		expect(mockBundleContext.getServiceReferences(ILayerListener.class.getName(), "(name=test)")).andReturn(serviceReferences).anyTimes();
+		expect(mockBundleContext.getService(mockServiceRef1)).andReturn(testListener1);
+		expect(mockBundleContext.getService(mockServiceRef2)).andReturn(testListener2);
+		expect(mockBundleContext.ungetService(mockServiceRef1)).andReturn(true);
+		expect(mockBundleContext.ungetService(mockServiceRef2)).andReturn(true);
+		replay(mockBundleContext);
+		listener1Result[0] = "foo";
+		listener2Result[0] = "bar";
+		expectedModuleList.clear();
+		expectedModuleList.add(module2);
+		// Test BEGIN_MODULE with two string contributions
+		result = builder.notifyLayerListeners(EventType.BEGIN_MODULE, mockRequest, module2);
+		EasyMock.verify(mockBundleContext);
+		Assert.assertEquals("foobar", result);
+		Assert.assertEquals(0,  moduleList.getDependentFeatures().size());
+		
+		reset(mockBundleContext);
+		expect(mockBundleContext.getServiceReferences(ILayerListener.class.getName(), "(name=test)")).andReturn(serviceReferences).anyTimes();
+		expect(mockBundleContext.getService(mockServiceRef1)).andReturn(testListener1);
+		expect(mockBundleContext.ungetService(mockServiceRef1)).andReturn(true);
+		replay(mockBundleContext);
+		// Test exception
+		try {
+			result = builder.notifyLayerListeners(EventType.BEGIN_MODULE, mockRequest, module1);
+			Assert.fail();
+		} catch (AssertionFailedError e) {
+		}
+		EasyMock.verify(mockBundleContext);		// verifies that bundleContext.getService()/ungetService() 
+												// are matched even though exception was thrown by listener
+		
+		reset(mockBundleContext);
+		expect(mockBundleContext.getServiceReferences(ILayerListener.class.getName(), "(name=test)")).andReturn(serviceReferences).anyTimes();
+		expect(mockBundleContext.getService(mockServiceRef1)).andReturn(testListener1);
+		expect(mockBundleContext.getService(mockServiceRef2)).andReturn(testListener2);
+		expect(mockBundleContext.ungetService(mockServiceRef1)).andReturn(true);
+		expect(mockBundleContext.ungetService(mockServiceRef2)).andReturn(true);
+		replay(mockBundleContext);
+		dependentFeatures1.add("feature1");
+		dependentFeatures2.add("feature2");
+		// Verify that dependent features can be updated by listeners
+		result = builder.notifyLayerListeners(EventType.BEGIN_MODULE, mockRequest, module2);
+		EasyMock.verify(mockBundleContext);
+		Assert.assertEquals("foobar", result);
+		Assert.assertEquals(new HashSet<String>(Arrays.asList(new String[]{"feature1", "feature2"})), moduleList.getDependentFeatures());
+	}
 	
 	String toString(Reader reader) throws IOException {
 		Writer writer = new StringWriter();
@@ -520,5 +677,51 @@ public class LayerBuilderTest {
 		return writer.toString();
 		
 	}
-
+	
+	static class TestLayerBuilder extends LayerBuilder {
+		Map<String, String> content;
+		HttpServletRequest request;
+		List<ICacheKeyGenerator> keyGens;
+		ModuleList moduleList;
+		Map<String, List<ICacheKeyGenerator>> mbrKeygens = null;
+		TestLayerBuilder(HttpServletRequest request, List<ICacheKeyGenerator> keyGens, ModuleList moduleList, Map<String, String> content) {
+			super(request, keyGens, moduleList);
+			this.content = content;
+			this.request = request;
+			this.keyGens = keyGens;
+			this.moduleList = moduleList;
+		}
+		
+		void setKeyGens(Map<String, List<ICacheKeyGenerator>> keyGenerators) {
+			mbrKeygens = keyGenerators;
+		}
+		
+		@Override 
+		protected List<ModuleBuildFuture> collectFutures(ModuleList moduleList, HttpServletRequest request)
+				throws IOException {
+			List<ModuleBuildFuture> result = new ArrayList<ModuleBuildFuture>();
+			for (ModuleListEntry entry : moduleList) {
+				String mid = entry.getModule().getModuleId();
+				List<ICacheKeyGenerator> mbrKeygen = null;
+				if (mbrKeygens != null) {
+					mbrKeygen = mbrKeygens.get(mid);
+				}
+				ModuleBuildReader mbr = new ModuleBuildReader(new StringReader(content.get(mid)), mbrKeygen, false);
+				ModuleBuildFuture future = new ModuleBuildFuture(
+						new ModuleImpl(mid, entry.getModule().getURI()),
+						new CompletedFuture<ModuleBuildReader>(mbr),
+						entry.getSource()
+				);
+				result.add(future);
+			}
+			return result;
+		}
+		
+		@Override
+		protected String notifyLayerListeners(ILayerListener.EventType type, HttpServletRequest request, IModule module) throws IOException {
+			IAggregator aggr = (IAggregator)request.getAttribute(IAggregator.AGGREGATOR_REQATTRNAME);
+			ILayerListener listener = new AggregatorLayerListener(aggr);
+			return listener.layerBeginEndNotifier(type, request, Arrays.asList(new IModule[]{module}), new HashSet<String>());
+		}
+	}
 }

--- a/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/module/ModuleImplTest.java
+++ b/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/module/ModuleImplTest.java
@@ -209,6 +209,7 @@ public class ModuleImplTest {
 		writer = new StringWriter();
 		CopyUtil.copy(reader, writer);
 		compiled = writer.toString();
+		System.out.println(compiled);
 		assertTrue(Pattern.compile("require\\(\\[.*?,\\\"p1/foo/d\\\".*?\\],").matcher(compiled).find());
 
 		features.put("bar", true);

--- a/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/modulebuilder/i18n/I18nModuleBuilderTest.java
+++ b/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/modulebuilder/i18n/I18nModuleBuilderTest.java
@@ -142,7 +142,7 @@ public class I18nModuleBuilderTest extends EasyMock {
 		Assert.assertTrue(s.contains("i18n:null:provisional"));
 		keyGens = null;
 		ModuleBuild build = buildIt();
-		output = build.getBuildOutput();
+		output = build.getBuildOutput().toString();
 		
 		Assert.assertTrue(builder.handles("nls/strings", new FileResource(new File(nls, "strings.js").toURI())));
 		Assert.assertEquals(0, build.getBefore().size());
@@ -165,7 +165,7 @@ public class I18nModuleBuilderTest extends EasyMock {
 		System.out.println(s);
 		Assert.assertTrue(s.contains("i18n{en}"));
 		build = buildIt();
-		output = build.getBuildOutput();
+		output = build.getBuildOutput().toString();
 		System.out.println(output);
 		Assert.assertEquals("define(\"nls/strings\",{locale_label:\"root\"});", output);
 		Assert.assertEquals(1, build.getBefore().size());
@@ -180,7 +180,7 @@ public class I18nModuleBuilderTest extends EasyMock {
 		System.out.println(s);
 		Assert.assertFalse(s.contains("i18n"));
 		build = buildIt();
-		output = build.getBuildOutput();
+		output = build.getBuildOutput().toString();
 		System.out.println(output);
 		Assert.assertEquals("define(\"nls/strings\",{locale_label:\"root\"});", output);
 		Assert.assertEquals(0, build.getBefore().size());
@@ -191,7 +191,7 @@ public class I18nModuleBuilderTest extends EasyMock {
 		eb.mkdir();
 		CopyUtil.copy("define({locale_label:'eb'});", new FileWriter(new File(eb, "strings.js")));
 		build = buildIt();
-		output = build.getBuildOutput();
+		output = build.getBuildOutput().toString();
 		System.out.println(output);
 		Assert.assertEquals("define(\"nls/strings\",{locale_label:\"root\"});", output);
 		Assert.assertEquals(0, build.getBefore().size());
@@ -201,7 +201,7 @@ public class I18nModuleBuilderTest extends EasyMock {
 		mockAggregator.getOptions().setOption(IOptions.DEVELOPMENT_MODE, true);
 		keyGens = null;
 		build = buildIt();
-		output = build.getBuildOutput();
+		output = build.getBuildOutput().toString();
 		s = KeyGenUtil.toString(keyGens);
 		System.out.println(s);
 		Assert.assertTrue(s.contains("i18n:null"));
@@ -220,7 +220,7 @@ public class I18nModuleBuilderTest extends EasyMock {
 		File file = new File(eb, "strings.js");
 		CopyUtil.copy("define({locale_label:'eb'});", new FileWriter(file));
 		build = buildIt();
-		output = build.getBuildOutput();
+		output = build.getBuildOutput().toString();
 		System.out.println(output);
 		Assert.assertEquals("define(\"nls/strings\",{locale_label:\"root\"});", output);
 		Assert.assertEquals(1, build.getBefore().size());

--- a/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/modulebuilder/javascript/JavaScriptBuildRendererTest.java
+++ b/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/modulebuilder/javascript/JavaScriptBuildRendererTest.java
@@ -1,0 +1,101 @@
+/*
+ * (C) Copyright 2012, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ibm.jaggr.service.impl.modulebuilder.javascript;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import junit.framework.Assert;
+
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import com.ibm.jaggr.service.deps.ModuleDepInfo;
+import com.ibm.jaggr.service.deps.ModuleDeps;
+import com.ibm.jaggr.service.test.TestUtils;
+
+public class JavaScriptBuildRendererTest {
+	static final String content = "define([],function() {require(\"foo\",\"" + 
+			String.format(JavaScriptBuildRenderer.REQUIRE_EXPANSION_PLACEHOLDER_FMT, 0) +
+			"\");require(\"bar\",\"" +
+			String.format(JavaScriptBuildRenderer.REQUIRE_EXPANSION_PLACEHOLDER_FMT, 1) +
+			"\")});";
+
+	@Test
+	public void testRenderBuild() throws Exception {
+		ModuleDeps deps1 = new ModuleDeps();
+		ModuleDeps deps2 = new ModuleDeps();
+		deps1.add("foodep1", new ModuleDepInfo());
+		deps1.add("foodep2", new ModuleDepInfo());
+		deps2.add("bardep", new ModuleDepInfo());
+		List<ModuleDeps> depsList = Arrays.asList(new ModuleDeps[]{deps1, deps2});
+		JavaScriptBuildRenderer compiled = new JavaScriptBuildRenderer(content, depsList, false);
+		
+		// validate the rendered output
+		HttpServletRequest mockRequest = TestUtils.createMockRequest(TestUtils.createMockAggregator());
+		EasyMock.replay(mockRequest);
+		String result = compiled.renderBuild(mockRequest);
+		System.out.println(result);
+		Assert.assertEquals("define([],function() {require(\"foo\",\"foodep1\",\"foodep2\");require(\"bar\",\"bardep\")});", result);
+		
+		ModuleDeps enclosingDeps = new ModuleDeps();
+		enclosingDeps.add("foodep2", new ModuleDepInfo());
+		enclosingDeps.add("bardep", new ModuleDepInfo());
+		mockRequest.setAttribute(JavaScriptModuleBuilder.EXPANDED_DEPENDENCIES, enclosingDeps);
+		result = compiled.renderBuild(mockRequest);
+		System.out.println(result);
+		Assert.assertEquals("define([],function() {require(\"foo\",\"foodep1\");require(\"bar\")});", result);
+	}
+
+	@Test
+	public void testRenderBuild_withDetails() throws Exception {
+		String contentWithComments = content + 
+				"console.log(\"deps1=" +
+				String.format(JavaScriptBuildRenderer.REQUIRE_EXPANSION_LOG_PLACEHOLDER_FMT, 0) +
+				"\");console.log(\"deps2=" +
+				String.format(JavaScriptBuildRenderer.REQUIRE_EXPANSION_LOG_PLACEHOLDER_FMT, 1) +
+				"\");";
+		ModuleDeps deps1 = new ModuleDeps();
+		ModuleDeps deps2 = new ModuleDeps();
+		deps1.add("foodep1", new ModuleDepInfo());
+		deps1.add("foodep2", new ModuleDepInfo());
+		deps2.add("bardep", new ModuleDepInfo());
+		List<ModuleDeps> depsList = Arrays.asList(new ModuleDeps[]{deps1, deps2, deps1, deps2});
+		JavaScriptBuildRenderer compiled = new JavaScriptBuildRenderer(contentWithComments, depsList, true);
+		
+		// validate the rendered output
+		HttpServletRequest mockRequest = TestUtils.createMockRequest(TestUtils.createMockAggregator());
+		EasyMock.replay(mockRequest);
+		String result = compiled.renderBuild(mockRequest);
+		System.out.println(result);
+		Assert.assertEquals(
+				"define([],function() {require(\"foo\",\"foodep1\",\"foodep2\");require(\"bar\",\"bardep\")});console.log(\"deps1=foodep1, foodep2\");console.log(\"deps2=bardep\");",
+				result);
+
+		ModuleDeps enclosingDeps = new ModuleDeps();
+		enclosingDeps.add("foodep2", new ModuleDepInfo());
+		enclosingDeps.add("bardep", new ModuleDepInfo());
+		mockRequest.setAttribute(JavaScriptModuleBuilder.EXPANDED_DEPENDENCIES, enclosingDeps);
+		result = compiled.renderBuild(mockRequest);
+		Assert.assertEquals(
+				"define([],function() {require(\"foo\",\"foodep1\");require(\"bar\")});console.log(\"deps1=foodep1\");console.log(\"deps2=\");", 
+				result);
+		System.out.println(result);
+	}
+}

--- a/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/modulebuilder/text/TxtModuleContentProviderTest.java
+++ b/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/modulebuilder/text/TxtModuleContentProviderTest.java
@@ -96,7 +96,7 @@ public class TxtModuleContentProviderTest extends EasyMock {
 		String code = builder.build(
 				"test.txt", 
 				new FileResource(test.toURI()), 
-				mockRequest, null).getBuildOutput();
+				mockRequest, null).getBuildOutput().toString();
 		System.out.println(code);
 		assertEquals("define('\\'This is a test\\'. \\'\\'  Test\\'s\\'');", code);
 	}

--- a/jaggr-service/src/test/java/com/ibm/jaggr/service/test/TestCacheManager.java
+++ b/jaggr-service/src/test/java/com/ibm/jaggr/service/test/TestCacheManager.java
@@ -19,9 +19,12 @@ package com.ibm.jaggr.service.test;
 import java.io.IOException;
 
 import com.ibm.jaggr.service.IAggregator;
+import com.ibm.jaggr.service.cache.ICache;
 import com.ibm.jaggr.service.impl.cache.CacheManagerImpl;
 
 public class TestCacheManager extends CacheManagerImpl {
+	
+	private ICache cache = null;
 
 	public TestCacheManager(IAggregator aggregator, long stamp) throws IOException {
 		super(aggregator, stamp);
@@ -30,5 +33,14 @@ public class TestCacheManager extends CacheManagerImpl {
 	@Override
 	public void serializeCache() {
 		super.serializeCache();
+	}
+	
+	public void setCache(ICache cache) {
+		this.cache = cache;
+	}
+	
+	@Override 
+	public ICache getCache() {
+		return cache == null ? super.getCache() : cache;
 	}
 }

--- a/jaggr-service/src/test/java/com/ibm/jaggr/service/test/TestUtils.java
+++ b/jaggr-service/src/test/java/com/ibm/jaggr/service/test/TestUtils.java
@@ -366,9 +366,7 @@ public class TestUtils {
 	}
 	
 	public static HttpServletRequest createMockRequest(IAggregator aggregator) {
-		HttpServletRequest mockRequest = EasyMock.createNiceMock(HttpServletRequest.class);
-		EasyMock.expect(mockRequest.getAttribute(IAggregator.AGGREGATOR_REQATTRNAME)).andReturn(aggregator).anyTimes();
-		return mockRequest;
+		return createMockRequest(aggregator, new HashMap<String, Object>());
 	}
 	
 	public static HttpServletRequest createMockRequest(IAggregator aggregator, Map<String, Object> requestAttributes) {

--- a/pom.xml
+++ b/pom.xml
@@ -412,6 +412,21 @@
         <artifactId>easymock</artifactId>
         <version>3.1</version>
       </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-core</artifactId>
+        <version>1.5.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-easymock</artifactId>
+        <version>1.5.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <version>1.5.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>


### PR DESCRIPTION
Require list expansion is an effective technique for reducing HTTP requests caused by dependency discovery as modules are loaded, but it has the downside of increasing the size of the code somewhat.  The aggregator already addresses this by filtering the expanded require list using the expanded dependencies of the containing modules, plus any scoped require lists.  This change further reduces the impact of require list expansion on code size by filtering the expanded require list using the expanded dependencies of all the modules in the layer that the module belongs to.

A new interface, ILayerListener specifies an OSGi service interface that is called by the layer builder for layer events (BEGIN_LAYER, BEGIN_MODULE, END_LAYER).  The JavaScriptModuleBuilder registers a layer listener and calculates the expanded dependencies for all the modules in the layer during BEGIN_LAYER notification and saves the expanded layer dependencies in a request attribute.

A new interface, IModuleRenderer allows module builders to render a module build at layer assembly time.  The javascript module renderer filters the expanded dependencies for require calls in the module with the expanded dependencies for the layer that were calculated by the layer listener.

The javascript module renderer encapsulates the compiled module and the expanded dependencies that were determined by the module builder in a way that allows it to quickly and efficiently replace the expanded dependency list that with the filtered dependency list in the rendered output.
