### PR TITLE
 	Remove OSGi dependencies form http transport

### DIFF
--- a/jaggr-service/.settings/.gitignore
+++ b/jaggr-service/.settings/.gitignore
@@ -1,2 +1,3 @@
 /org.eclipse.core.resources.prefs
 /org.eclipse.m2e.core.prefs
+/de.loskutov.FileSync.prefs

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/transport/AbstractDojoHttpTransport.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/transport/AbstractDojoHttpTransport.java
@@ -1,0 +1,520 @@
+/*
+ * (C) Copyright 2012, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ibm.jaggr.service.impl.transport;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+
+import com.ibm.jaggr.core.IAggregator;
+import com.ibm.jaggr.core.IAggregatorExtension;
+import com.ibm.jaggr.core.IExtensionInitializer;
+import com.ibm.jaggr.core.cachekeygenerator.ICacheKeyGenerator;
+import com.ibm.jaggr.core.config.IConfig;
+import com.ibm.jaggr.core.config.IConfig.Location;
+import com.ibm.jaggr.core.options.IOptions;
+import com.ibm.jaggr.core.resource.AggregationResource;
+import com.ibm.jaggr.core.resource.IResource;
+import com.ibm.jaggr.core.resource.IResourceFactory;
+import com.ibm.jaggr.core.resource.IResourceFactoryExtensionPoint;
+import com.ibm.jaggr.core.transport.IHttpTransport;
+import com.ibm.jaggr.core.util.TypeUtil;
+
+/**
+ * Implements the functionality specific for the Dojo Http Transport (supporting
+ * the dojo AMD loader).
+ */
+public abstract class AbstractDojoHttpTransport extends AbstractHttpTransport implements IHttpTransport, IExtensionInitializer {
+	private static final Logger log = Logger.getLogger(AbstractDojoHttpTransport.class.getName());
+
+    static final String textPluginPath = "dojo/text"; //$NON-NLS-1$
+    static final String loaderExtensionPath = "/WebContent/loaderExt.js"; //$NON-NLS-1$
+    static final String[] loaderExtensionResources = {
+    	"./loaderExtCommon.js", //$NON-NLS-1$
+    	"./dojo/_loaderExt.js" //$NON-NLS-1$
+    };
+    static final String dojo = "dojo"; //$NON-NLS-1$
+    static final String aggregatorTextPluginAlias = "__aggregator_text_plugin"; //$NON-NLS-1$
+    static final String dojoTextPluginAlias = "__original_text_plugin"; //$NON-NLS-1$
+    static final String dojoTextPluginAliasFullPath = dojo+"/"+dojoTextPluginAlias; //$NON-NLS-1$
+    static final String dojoTextPluginName = "text"; //$NON-NLS-1$
+    static final String dojoTextPluginFullPath = dojo+"/"+dojoTextPluginName; //$NON-NLS-1$
+    static final URI dojoPluginUri;
+
+    static {
+    	try {
+    		dojoPluginUri = new URI("./"+dojoTextPluginName); //$NON-NLS-1$
+    	} catch (URISyntaxException e) {
+    		// Should never happen
+    		throw new RuntimeException(e);
+    	}
+    }
+
+    private List<String[]> clientConfigAliases = new LinkedList<String[]>();
+
+    /**
+     * Property accessor for the loaderExtensionPath property
+     *
+     * @return the loader extension path
+     */
+    protected String getLoaderExtensionPath() {
+    	return loaderExtensionPath;
+    }
+
+    /**
+     * Property accessor for the loaderExtensionResources property
+     *
+     * @return the loader extension resources
+     */
+    protected String[] getLoaderExtensionResources() {
+    	return loaderExtensionResources;
+    }
+
+    /**
+     * Returns the list of client config aliases
+     *
+     * @return the client aliases
+     */
+    protected List<String[]> getClientConfigAliases() {
+    	return clientConfigAliases;
+    }
+
+    protected String getAggregatorTextPluginName() {
+    	return getResourcePathId() + "/text"; //$NON-NLS-1$
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.jaggr.service.transport.AbstractHttpTransport#getLayerContribution(javax.servlet.http.HttpServletRequest, com.ibm.jaggr.service.transport.IHttpTransport.LayerContributionType, java.lang.String)
+     */
+    @Override
+	public String getLayerContribution(HttpServletRequest request,
+			LayerContributionType type, Object arg) {
+
+    	super.validateLayerContributionState(request, type, arg);
+
+    	// Implement wrapping of modules required by dojo loader for modules that
+    	// are loaded with the loader.
+    	switch (type) {
+		case BEGIN_REQUIRED_MODULES:
+			return "require({cache:{"; //$NON-NLS-1$
+		case BEFORE_FIRST_REQUIRED_MODULE:
+			return getBeforeRequiredModule(request, arg.toString());
+		case BEFORE_SUBSEQUENT_REQUIRED_MODULE:
+			return "," + getBeforeRequiredModule(request, arg.toString()); //$NON-NLS-1$
+		case AFTER_REQUIRED_MODULE:
+			return getAfterRequiredModule(request, arg.toString());
+		case END_REQUIRED_MODULES:
+			{
+				StringBuffer sb = new StringBuffer();
+				sb.append("}});require({cache:{}});require(["); //$NON-NLS-1$
+				int i = 0;
+				@SuppressWarnings("unchecked")
+				Set<String> requiredModules = (Set<String>)arg;
+				for (String name : requiredModules) {
+					sb.append(i++ > 0 ? "," : "").append("\"").append(name).append("\""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+				}
+				sb.append("]);"); //$NON-NLS-1$
+				return sb.toString();
+			}
+		default:
+		}
+		return null;
+	}
+
+    static final Pattern urlId = Pattern.compile("^[a-zA-Z]+\\:\\/\\/"); //$NON-NLS-1$
+    /* (non-Javadoc)
+     * @see com.ibm.jaggr.service.impl.transport.AbstractHttpTransport#isServerExpandable(javax.servlet.http.HttpServletRequest, java.lang.String)
+     */
+    @Override
+	public boolean isServerExpandable(HttpServletRequest request, String mid) {
+    	int idx = mid.indexOf("!"); //$NON-NLS-1$
+    	String plugin = idx != -1 ? mid.substring(0, idx) : null;
+    	String name = idx != -1 ? mid.substring(idx+1) : mid;
+    	if (name.startsWith("/") || urlId.matcher(name).find() || name.contains("?")) { //$NON-NLS-1$ //$NON-NLS-2$
+    		return false;
+    	}
+    	if (plugin != null) {
+    		IAggregator aggr = (IAggregator)request.getAttribute(IAggregator.AGGREGATOR_REQATTRNAME);
+    		if (!aggr.getConfig().getTextPluginDelegators().contains(plugin) &&
+    			!aggr.getConfig().getJsPluginDelegators().contains(plugin)) {
+    			return false;
+    		}
+    	}
+		return true;
+	}
+
+	protected String getBeforeRequiredModule(HttpServletRequest request, String mid) {
+    	String result;
+    	int idx = mid.indexOf("!"); //$NON-NLS-1$
+    	if (idx == -1) {
+    		result = "\"" + mid + "\":function(){"; //$NON-NLS-1$ //$NON-NLS-2$
+    	} else {
+    		String plugin = mid.substring(0, idx);
+    		IAggregator aggr = (IAggregator)request.getAttribute(IAggregator.AGGREGATOR_REQATTRNAME);
+    		IConfig config = aggr.getConfig();
+    		if (config.getTextPluginDelegators().contains(plugin)) {
+    			result = "\"url:" + mid.substring(idx+1) + "\":"; //$NON-NLS-1$ //$NON-NLS-2$
+    		} else if (config.getJsPluginDelegators().contains(plugin)) {
+    			result = "\"" + mid.substring(idx+1) + "\":function(){"; //$NON-NLS-1$ //$NON-NLS-2$
+    		} else {
+    			result = "\"" + mid + "\":function(){"; //$NON-NLS-1$ //$NON-NLS-2$
+    		}
+    	}
+    	return result;
+    }
+
+    protected String getAfterRequiredModule(HttpServletRequest request, String mid) {
+    	int idx = mid.indexOf("!"); //$NON-NLS-1$
+    	String plugin = idx == -1 ? null : mid.substring(0, idx);
+    	String result = "}";//$NON-NLS-1$
+    	if (plugin != null) {
+    		IAggregator aggr = (IAggregator)request.getAttribute(IAggregator.AGGREGATOR_REQATTRNAME);
+    		IConfig config = aggr.getConfig();
+    		if (config.getTextPluginDelegators().contains(plugin)) {
+    			result = ""; //$NON-NLS-1$
+    		}
+    	}
+    	return result;
+    }
+
+	/* (non-Javadoc)
+	 * @see com.ibm.jaggr.service.transport.AbstractHttpTransport#getCacheKeyGenerators()
+	 */
+	@Override
+	public List<ICacheKeyGenerator> getCacheKeyGenerators() {
+		/*
+		 * The content generated by this transport is invariant with regard
+		 * to request parameters (for a given set of modules) so we don't
+		 * need to provide a cache key generator.
+		 */
+		return null;
+	}
+
+	@Override
+	public void decorateRequest(HttpServletRequest request) throws IOException {
+		super.decorateRequest(request);
+		if (request.getAttribute(IHttpTransport.REQUIRED_REQATTRNAME) != null) {
+			// If we're building a pre-boot layer, then don't adorn text strings
+			// and don't export module names
+			request.setAttribute(IHttpTransport.NOTEXTADORN_REQATTRNAME, Boolean.TRUE);
+			request.setAttribute(IHttpTransport.EXPORTMODULENAMES_REQATTRNAME, Boolean.FALSE);
+		}
+		if (!(TypeUtil.asBoolean(request.getAttribute(IHttpTransport.EXPORTMODULENAMES_REQATTRNAME)) &&
+				(OptimizationLevel)request.getAttribute(IHttpTransport.OPTIMIZATIONLEVEL_REQATTRNAME) != OptimizationLevel.NONE ||
+				request.getAttribute(IHttpTransport.REQUIRED_REQATTRNAME) != null)) {
+			// If we're not exporting module names and we aren't doing server side expansion
+			// of dependencies (i.e. using a prebuild cache), then we can't expand i18n
+			// resources.
+			request.setAttribute(IHttpTransport.NOADDMODULES_REQATTRNAME, true);
+		}
+	}
+
+	/* (non-Javadoc)
+	 * @see com.ibm.jaggr.service.transport.AbstractHttpTransport#initialize(com.ibm.jaggr.service.IAggregator, com.ibm.jaggr.service.IAggregatorExtension, com.ibm.jaggr.service.IExtensionInitializer.IExtensionRegistrar)
+	 */
+	@Override
+	public void initialize(IAggregator aggregator, IAggregatorExtension extension, IExtensionRegistrar reg) {
+		super.initialize(aggregator, extension, reg);
+
+		// Get first resource factory extension so we can add to beginning of list
+    	Iterable<IAggregatorExtension> resourceFactoryExtensions = aggregator.getResourceFactoryExtensions();
+    	IAggregatorExtension first = resourceFactoryExtensions.iterator().next();
+
+    	// Register the loaderExt resource factory
+    	Properties attributes = new Properties();
+    	attributes.put("scheme", "namedbundleresource"); //$NON-NLS-1$ //$NON-NLS-2$
+		reg.registerExtension(
+				new LoaderExtensionResourceFactory(),
+				attributes,
+				IResourceFactoryExtensionPoint.ID,
+				getTransportId(),
+				first);
+
+	}
+
+	/* (non-Javadoc)
+	 * @see com.ibm.jaggr.service.transport.AbstractHttpTransport#getDynamicLoaderExtensionJavaScript()
+	 */
+	@Override
+	protected String getDynamicLoaderExtensionJavaScript() {
+		StringBuffer sb = new StringBuffer();
+		sb.append("plugins[\"") //$NON-NLS-1$
+		  .append(getResourcePathId())
+		  .append("/text") //$NON-NLS-1$
+		  .append("\"] = 1;\r\n"); //$NON-NLS-1$
+		for (String[] alias : getClientConfigAliases()) {
+			sb.append("aliases.push([\"" + alias[0] + "\", \"" + alias[1] + "\"]);\r\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		}
+		// Add server option settings that we care about
+		IOptions options = getAggregator().getOptions();
+		sb.append("combo.serverOptions={skipHasFiltering:") //$NON-NLS-1$
+		  .append(Boolean.toString(options.isDisableHasFiltering()))
+		  .append("};\r\n"); //$NON-NLS-1$
+
+		// add in the super class's contribution
+		sb.append(super.getDynamicLoaderExtensionJavaScript());
+
+		return sb.toString();
+	}
+
+	/* (non-Javadoc)
+	 * @see com.ibm.jaggr.service.config.IConfigModifier#modifyConfig(com.ibm.jaggr.service.IAggregator, java.util.Map)
+	 */
+	/**
+	 * Add paths and aliases mappings to the config for the dojo text plugin.
+	 * <p>
+	 * The reason this is a bit complex is that in order to support text plugin
+	 * resources that specify an absolute path (e.g.
+	 * dojo/text!http://server.com/resource.html), we use server-side config
+	 * paths entries to map dojo/text to a proxy plugin module provided by this
+	 * transport. The proxy plugin module examines the module id of the
+	 * requested resource, and if the id is absolute, it delegates to the dojo
+	 * text plugin which can still be accessed from the client using an
+	 * alternative path which we set up below. If the module id is relative,
+	 * then the proxy plugin module delegates to the aggregator text plugin
+	 * (which is a pseudo plugin that resolves to the aggregator itself).
+	 * <p>
+	 * In addition to the paths mappings, aliases are used, both in the
+	 * server-side config and in the client config, to allow the proxy plugin
+	 * module to refer to the dojo text plugin module and the aggregator text
+	 * plugin via static names, allowing the actual names to be dynamic without
+	 * requiring us to dynamically modify the contents of the proxy plugin
+	 * resource itself.  This method sets the server-side config aliases
+	 * and sets up the client-side config aliases to be set in
+	 * {@link #contributeLoaderExtensionJavaScript(String)}.
+	 */
+	@Override
+	public void modifyConfig(IAggregator aggregator, Scriptable config) {
+		// let the superclass do its thing
+		super.modifyConfig(aggregator, config);
+
+		// Get the server-side config properties we need to start with
+		Object pathsObj = config.get(IConfig.PATHS_CONFIGPARAM, config);
+		Object packagesObj = config.get(IConfig.PACKAGES_CONFIGPARAM, config);
+		Object aliasesObj = config.get(IConfig.ALIASES_CONFIGPARAM, config);
+		Object textPluginDelegatorsObj = config.get(IConfig.TEXTPLUGINDELEGATORS_CONFIGPARAM, config);
+		Object jsPluginDelegatorsObj = config.get(IConfig.JSPLUGINDELEGATORS_CONFIGPARAM, config);
+
+		Scriptable paths = (pathsObj != null && pathsObj instanceof Scriptable) ? (Scriptable)pathsObj : null;
+		Scriptable packages = (packagesObj != null && packagesObj instanceof Scriptable) ? (Scriptable)packagesObj : null;
+		Scriptable aliases = (aliasesObj != null && aliasesObj instanceof Scriptable) ? (Scriptable)aliasesObj : null;
+		Scriptable textPluginDelegators = (textPluginDelegatorsObj != null && textPluginDelegatorsObj instanceof Scriptable) ? (Scriptable)textPluginDelegatorsObj : null;
+		Scriptable jsPluginDelegators = (jsPluginDelegatorsObj != null && jsPluginDelegatorsObj instanceof Scriptable) ? (Scriptable)jsPluginDelegatorsObj : null;
+		// Get the URI for the location of the dojo package on the server
+		IConfig.Location dojoLoc = null;
+		if (packages != null) {
+			for (Object id : packages.getIds()) {
+				if (!(id instanceof Number)) {
+					continue;
+				}
+				Number i = (Number)id;
+				Object pkgObj = packages.get((Integer)i, packages);
+				if (pkgObj instanceof Scriptable) {
+					Scriptable pkg = (Scriptable)pkgObj;
+					if (dojo.equals(pkg.get(IConfig.PKGNAME_CONFIGPARAM, pkg).toString())) {
+						try {
+							Object dojoLocObj = pkg.get(IConfig.PKGLOCATION_CONFIGPARAM, pkg);
+							if (dojoLoc == Scriptable.NOT_FOUND) {
+								dojoLoc = new IConfig.Location(new URI("."), null); //$NON-NLS-1$
+							} else if (dojoLocObj instanceof Scriptable) {
+								Scriptable values = (Scriptable)dojoLocObj;
+								String str = Context.toString(values.get(0, values));
+								if (!str.endsWith("/")) str += '/'; //$NON-NLS-1$
+								URI primary = new URI(str).normalize(), override = null;
+								Object obj = values.get(1, values);
+								if (obj != Scriptable.NOT_FOUND) {
+									str = Context.toString(obj);
+									if (!str.endsWith("/")) str += '/'; //$NON-NLS-1$
+									try {
+										override = new URI(str).normalize();
+									} catch (URISyntaxException ignore) {}
+								}
+								dojoLoc = new Location(primary, override);
+							} else {
+								String str = Context.toString(dojoLocObj);
+								if (!str.endsWith("/")) str += '/'; //$NON-NLS-1$
+								dojoLoc = new Location(new URI(str).normalize());
+							}
+						} catch (URISyntaxException e) {
+							if (log.isLoggable(Level.WARNING)) {
+								log.log(Level.WARNING, e.getMessage(), e);
+							}
+						}
+					}
+				}
+			}
+		}
+		// Bail if we can't find dojo
+		if (dojoLoc == null) {
+			if (log.isLoggable(Level.WARNING)) {
+				log.warning(Messages.DojoHttpTransport_0);
+			}
+			return;
+		}
+
+		if (paths != null && paths.get(dojoTextPluginFullPath, paths) != Scriptable.NOT_FOUND) {
+			// if config overrides dojo/text, then bail
+			if (log.isLoggable(Level.INFO)) {
+				log.info(MessageFormat.format(Messages.DojoHttpTransport_2,
+						new Object[]{dojoTextPluginFullPath}));
+			}
+			return;
+		}
+
+		Context context = Context.enter();
+		try {
+			// Create the paths and aliases config properties if necessary
+			if (paths == null) {
+				config.put(IConfig.PATHS_CONFIGPARAM, config, context.newObject(config));
+				paths = (Scriptable)config.get(IConfig.PATHS_CONFIGPARAM, null);
+			}
+			if (aliases == null) {
+				config.put(IConfig.ALIASES_CONFIGPARAM, config, context.newArray(config, 0));
+				aliases = (Scriptable)config.get(IConfig.ALIASES_CONFIGPARAM, null);
+			}
+			if (textPluginDelegators == null) {
+				config.put(IConfig.TEXTPLUGINDELEGATORS_CONFIGPARAM, config, context.newArray(config, 0));
+				textPluginDelegators = (Scriptable)config.get(IConfig.TEXTPLUGINDELEGATORS_CONFIGPARAM, null);
+			}
+			if (jsPluginDelegators == null) {
+				config.put(IConfig.JSPLUGINDELEGATORS_CONFIGPARAM, config, context.newArray(config, 0));
+				jsPluginDelegators = (Scriptable)config.get(IConfig.JSPLUGINDELEGATORS_CONFIGPARAM, null);
+			}
+
+			// Specify paths entry to map dojo/text to our text plugin proxy
+			if (log.isLoggable(Level.INFO)) {
+				log.info(MessageFormat.format(
+						Messages.DojoHttpTransport_3,
+						new Object[]{dojoTextPluginFullPath, getComboUri().resolve(textPluginPath)}
+				));
+			}
+
+			paths.put(dojoTextPluginFullPath, paths, getComboUri().resolve(textPluginPath));
+
+			// Specify paths entry to map the dojo text plugin alias name to the original
+			// dojo text plugin
+			Scriptable dojoTextPluginPath = context.newArray(config, 2);
+			URI primary = dojoLoc.getPrimary(), override = dojoLoc.getOverride();
+			primary = primary.resolve(dojoPluginUri);
+			if (override != null) {
+				override = override.resolve(dojoPluginUri);
+			}
+			dojoTextPluginPath.put(0, dojoTextPluginPath, primary.toString());
+			if (override != null) {
+				dojoTextPluginPath.put(1, dojoTextPluginPath, override.toString());
+			}
+			if (log.isLoggable(Level.INFO)) {
+				log.info(MessageFormat.format(
+						Messages.DojoHttpTransport_3,
+						new Object[]{dojoTextPluginAliasFullPath, Context.toString(dojoTextPluginPath)}
+				));
+			}
+			paths.put(dojoTextPluginAliasFullPath, paths, dojoTextPluginPath);
+
+			// Specify an alias mapping for the static alias used
+			// by the proxy module to the name which includes the path dojo/ so that
+			// relative module ids in dojo/text will resolve correctly.
+			//
+			// We need this in the server-side config so that the server can follow
+			// module dependencies from the plugin proxy
+			if (log.isLoggable(Level.INFO)) {
+				log.info(MessageFormat.format(
+						Messages.DojoHttpTransport_4,
+						new Object[]{dojoTextPluginAlias, dojoTextPluginAliasFullPath}
+				));
+			}
+			Scriptable alias = context.newArray(config, 3);
+			alias.put(0, alias, dojoTextPluginAlias);
+			alias.put(1, alias, dojoTextPluginAliasFullPath);
+			// Not easy to determine the size of an array using Scriptable
+			int max = -1;
+			for (Object id : aliases.getIds()) {
+				if (id instanceof Number) max = Math.max(max, (Integer)((Number)id));
+			}
+			aliases.put(max+1, aliases, alias);
+
+			max = -1;
+			for (Object id : textPluginDelegators.getIds()) {
+				if (id instanceof Number) max = Math.max(max, (Integer)((Number)id));
+			}
+			textPluginDelegators.put(max+1, textPluginDelegators, "dojo/text"); //$NON-NLS-1$
+			jsPluginDelegators.put(max+1, jsPluginDelegators, "dojo/i18n"); //$NON-NLS-1$
+		} finally {
+			Context.exit();
+		}
+
+		// Add alias definitions to be specified in client-side config
+		getClientConfigAliases().add(new String[]{dojoTextPluginAlias, dojoTextPluginAliasFullPath});
+		// Add alias mapping for aggregator text plugin alias used in the text plugin proxy
+		// to the actual aggregator text plugin name as determined from the module builder
+		// definitions
+		getClientConfigAliases().add(new String[]{aggregatorTextPluginAlias, getAggregatorTextPluginName()});
+	}
+
+	/**
+	 * Resource factory that creates a
+	 * {@link AbstractHttpTransport.LoaderExtensionResource} for the dojo http
+	 * transport when the loader extension resource URI is requested
+	 */
+	private class LoaderExtensionResourceFactory implements IResourceFactory {
+
+		/* (non-Javadoc)
+		 * @see com.ibm.jaggr.service.resource.IResourceFactory#handles(java.net.URI)
+		 */
+		@Override
+		public boolean handles(URI uri) {
+			String path = uri.getPath();
+			if (path.equals(getLoaderExtensionPath())) {
+				if (uri.getScheme().equals(getComboUri().getScheme())
+						&& uri.getHost().equals(getComboUri().getHost())) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		/* (non-Javadoc)
+		 * @see com.ibm.jaggr.service.resource.IResourceFactory#newResource(java.net.URI)
+		 */
+		@Override
+		public IResource newResource(URI uri) {
+			String path = uri.getPath();
+			if (!path.equals(getLoaderExtensionPath())) {
+				throw new UnsupportedOperationException(uri.toString());
+			}
+			List<IResource> aggregate = new ArrayList<IResource>(2);
+			for (String res : getLoaderExtensionResources()) {
+				aggregate.add(getAggregator().newResource(uri.resolve(res)));
+			}
+			return new LoaderExtensionResource(new AggregationResource(uri, aggregate));
+		}
+	}
+}

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/transport/AbstractHttpTransport.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/transport/AbstractHttpTransport.java
@@ -16,6 +16,37 @@
 
 package com.ibm.jaggr.service.impl.transport;
 
+import com.ibm.jaggr.core.BadRequestException;
+import com.ibm.jaggr.core.IAggregator;
+import com.ibm.jaggr.core.IAggregatorExtension;
+import com.ibm.jaggr.core.IPlatformServices;
+import com.ibm.jaggr.core.IShutdownListener;
+import com.ibm.jaggr.core.ProcessingDependenciesException;
+import com.ibm.jaggr.core.cachekeygenerator.ICacheKeyGenerator;
+import com.ibm.jaggr.core.config.IConfigModifier;
+import com.ibm.jaggr.core.deps.IDependencies;
+import com.ibm.jaggr.core.deps.IDependenciesListener;
+import com.ibm.jaggr.core.readers.AggregationReader;
+import com.ibm.jaggr.core.resource.IResource;
+import com.ibm.jaggr.core.resource.IResourceFactory;
+import com.ibm.jaggr.core.resource.IResourceFactoryExtensionPoint;
+import com.ibm.jaggr.core.resource.IResourceVisitor;
+import com.ibm.jaggr.core.resource.IResourceVisitor.Resource;
+import com.ibm.jaggr.core.resource.StringResource;
+import com.ibm.jaggr.core.transport.IHttpTransport;
+import com.ibm.jaggr.core.util.Features;
+import com.ibm.jaggr.core.util.TypeUtil;
+import com.ibm.jaggr.service.impl.resource.ExceptionResource;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.input.ReaderInputStream;
+import org.apache.commons.lang.StringUtils;
+import org.apache.wink.json4j.JSONArray;
+import org.apache.wink.json4j.JSONException;
+import org.apache.wink.json4j.JSONObject;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -46,54 +77,16 @@ import java.util.regex.Pattern;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.io.input.ReaderInputStream;
-import org.apache.commons.lang.StringUtils;
-import org.apache.wink.json4j.JSONArray;
-import org.apache.wink.json4j.JSONException;
-import org.apache.wink.json4j.JSONObject;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IConfigurationElement;
-import org.eclipse.core.runtime.IExecutableExtension;
-import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
-import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleException;
-import org.osgi.framework.ServiceRegistration;
-
-import com.ibm.jaggr.core.BadRequestException;
-import com.ibm.jaggr.core.IAggregator;
-import com.ibm.jaggr.core.IAggregatorExtension;
-import com.ibm.jaggr.core.IShutdownListener;
-import com.ibm.jaggr.core.ProcessingDependenciesException;
-import com.ibm.jaggr.core.cachekeygenerator.ICacheKeyGenerator;
-import com.ibm.jaggr.core.config.IConfigModifier;
-import com.ibm.jaggr.core.deps.IDependencies;
-import com.ibm.jaggr.core.deps.IDependenciesListener;
-import com.ibm.jaggr.core.readers.AggregationReader;
-import com.ibm.jaggr.core.resource.IResource;
-import com.ibm.jaggr.core.resource.IResourceFactory;
-import com.ibm.jaggr.core.resource.IResourceFactoryExtensionPoint;
-import com.ibm.jaggr.core.resource.IResourceVisitor;
-import com.ibm.jaggr.core.resource.StringResource;
-import com.ibm.jaggr.core.resource.IResourceVisitor.Resource;
-import com.ibm.jaggr.core.transport.IHttpTransport;
-import com.ibm.jaggr.core.util.Features;
-import com.ibm.jaggr.core.util.TypeUtil;
-import com.ibm.jaggr.service.impl.resource.ExceptionResource;
-
 /**
  * Implements common functionality useful for all Http Transport implementation
  * and defines abstract methods that subclasses need to implement
  */
-public abstract class AbstractHttpTransport implements IHttpTransport, IExecutableExtension, IConfigModifier, IShutdownListener, IDependenciesListener {
-	private static final Logger log = Logger.getLogger(DojoHttpTransport.class.getName());
+public abstract class AbstractHttpTransport implements IHttpTransport, IConfigModifier, IShutdownListener, IDependenciesListener {
+	private static final Logger log = Logger.getLogger(AbstractDojoHttpTransport.class.getName());
 
 	public static final String PATH_ATTRNAME = "path"; //$NON-NLS-1$
 	public static final String PATHS_PROPNAME = "paths"; //$NON-NLS-1$
-	
+
 	public static final String REQUESTEDMODULES_REQPARAM = "modules"; //$NON-NLS-1$
 	public static final String REQUESTEDMODULESCOUNT_REQPARAM = "count"; //$NON-NLS-1$
 	public static final String REQUIRED_REQPARAM = "required"; //$NON-NLS-1$
@@ -114,66 +107,65 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 	public static final String[] NOCACHE_REQPARAMS = {"noCache", "nc"}; //$NON-NLS-1$ //$NON-NLS-2$
 
 	public static final String[] REQUESTEDLOCALES_REQPARAMS = {"locales", "locs"}; //$NON-NLS-1$ //$NON-NLS-2$
-	
-	public static final String[] HASPLUGINBRANCHING_REQPARAMS = {"hasBranching", "hb"}; //$NON-NLS-1$ //$NON-NLS-2$ 
-	
+
+	public static final String[] HASPLUGINBRANCHING_REQPARAMS = {"hasBranching", "hb"}; //$NON-NLS-1$ //$NON-NLS-2$
+
 	public static final String CONFIGVARNAME_REQPARAM = "configVarName"; //$NON-NLS-1$
-	
+
 	public static final String LAYERCONTRIBUTIONSTATE_REQATTRNAME = AbstractHttpTransport.class.getName() + ".LayerContributionState"; //$NON-NLS-1$
     public static final String ENCODED_FEATURE_MAP_REQPARAM = "hasEnc"; //$NON-NLS-1$
-    
+
     static final String FEATUREMAP_JS_PATH = "/WebContent/featureList.js"; //$NON-NLS-1$
     public static final String FEATURE_LIST_PRELUDE = "define([], "; //$NON-NLS-1$
     public static final String FEATURE_LIST_PROLOGUE = ");"; //$NON-NLS-1$
 
 	/** A cache of folded module list strings to expanded file name lists.  Used by LayerImpl cache */
     private Map<String, Collection<String>> _encJsonMap = new ConcurrentHashMap<String, Collection<String>>();
-    
+
     private static final Pattern DECODE_JSON = Pattern.compile("([!()|*<>])"); //$NON-NLS-1$
     private static final Pattern REQUOTE_JSON = Pattern.compile("([{,:])([^{},:\"]+)([},:])"); //$NON-NLS-1$
 
-    private String resourcePathId;
-    private List<ServiceRegistration> serviceRegistrations = new ArrayList<ServiceRegistration>();
+    private List<Object> serviceRegistrations = new ArrayList<Object>();
     private IAggregator aggregator = null;
     private List<String> extensionContributions = new LinkedList<String>();
 
     private List<String> dependentFeatures = null;
     private IResource depFeatureListResource = null;
-    
+
     private CountDownLatch depsInitialized = null;
-    
+
     /** default constructor */
     public AbstractHttpTransport() {}
-    	
+
     /** For unit tests */
     AbstractHttpTransport(CountDownLatch depsInitialized, List<String> dependentFeatures, long depsLastMod) {
     	this.depsInitialized = depsInitialized;
     	this.dependentFeatures = dependentFeatures;
     	this.depFeatureListResource = createFeatureListResource(dependentFeatures, getFeatureListResourceUri(), depsLastMod);
     }
-    
+
     /**
      * Returns the URI to the folder containing the javascript resources
      * for this transport.
-     * 
+     *
      * @return the combo resource URI
      */
     protected abstract URI getComboUri();
-    
+
 	/* (non-Javadoc)
 	 * @see com.ibm.jaggr.service.transport.IHttpTransport#decorateRequest(javax.servlet.http.HttpServletRequest, com.ibm.jaggr.service.IAggregator)
 	 */
 	@Override
 	public void decorateRequest(HttpServletRequest request) throws IOException {
-		
+
 		// Get module list from request
 		request.setAttribute(REQUESTEDMODULES_REQATTRNAME, getModuleListFromRequest(request));
-		
+
 		// Get the feature list, if any
 		request.setAttribute(FEATUREMAP_REQATTRNAME, getFeaturesFromRequest(request));
-		
+
 		request.setAttribute(OPTIMIZATIONLEVEL_REQATTRNAME, getOptimizationLevelFromRequest(request));
-		
+
 		String value = getParameter(request, EXPANDREQUIRELISTS_REQPARAMS);
 		if ("log".equals(value)) { //$NON-NLS-1$
 			request.setAttribute(EXPANDREQLOGGING_REQATTRNAME, Boolean.TRUE);
@@ -182,24 +174,24 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 	   		request.setAttribute(EXPANDREQUIRELISTS_REQATTRNAME, TypeUtil.asBoolean(value));
 		}
    		request.setAttribute(EXPORTMODULENAMES_REQATTRNAME, TypeUtil.asBoolean(getParameter(request, EXPORTMODULENAMES_REQPARAMS), true));
-   		
+
    		request.setAttribute(SHOWFILENAMES_REQATTRNAME, TypeUtil.asBoolean(getParameter(request, SHOWFILENAMES_REQPARAMS)));
-   		
+
    		request.setAttribute(NOCACHE_REQATTRNAME, TypeUtil.asBoolean(getParameter(request, NOCACHE_REQPARAMS)));
-   		
+
    		request.setAttribute(HASPLUGINBRANCHING_REQATTRNAME, TypeUtil.asBoolean(getParameter(request, HASPLUGINBRANCHING_REQPARAMS), true));
-   		
+
    		request.setAttribute(REQUESTEDLOCALES_REQATTRNAME, getRequestedLocales(request));
 
    		if (request.getParameter(CONFIGVARNAME_REQPARAM) != null) {
    			request.setAttribute(CONFIGVARNAME_REQATTRNAME, request.getParameter(CONFIGVARNAME_REQPARAM));
    		}
 	}
-	
+
 	/**
 	 * Unfolds the folded module list in the request into a {@code Collection<String>}
 	 * of module names.
-	 * 
+	 *
 	 * @param request the request object
 	 * @return the Collection of module names
 	 * @throws IOException
@@ -212,11 +204,11 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
         if (countParam != null) {
         	count = Integer.parseInt(request.getParameter(REQUESTEDMODULESCOUNT_REQPARAM));
         }
-        
+
         if (moduleQueryArg == null) {
         	return Collections.emptySet();
         }
-        
+
         try {
 			moduleQueryArg = URLDecoder.decode(moduleQueryArg, "UTF-8"); //$NON-NLS-1$
 		} catch (UnsupportedEncodingException e) {
@@ -232,11 +224,11 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 	        	} catch (JSONException e) {
 	        		throw new IOException(e);
 	        	}
-	            
+
 	            // Save buildReader so we don't have to do this again.
 	            _encJsonMap.put(moduleQueryArg, moduleList);
 	        }
-    	} else {  
+    	} else {
         	// Hand crafted URL; get module names from one or more module query args
     		moduleList.addAll(Arrays.asList(moduleQueryArg.split("\\s*,\\s*", 0))); //$NON-NLS-1$
     		String required = request.getParameter(REQUIRED_REQPARAM);
@@ -247,12 +239,12 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
     	}
 		return Collections.unmodifiableCollection(new ModuleList(moduleList, moduleQueryArg));
 	}
-	
+
 	/**
 	 * Returns the requested locales as a collection of locale strings
-	 * 
+	 *
 	 * @param request the request object
-	 * @return the locale strings 
+	 * @return the locale strings
 	 */
 	protected Collection<String> getRequestedLocales(HttpServletRequest request) {
 		String[] locales;
@@ -263,14 +255,14 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 			locales = new String[0];
 		}
 		return Collections.unmodifiableCollection(Arrays.asList(locales));
-		
+
 	}
-	
+
     /**
      *  Decode JSON object encoded for url transport.
      *  Enforces ordering of object keys and mangles JSON format to prevent encoding of frequently used characters.
      *  Assumes that keynames and values are valid filenames, and do not contain illegal filename chars.
-     *  See http://www.w3.org/Addressing/rfc1738.txt for small set of safe chars.  
+     *  See http://www.w3.org/Addressing/rfc1738.txt for small set of safe chars.
      */
     protected  JSONObject decodeModules(String encstr) throws IOException {
         StringBuffer json = new StringBuffer(encstr.length() * 2);
@@ -304,13 +296,13 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 		}
         return decoded;
     }
-    
+
 	/**
 	 * Regular expression for a non-path property (i.e. auxiliary information or processing
 	 * instruction) of a folded path json object.
 	 */
 	static public Pattern NON_PATH_PROP_PATTERN = Pattern.compile("^/[^/]+/$"); //$NON-NLS-1$
-	
+
 	/**
 	 * Name of folded path json property used to identify the names of loader
 	 * plugin prefixes and their ordinals used in the folded path.  This must
@@ -318,14 +310,14 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 	 * slashes (/) ensure that the name won't collide with a real path name.
 	 */
 	static public String PLUGIN_PREFIXES_PROP_NAME = "/pre/"; //$NON-NLS-1$
-	
+
 	/**
 	 * Unfolds a folded module name list into a String array of unfolded names
 	 * <p>
 	 * The returned list must be sorted the same way it was requested ordering
 	 * modules in the same way as in the companion js extension to amd loader
 	 * order provided in the folded module leaf
-	 * 
+	 *
 	 * @param modules
 	 *            The folded module name list
 	 * @param count
@@ -352,10 +344,10 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 		}
 		return ret;
 	}
-    
+
     /**
-     * Helper routine to unfold folded module names 
-     * 
+     * Helper routine to unfold folded module names
+     *
      * @param obj
      * @param path
      * @param modules
@@ -373,9 +365,9 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
         else if (obj instanceof String){
             String[] values = ((String)obj).split("-"); //$NON-NLS-1$
             try {
-                modules[Integer.parseInt(values[0])] = values.length > 1 ? 
-                	((aPrefixes != null ? 
-                			aPrefixes[Integer.parseInt(values[1])] : values[1]) 
+                modules[Integer.parseInt(values[0])] = values.length > 1 ?
+                	((aPrefixes != null ?
+                			aPrefixes[Integer.parseInt(values[1])] : values[1])
                 		+ "!" + path) : //$NON-NLS-1$
                 	path;
             } catch (Exception e) {
@@ -386,13 +378,13 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
         	throw new BadRequestException();
         }
     }
-    
+
     /**
      * Returns a map containing the has-condition/value pairs specified in the request
-     * 
+     *
      * @param request The http request object
      * @return The map containing the has-condition/value pairs.
-     * @throws  
+     * @throws
      */
     protected Features getFeaturesFromRequest(HttpServletRequest request) throws IOException {
 		Features features = getFeaturesFromRequestEncoded(request);
@@ -420,11 +412,11 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
     }
 
 	/**
-	 * This method checks the request for the has conditions which may either be contained in URL 
+	 * This method checks the request for the has conditions which may either be contained in URL
 	 * query arguments or in a cookie sent from the client.
-	 * 
+	 *
 	 * @return The has conditions from the request.
-	 * @throws UnsupportedEncodingException 
+	 * @throws UnsupportedEncodingException
 	 */
 	protected String getHasConditionsFromRequest(HttpServletRequest request) throws IOException {
 
@@ -455,13 +447,13 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 		}
 		else
 			ret = request.getParameter(FEATUREMAP_REQPARAM);
-		
+
 		return ret;
 	}
-    
+
 	/**
 	 * Returns the value of the requested parameter from the request, or null
-	 * 
+	 *
 	 * @param request
 	 *            the request object
 	 * @param aliases
@@ -486,7 +478,7 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 
 	/**
 	 * Returns the requested optimization level from the request.
-	 * 
+	 *
 	 * @param request the request object
 	 * @return the optimization level specified in the request
 	 */
@@ -504,10 +496,10 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
         }
         return level;
 	}
-    
+
 	/**
 	 * Extends the default implementation of {@link LinkedList} to override
-	 * the {@code toString) method (used in generating layer cache keys) so 
+	 * the {@code toString) method (used in generating layer cache keys) so
 	 * that we can return the folded module name list (allowing for more
 	 * compact cache keys).
 	 */
@@ -520,7 +512,7 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 			super(source);
 			this.stringized = stringized;
 		}
-		
+
 		/* (non-Javadoc)
 		 * @see java.util.AbstractCollection#toString()
 		 */
@@ -531,47 +523,12 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 	}
 
 	/* (non-Javadoc)
-	 * @see org.eclipse.core.runtime.IExecutableExtension#setInitializationData(org.eclipse.core.runtime.IConfigurationElement, java.lang.String, java.lang.Object)
-	 */
-	@Override
-	public void setInitializationData(IConfigurationElement config, String propertyName,
-			Object data) throws CoreException {
-		
-		// Make sure the contributing bundle is started
-		Bundle contributingBundle = Platform.getBundle(config.getNamespaceIdentifier());
-		if (contributingBundle.getState() != Bundle.ACTIVE) {
-			try {
-				contributingBundle.start();
-			} catch (BundleException e) {
-				throw new CoreException(
-						new Status(Status.ERROR, config.getNamespaceIdentifier(), 
-								e.getMessage(), e)
-					);
-			}
-		}
-		
-		// Get the resource (combo) path name from the this extension's 
-		// path attribute
-		resourcePathId = config.getAttribute(PATH_ATTRNAME);
-		if (resourcePathId == null) {
-			throw new CoreException(
-					new Status(Status.ERROR, config.getNamespaceIdentifier(),
-						MessageFormat.format(
-							Messages.AbstractHttpTransport_1, 
-							new Object[]{config.getDeclaringExtension().getUniqueIdentifier()}
-						)
-					)
-				);
-		}
-	}
-	
-	/* (non-Javadoc)
 	 * @see com.ibm.jaggr.service.config.IConfigModifier#modifyConfig(com.ibm.jaggr.service.IAggregator, java.util.Map)
 	 */
 	@Override
 	public void modifyConfig(IAggregator aggregator, Scriptable config) {
-		// The server-side AMD config has been updated.  Add an entry to the 
-		// {@code paths} property to map the resource (combo) path to the 
+		// The server-side AMD config has been updated.  Add an entry to the
+		// {@code paths} property to map the resource (combo) path to the
 		// location of the combo resources on the server.
 		Context context = Context.enter();
 		try {
@@ -586,7 +543,7 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 			Context.exit();
 		}
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see com.ibm.jaggr.service.IExtensionInitializer#initialize(com.ibm.jaggr.service.IAggregator, com.ibm.jaggr.service.IAggregatorExtension, com.ibm.jaggr.service.IExtensionInitializer.IExtensionRegistrar)
 	 */
@@ -595,7 +552,7 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 		this.aggregator = aggregator;
 
 		URI featureListResourceUri = getFeatureListResourceUri();
-		// register a config listener so that we get notified of changes to 
+		// register a config listener so that we get notified of changes to
 		// the server-side AMD config file.
 		String name = aggregator.getName();
 		Properties dict = new Properties();
@@ -610,20 +567,20 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 		));
 
 		if (featureListResourceUri != null) {
-		    depsInitialized = new CountDownLatch(1); 
+		    depsInitialized = new CountDownLatch(1);
 
 			// Get first resource factory extension so we can add to beginning of list
 	    	Iterable<IAggregatorExtension> resourceFactoryExtensions = aggregator.getResourceFactoryExtensions();
 	    	IAggregatorExtension first = resourceFactoryExtensions.iterator().next();
-	
+
 	    	// Register the featureMap resource factory
 	    	dict = new Properties();
 	    	dict.put("scheme", "namedbundleresource"); //$NON-NLS-1$ //$NON-NLS-2$
 			reg.registerExtension(
-					newFeatureListResourceFactory(featureListResourceUri), 
+					newFeatureListResourceFactory(featureListResourceUri),
 					dict,
 					IResourceFactoryExtensionPoint.ID,
-					getPluginUniqueId(),
+					getTransportId(),
 					first);
 
 			// Register the dependencies listener
@@ -631,7 +588,7 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 			dict.put("name", aggregator.getName()); //$NON-NLS-1$
 			serviceRegistrations.add(aggregator.getBundleContext().registerService(
 					IDependenciesListener.class.getName(), this, dict));
-		}	
+		}
 	}
 
 	/* (non-Javadoc)
@@ -640,27 +597,28 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 	@Override
 	public void shutdown(IAggregator aggregator) {
 		// unregister the service registrations
-		for (ServiceRegistration reg : serviceRegistrations) {
+		IPlatformServices platformServices = aggregator.getPlatformServices();
+		for (Object reg : serviceRegistrations) {
 			if (reg != null) {
-				reg.unregister();
+				platformServices.unRegisterService(reg);
 			}
 		}
 		serviceRegistrations.clear();
 	}
-	
+
 	/**
-	 * Returns the unique id for the implementing plugin.  Must
+	 * Returns the unique id for the transport.  Must
 	 * be implemented by subclasses.
-	 * 
+	 *
 	 * @return the plugin unique id.
 	 */
-	abstract protected String getPluginUniqueId();
+	abstract protected String getTransportId();
 
 	/**
 	 * Default implementation that returns null URI. Subclasses should
 	 * implement this method to return the loader specific URI to the resource
 	 * that implements the featureMap JavaScript code.
-	 * 
+	 *
 	 * @return null
 	 */
 	protected URI getFeatureListResourceUri() {
@@ -669,23 +627,21 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 
 	/**
 	 * Returns the aggregator instance that created this transport
-	 * 
+	 *
 	 * @return the aggregator
 	 */
 	protected IAggregator getAggregator() {
 		return aggregator;
 	}
-	
+
 	/**
 	 * Returns the resource (combo) path id specified by the transport's
 	 * plugin extension {@code path} attribute
-	 * 
+	 *
 	 * @return the resource path id
 	 */
-	protected String getResourcePathId() {
-		return resourcePathId;
-	}
-	
+	abstract protected String getResourcePathId();
+
 	/* (non-Javadoc)
 	 * @see com.ibm.jaggr.service.transport.IHttpTransport#contributeLoaderExtensionJavaScript(java.lang.String)
 	 */
@@ -711,21 +667,21 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 	 */
 	@Override
 	public abstract List<ICacheKeyGenerator> getCacheKeyGenerators();
-	
+
 	/**
 	 * Returns the extension contributions that have been registered with this
 	 * transport
-	 * 
+	 *
 	 * @return the extension contributions
 	 */
 	protected List<String> getExtensionContributions() {
 		return extensionContributions;
 	}
-	
+
 	/**
 	 * Returns the dynamic portion of the loader extension javascript for this
 	 * transport.  This includes all registered extension contributions.
-	 * 
+	 *
 	 * @return the dynamic portion of the loader extension javascript
 	 */
 	protected String getDynamicLoaderExtensionJavaScript() {
@@ -736,7 +692,7 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 		String cacheBust = aggregator.getConfig().getCacheBust();
 		String optionsCb = aggregator.getOptions().getCacheBust();
 		if (optionsCb != null && optionsCb.length() > 0) {
-			cacheBust = (cacheBust != null && cacheBust.length() > 0) ? 
+			cacheBust = (cacheBust != null && cacheBust.length() > 0) ?
 					(cacheBust + "-" + optionsCb) : optionsCb; //$NON-NLS-1$
 		}
 		if (cacheBust != null && cacheBust.length() > 0) {
@@ -745,12 +701,12 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 		}
 		return sb.toString();
 	}
-	
+
 	/**
 	 * Validate the {@link LayerContributionState} and argument type specified
 	 * in a call to
 	 * {@link #getLayerContribution(HttpServletRequest, com.ibm.jaggr.core.transport.IHttpTransport.LayerContributionType, Object)}
-	 * 
+	 *
 	 * @param request
 	 *            The http request object
 	 * @param type
@@ -759,7 +715,7 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 	 * @param arg
 	 *            The argument value
 	 */
-    protected void validateLayerContributionState(HttpServletRequest request, 
+    protected void validateLayerContributionState(HttpServletRequest request,
     		LayerContributionType type, Object arg) {
 
     	LayerContributionType previousType = (LayerContributionType)request.getAttribute(LAYERCONTRIBUTIONSTATE_REQATTRNAME);
@@ -775,13 +731,13 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
     		}
     		break;
     	case BEFORE_FIRST_MODULE:
-    		if (previousType != LayerContributionType.BEGIN_MODULES || 
+    		if (previousType != LayerContributionType.BEGIN_MODULES ||
     			!(arg instanceof String)) {
     			throw new IllegalStateException();
     		}
     		break;
     	case BEFORE_SUBSEQUENT_MODULE:
-    		if (previousType != LayerContributionType.AFTER_MODULE || 
+    		if (previousType != LayerContributionType.AFTER_MODULE ||
     			!(arg instanceof String)) {
     			throw new IllegalStateException();
     		}
@@ -806,20 +762,20 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
     		}
     		break;
     	case BEFORE_FIRST_REQUIRED_MODULE:
-    		if (previousType != LayerContributionType.BEGIN_REQUIRED_MODULES || 
+    		if (previousType != LayerContributionType.BEGIN_REQUIRED_MODULES ||
     			!(arg instanceof String)) {
     			throw new IllegalStateException();
     		}
     		break;
     	case BEFORE_SUBSEQUENT_REQUIRED_MODULE:
-    		if (previousType != LayerContributionType.AFTER_REQUIRED_MODULE || 
+    		if (previousType != LayerContributionType.AFTER_REQUIRED_MODULE ||
     			!(arg instanceof String)) {
    			    throw new IllegalStateException();
     		}
     		break;
     	case AFTER_REQUIRED_MODULE:
     		if (previousType != LayerContributionType.BEFORE_FIRST_REQUIRED_MODULE &&
-    			previousType != LayerContributionType.BEFORE_SUBSEQUENT_REQUIRED_MODULE || 
+    			previousType != LayerContributionType.BEFORE_SUBSEQUENT_REQUIRED_MODULE ||
     			!(arg instanceof String)) {
 				throw new IllegalStateException();
 			}
@@ -839,7 +795,7 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
     	}
     	request.setAttribute(LAYERCONTRIBUTIONSTATE_REQATTRNAME, type);
     }
-    
+
 	/**
 	 * Returns the has conditions specified in the request as a base64 encoded
 	 * trit map of feature values where each trit (three state value - 0, 1 and
@@ -850,7 +806,7 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 	 * <p>
 	 * Each byte from the base64 decoded byte array encodes 5 trits (3**5 = 243
 	 * states out of the 256 possible states).
-	 * 
+	 *
 	 * @param request
 	 *            The http request object
 	 * @return the decoded feature list as a string, or null
@@ -918,10 +874,10 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 		}
 		return result;
 	}
-	
+
 	/**
 	 * Returns an instance of a FeatureMapJSResourceFactory.
-	 * 
+	 *
 	 * @param resourcePath
 	 *            the resource path
 	 * @return a new factory object
@@ -938,18 +894,18 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 		}
 		return factory;
 	}
-	
+
 	/**
 	 * Resource factory for serving the featureMap JavaScript resource containing the
-	 * dynamically generated list of dependent features.  This list is used by the 
-	 * client to encode the states of the features as a trit map of values over 
-	 * the list, where each trit in the encoded data is the value of a feature 
-	 * in the list. 
+	 * dynamically generated list of dependent features.  This list is used by the
+	 * client to encode the states of the features as a trit map of values over
+	 * the list, where each trit in the encoded data is the value of a feature
+	 * in the list.
 	 */
 	protected class FeatureListResourceFactory implements IResourceFactory {
-		
+
 		private final URI resourceUri;
-		
+
 		public FeatureListResourceFactory(URI resourceUri) {
 			this.resourceUri = resourceUri;
 		}
@@ -998,18 +954,18 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 			} catch (InterruptedException e) {
 				return new ExceptionResource(uri, 0L, new IOException(e));
 			}
-			IResource result = depFeatureListResource; 
+			IResource result = depFeatureListResource;
 			if (traceLogging) {
 				log.exiting(AbstractHttpTransport.FeatureListResourceFactory.class.getName(), methodName, depFeatureListResource);
 			}
 			return result;
 		}
 	}
-	
+
 	/**
 	 * Creates an {@link IResource} object for the dependent feature list AMD
 	 * module
-	 * 
+	 *
 	 * @param list
 	 *            the dependent features list
 	 * @param uri
@@ -1027,7 +983,7 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 		}
 		StringBuffer sb = new StringBuffer();
 		sb.append(FEATURE_LIST_PRELUDE).append(json).append(FEATURE_LIST_PROLOGUE);
-		IResource result = new StringResource(sb.toString(), uri, lastmod); 
+		IResource result = new StringResource(sb.toString(), uri, lastmod);
 		return result;
 	}
 
@@ -1057,26 +1013,26 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 			if (log.isLoggable(Level.SEVERE)) {
 				log.log(Level.SEVERE, t.getMessage(), t);
 			}
-			// Clear the latch to allow the waiting thread to wake up.  If 
+			// Clear the latch to allow the waiting thread to wake up.  If
 			// dependencies have never been initialized, then NullPointerExceptions
-			// will be thrown for any threads trying to access the uninitialized 
+			// will be thrown for any threads trying to access the uninitialized
 			// dependencies.
 			depsInitialized.countDown();
-			
+
 		}
-	}	
+	}
 	/**
-	 * Implementation of an {@link IResource} that aggregates the various 
-	 * sources (dynamic and static content) of the loader extension 
+	 * Implementation of an {@link IResource} that aggregates the various
+	 * sources (dynamic and static content) of the loader extension
 	 * javascript for this transport
 	 */
 	protected class LoaderExtensionResource implements IResource, IResourceVisitor.Resource {
 		IResource res;
-		
+
 		public LoaderExtensionResource(IResource res) {
 			this.res = res;
 		}
-		
+
 		/* (non-Javadoc)
 		 * @see com.ibm.jaggr.service.resource.IResource#getURI()
 		 */
@@ -1108,13 +1064,13 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IExecutab
 		public InputStream getInputStream() throws IOException {
 			return new ReaderInputStream(getReader(), "UTF-8"); //$NON-NLS-1$
 		}
-		
+
 		/* (non-Javadoc)
 		 * @see com.ibm.jaggr.service.resource.IResource#getReader()
 		 */
 		@Override
 		public Reader getReader() throws IOException {
-			
+
 			// Return an aggregation reader for the loader extension javascript
 			return new AggregationReader(
 					"(function(){", //$NON-NLS-1$

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/transport/DojoHttpTransport.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/transport/DojoHttpTransport.java
@@ -13,262 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.ibm.jaggr.service.impl.transport;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Properties;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.regex.Pattern;
-
-import javax.servlet.http.HttpServletRequest;
+import com.ibm.jaggr.service.impl.Activator;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExecutableExtension;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
-import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
 
-import com.ibm.jaggr.core.IAggregator;
-import com.ibm.jaggr.core.IAggregatorExtension;
-import com.ibm.jaggr.core.IExtensionInitializer;
-import com.ibm.jaggr.core.cachekeygenerator.ICacheKeyGenerator;
-import com.ibm.jaggr.core.config.IConfig;
-import com.ibm.jaggr.core.config.IConfig.Location;
-import com.ibm.jaggr.core.options.IOptions;
-import com.ibm.jaggr.core.resource.AggregationResource;
-import com.ibm.jaggr.core.resource.IResource;
-import com.ibm.jaggr.core.resource.IResourceFactory;
-import com.ibm.jaggr.core.resource.IResourceFactoryExtensionPoint;
-import com.ibm.jaggr.core.transport.IHttpTransport;
-import com.ibm.jaggr.core.util.TypeUtil;
-import com.ibm.jaggr.service.impl.Activator;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.MessageFormat;
 
 /**
- * Implements the functionality specific for the Dojo Http Transport (supporting
- * the dojo AMD loader).
+ * Extends {@link AbstractDojoHttpTransport} for OSGi platform
+ *
  */
-public class DojoHttpTransport extends AbstractHttpTransport implements IHttpTransport, IExecutableExtension, IExtensionInitializer {
-	private static final Logger log = Logger.getLogger(DojoHttpTransport.class.getName());
-	
-    static final String comboUriStr = "namedbundleresource://" + Activator.BUNDLE_NAME + "/WebContent"; //$NON-NLS-1$ //$NON-NLS-2$
-    static final String textPluginProxyUriStr = comboUriStr + "/dojo/text"; //$NON-NLS-1$
-    static final String loaderExtensionPath = "/WebContent/loaderExt.js"; //$NON-NLS-1$
-    static final String[] loaderExtensionResources = {
-    	"./loaderExtCommon.js", //$NON-NLS-1$
-    	"./dojo/_loaderExt.js" //$NON-NLS-1$
-    };
-    static final String dojo = "dojo"; //$NON-NLS-1$
-    static final String aggregatorTextPluginAlias = "__aggregator_text_plugin"; //$NON-NLS-1$
-    static final String dojoTextPluginAlias = "__original_text_plugin"; //$NON-NLS-1$
-    static final String dojoTextPluginAliasFullPath = dojo+"/"+dojoTextPluginAlias; //$NON-NLS-1$
-    static final String dojoTextPluginName = "text"; //$NON-NLS-1$
-    static final String dojoTextPluginFullPath = dojo+"/"+dojoTextPluginName; //$NON-NLS-1$
-    static final URI dojoPluginUri;
- 
-    static {
-    	try {
-    		dojoPluginUri = new URI("./"+dojoTextPluginName); //$NON-NLS-1$
-    	} catch (URISyntaxException e) {
-    		// Should never happen
-    		throw new RuntimeException(e);
-    	}
-    }
+public class DojoHttpTransport extends AbstractDojoHttpTransport implements IExecutableExtension {
 
-    private String pluginUniqueId = ""; //$NON-NLS-1$
-    private URI comboUri;
+    static final String comboUriStr = "namedbundleresource://" + Activator.BUNDLE_NAME + "/WebContent/"; //$NON-NLS-1$ //$NON-NLS-2$
 
-    private List<String[]> clientConfigAliases = new LinkedList<String[]>();
-    
-    /**
-     * Property accessor for the comboUriStr property
-     * 
-     * @return the combo URI string value
-     */
-    protected String getComboUriStr() {
-    	return comboUriStr;
-    }
-    
-    /* (non-Javadoc)
-     * @see com.ibm.jaggr.service.impl.transport.AbstractHttpTransport#getPluginUniqueId()
-     */
-    protected String getPluginUniqueId() {
-    	return pluginUniqueId;
-    }
-    
-    /**
-     * Property accessor for the loaderExtensionPath property
-     * 
-     * @return the loader extension path
-     */
-    protected String getLoaderExtensionPath() {
-    	return loaderExtensionPath;
-    }
-    
-    /**
-     * Property accessor for the loaderExtensionResources property
-     * 
-     * @return the loader extension resources
-     */
-    protected String[] getLoaderExtensionResources() {
-    	return loaderExtensionResources;
-    }
-    
-    /**
-     * Returns the list of client config aliases
-     * 
-     * @return the client aliases
-     */
-    protected List<String[]> getClientConfigAliases() {
-    	return clientConfigAliases;
-    }
-    
-    protected String getAggregatorTextPluginName() {
-    	return getResourcePathId() + "/text"; //$NON-NLS-1$
-    }
-    
-    /* (non-Javadoc)
-     * @see com.ibm.jaggr.service.transport.AbstractHttpTransport#getLayerContribution(javax.servlet.http.HttpServletRequest, com.ibm.jaggr.service.transport.IHttpTransport.LayerContributionType, java.lang.String)
-     */
-    @Override
-	public String getLayerContribution(HttpServletRequest request,
-			LayerContributionType type, Object arg) {
+    private String resourcePathId = null;
 
-    	super.validateLayerContributionState(request, type, arg);
-    	
-    	// Implement wrapping of modules required by dojo loader for modules that 
-    	// are loaded with the loader.
-    	switch (type) {
-		case BEGIN_REQUIRED_MODULES:
-			return "require({cache:{"; //$NON-NLS-1$
-		case BEFORE_FIRST_REQUIRED_MODULE:
-			return getBeforeRequiredModule(request, arg.toString());
-		case BEFORE_SUBSEQUENT_REQUIRED_MODULE:
-			return "," + getBeforeRequiredModule(request, arg.toString()); //$NON-NLS-1$
-		case AFTER_REQUIRED_MODULE:
-			return getAfterRequiredModule(request, arg.toString());
-		case END_REQUIRED_MODULES:
-			{
-				StringBuffer sb = new StringBuffer();
-				sb.append("}});require({cache:{}});require(["); //$NON-NLS-1$ 
-				int i = 0;
-				@SuppressWarnings("unchecked")
-				Set<String> requiredModules = (Set<String>)arg;
-				for (String name : requiredModules) {
-					sb.append(i++ > 0 ? "," : "").append("\"").append(name).append("\""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ 
-				}
-				sb.append("]);"); //$NON-NLS-1$
-				return sb.toString();
-			}
-		default:
-		}
-		return null;
-	}
-    
-    static final Pattern urlId = Pattern.compile("^[a-zA-Z]+\\:\\/\\/"); //$NON-NLS-1$
-    /* (non-Javadoc)
-     * @see com.ibm.jaggr.service.impl.transport.AbstractHttpTransport#isServerExpandable(javax.servlet.http.HttpServletRequest, java.lang.String)
-     */
-    @Override
-	public boolean isServerExpandable(HttpServletRequest request, String mid) {
-    	int idx = mid.indexOf("!"); //$NON-NLS-1$
-    	String plugin = idx != -1 ? mid.substring(0, idx) : null;
-    	String name = idx != -1 ? mid.substring(idx+1) : mid;
-    	if (name.startsWith("/") || urlId.matcher(name).find() || name.contains("?")) { //$NON-NLS-1$ //$NON-NLS-2$
-    		return false;
-    	}
-    	if (plugin != null) {
-    		IAggregator aggr = (IAggregator)request.getAttribute(IAggregator.AGGREGATOR_REQATTRNAME);
-    		if (!aggr.getConfig().getTextPluginDelegators().contains(plugin) &&
-    			!aggr.getConfig().getJsPluginDelegators().contains(plugin)) {
-    			return false;
-    		}
-    	}
-		return true;
-	}
+    private URI comboUri = null;
 
-	protected String getBeforeRequiredModule(HttpServletRequest request, String mid) {
-    	String result;
-    	int idx = mid.indexOf("!"); //$NON-NLS-1$
-    	if (idx == -1) {
-    		result = "\"" + mid + "\":function(){"; //$NON-NLS-1$ //$NON-NLS-2$
-    	} else {
-    		String plugin = mid.substring(0, idx);
-    		IAggregator aggr = (IAggregator)request.getAttribute(IAggregator.AGGREGATOR_REQATTRNAME);
-    		IConfig config = aggr.getConfig();
-    		if (config.getTextPluginDelegators().contains(plugin)) {
-    			result = "\"url:" + mid.substring(idx+1) + "\":"; //$NON-NLS-1$ //$NON-NLS-2$
-    		} else if (config.getJsPluginDelegators().contains(plugin)) {
-    			result = "\"" + mid.substring(idx+1) + "\":function(){"; //$NON-NLS-1$ //$NON-NLS-2$
-    		} else {
-    			result = "\"" + mid + "\":function(){"; //$NON-NLS-1$ //$NON-NLS-2$
-    		}
-    	}
-    	return result;
-    }
-    
-    protected String getAfterRequiredModule(HttpServletRequest request, String mid) {
-    	int idx = mid.indexOf("!"); //$NON-NLS-1$
-    	String plugin = idx == -1 ? null : mid.substring(0, idx);
-    	String result = "}";//$NON-NLS-1$
-    	if (plugin != null) {
-    		IAggregator aggr = (IAggregator)request.getAttribute(IAggregator.AGGREGATOR_REQATTRNAME);
-    		IConfig config = aggr.getConfig();
-    		if (config.getTextPluginDelegators().contains(plugin)) {
-    			result = ""; //$NON-NLS-1$
-    		}
-    	}
-    	return result;
-    }
-
-	/* (non-Javadoc)
-	 * @see com.ibm.jaggr.service.transport.AbstractHttpTransport#getCacheKeyGenerators()
-	 */
-	@Override
-	public List<ICacheKeyGenerator> getCacheKeyGenerators() {
-		/*
-		 * The content generated by this transport is invariant with regard
-		 * to request parameters (for a given set of modules) so we don't
-		 * need to provide a cache key generator.
-		 */
-		return null;
-	}
-	
-	/* (non-Javadoc)
-	 * @see com.ibm.jaggr.service.transport.AbstractHttpTransport#getComboUri()
-	 */
-	@Override 
-	protected URI getComboUri() {
-		return comboUri;
-	}
-	
-	@Override
-	public void decorateRequest(HttpServletRequest request) throws IOException {
-		super.decorateRequest(request);
-		if (request.getAttribute(IHttpTransport.REQUIRED_REQATTRNAME) != null) {
-			// If we're building a pre-boot layer, then don't adorn text strings
-			// and don't export module names
-			request.setAttribute(IHttpTransport.NOTEXTADORN_REQATTRNAME, Boolean.TRUE);
-			request.setAttribute(IHttpTransport.EXPORTMODULENAMES_REQATTRNAME, Boolean.FALSE);
-		}
-		if (!(TypeUtil.asBoolean(request.getAttribute(IHttpTransport.EXPORTMODULENAMES_REQATTRNAME)) &&
-				(OptimizationLevel)request.getAttribute(IHttpTransport.OPTIMIZATIONLEVEL_REQATTRNAME) != OptimizationLevel.NONE ||
-				request.getAttribute(IHttpTransport.REQUIRED_REQATTRNAME) != null)) {
-			// If we're not exporting module names and we aren't doing server side expansion
-			// of dependencies (i.e. using a prebuild cache), then we can't expand i18n
-			// resources.
-			request.setAttribute(IHttpTransport.NOADDMODULES_REQATTRNAME, true);
-		}
-	}
+    private String pluginUniqueId = null;
 
 	/* (non-Javadoc)
 	 * @see com.ibm.jaggr.service.transport.AbstractHttpTransport#setInitializationData(org.eclipse.core.runtime.IConfigurationElement, java.lang.String, java.lang.Object)
@@ -276,300 +49,69 @@ public class DojoHttpTransport extends AbstractHttpTransport implements IHttpTra
 	@Override
 	public void setInitializationData(IConfigurationElement config, String propertyName,
 			Object data) throws CoreException {
-		
+
+		// Make sure the contributing bundle is started
+		Bundle contributingBundle = Platform.getBundle(config.getNamespaceIdentifier());
+		if (contributingBundle.getState() != Bundle.ACTIVE) {
+			try {
+				contributingBundle.start();
+			} catch (BundleException e) {
+				throw new CoreException(
+						new Status(Status.ERROR, config.getNamespaceIdentifier(),
+								e.getMessage(), e)
+					);
+			}
+		}
+
+		// Get the resource (combo) path name from the this extension's
+		// path attribute
+		resourcePathId = config.getAttribute(PATH_ATTRNAME);
+		if (resourcePathId == null) {
+			throw new CoreException(
+					new Status(Status.ERROR, config.getNamespaceIdentifier(),
+						MessageFormat.format(
+							Messages.AbstractHttpTransport_1,
+							new Object[]{config.getDeclaringExtension().getUniqueIdentifier()}
+						)
+					)
+				);
+		}
 		// Save this extension's pluginUniqueId
 		pluginUniqueId = config.getDeclaringExtension().getUniqueIdentifier();
 
 		// Initialize the combo uri
-		super.setInitializationData(config, propertyName, data);
 		try {
-			comboUri = new URI(getComboUriStr()); 
+			comboUri = new URI(comboUriStr);
 		} catch (URISyntaxException e) {
 			throw new CoreException(
-					new Status(Status.ERROR, config.getNamespaceIdentifier(), 
+					new Status(Status.ERROR, config.getNamespaceIdentifier(),
 							e.getMessage(), e)
 				);
 		}
 	}
-	
+
 	/* (non-Javadoc)
-	 * @see com.ibm.jaggr.service.transport.AbstractHttpTransport#initialize(com.ibm.jaggr.service.IAggregator, com.ibm.jaggr.service.IAggregatorExtension, com.ibm.jaggr.service.IExtensionInitializer.IExtensionRegistrar)
+	 * @see com.ibm.jaggr.service.impl.transport.AbstractHttpTransport#getComboUri()
 	 */
 	@Override
-	public void initialize(IAggregator aggregator, IAggregatorExtension extension, IExtensionRegistrar reg) {
-		super.initialize(aggregator, extension, reg);
-
-		// Get first resource factory extension so we can add to beginning of list
-    	Iterable<IAggregatorExtension> resourceFactoryExtensions = aggregator.getResourceFactoryExtensions();
-    	IAggregatorExtension first = resourceFactoryExtensions.iterator().next();
-    	
-    	// Register the loaderExt resource factory
-    	Properties attributes = new Properties();
-    	attributes.put("scheme", "namedbundleresource"); //$NON-NLS-1$ //$NON-NLS-2$
-		reg.registerExtension(
-				new LoaderExtensionResourceFactory(), 
-				attributes,
-				IResourceFactoryExtensionPoint.ID,
-				getPluginUniqueId(),
-				first);
-		
+	protected URI getComboUri() {
+		return comboUri;
 	}
-	
+
 	/* (non-Javadoc)
-	 * @see com.ibm.jaggr.service.transport.AbstractHttpTransport#getDynamicLoaderExtensionJavaScript()
+	 * @see com.ibm.jaggr.service.impl.transport.AbstractHttpTransport#getTransportId()
 	 */
 	@Override
-	protected String getDynamicLoaderExtensionJavaScript() {
-		StringBuffer sb = new StringBuffer();
-		sb.append("plugins[\"") //$NON-NLS-1$
-		  .append(getResourcePathId())
-		  .append("/text") //$NON-NLS-1$
-		  .append("\"] = 1;\r\n"); //$NON-NLS-1$
-		for (String[] alias : getClientConfigAliases()) {
-			sb.append("aliases.push([\"" + alias[0] + "\", \"" + alias[1] + "\"]);\r\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		}
-		// Add server option settings that we care about
-		IOptions options = getAggregator().getOptions();
-		sb.append("combo.serverOptions={skipHasFiltering:") //$NON-NLS-1$
-		  .append(Boolean.toString(options.isDisableHasFiltering()))
-		  .append("};\r\n"); //$NON-NLS-1$
-		
-		// add in the super class's contribution
-		sb.append(super.getDynamicLoaderExtensionJavaScript());
-		
-		return sb.toString();
+	protected String getTransportId() {
+		return pluginUniqueId;
 	}
-	
+
 	/* (non-Javadoc)
-	 * @see com.ibm.jaggr.service.config.IConfigModifier#modifyConfig(com.ibm.jaggr.service.IAggregator, java.util.Map)
-	 */
-	/**
-	 * Add paths and aliases mappings to the config for the dojo text plugin.
-	 * <p>
-	 * The reason this is a bit complex is that in order to support text plugin
-	 * resources that specify an absolute path (e.g.
-	 * dojo/text!http://server.com/resource.html), we use server-side config
-	 * paths entries to map dojo/text to a proxy plugin module provided by this
-	 * transport. The proxy plugin module examines the module id of the
-	 * requested resource, and if the id is absolute, it delegates to the dojo
-	 * text plugin which can still be accessed from the client using an
-	 * alternative path which we set up below. If the module id is relative,
-	 * then the proxy plugin module delegates to the aggregator text plugin
-	 * (which is a pseudo plugin that resolves to the aggregator itself).
-	 * <p>
-	 * In addition to the paths mappings, aliases are used, both in the
-	 * server-side config and in the client config, to allow the proxy plugin
-	 * module to refer to the dojo text plugin module and the aggregator text
-	 * plugin via static names, allowing the actual names to be dynamic without
-	 * requiring us to dynamically modify the contents of the proxy plugin
-	 * resource itself.  This method sets the server-side config aliases
-	 * and sets up the client-side config aliases to be set in 
-	 * {@link #contributeLoaderExtensionJavaScript(String)}.
+	 * @see com.ibm.jaggr.service.impl.transport.AbstractHttpTransport#getResourcePathId()
 	 */
 	@Override
-	public void modifyConfig(IAggregator aggregator, Scriptable config) {
-		// let the superclass do its thing
-		super.modifyConfig(aggregator, config);
-		
-		// Get the server-side config properties we need to start with
-		Object pathsObj = config.get(IConfig.PATHS_CONFIGPARAM, config);
-		Object packagesObj = config.get(IConfig.PACKAGES_CONFIGPARAM, config);
-		Object aliasesObj = config.get(IConfig.ALIASES_CONFIGPARAM, config);
-		Object textPluginDelegatorsObj = config.get(IConfig.TEXTPLUGINDELEGATORS_CONFIGPARAM, config);
-		Object jsPluginDelegatorsObj = config.get(IConfig.JSPLUGINDELEGATORS_CONFIGPARAM, config);
-		
-		Scriptable paths = (pathsObj != null && pathsObj instanceof Scriptable) ? (Scriptable)pathsObj : null;
-		Scriptable packages = (packagesObj != null && packagesObj instanceof Scriptable) ? (Scriptable)packagesObj : null;
-		Scriptable aliases = (aliasesObj != null && aliasesObj instanceof Scriptable) ? (Scriptable)aliasesObj : null;
-		Scriptable textPluginDelegators = (textPluginDelegatorsObj != null && textPluginDelegatorsObj instanceof Scriptable) ? (Scriptable)textPluginDelegatorsObj : null;
-		Scriptable jsPluginDelegators = (jsPluginDelegatorsObj != null && jsPluginDelegatorsObj instanceof Scriptable) ? (Scriptable)jsPluginDelegatorsObj : null;
-		// Get the URI for the location of the dojo package on the server
-		IConfig.Location dojoLoc = null;
-		if (packages != null) {
-			for (Object id : packages.getIds()) {
-				if (!(id instanceof Number)) {
-					continue;
-				}
-				Number i = (Number)id;
-				Object pkgObj = packages.get((Integer)i, packages);
-				if (pkgObj instanceof Scriptable) {
-					Scriptable pkg = (Scriptable)pkgObj;
-					if (dojo.equals(pkg.get(IConfig.PKGNAME_CONFIGPARAM, pkg).toString())) {
-						try {
-							Object dojoLocObj = pkg.get(IConfig.PKGLOCATION_CONFIGPARAM, pkg);
-							if (dojoLoc == Scriptable.NOT_FOUND) {
-								dojoLoc = new IConfig.Location(new URI("."), null); //$NON-NLS-1$
-							} else if (dojoLocObj instanceof Scriptable) {
-								Scriptable values = (Scriptable)dojoLocObj;
-								String str = Context.toString(values.get(0, values));
-								if (!str.endsWith("/")) str += '/'; //$NON-NLS-1$
-								URI primary = new URI(str).normalize(), override = null;
-								Object obj = values.get(1, values);
-								if (obj != Scriptable.NOT_FOUND) {
-									str = Context.toString(obj);
-									if (!str.endsWith("/")) str += '/'; //$NON-NLS-1$
-									try {
-										override = new URI(str).normalize();
-									} catch (URISyntaxException ignore) {}
-								}
-								dojoLoc = new Location(primary, override);
-							} else {
-								String str = Context.toString(dojoLocObj);
-								if (!str.endsWith("/")) str += '/'; //$NON-NLS-1$
-								dojoLoc = new Location(new URI(str).normalize());
-							}
-						} catch (URISyntaxException e) {
-							if (log.isLoggable(Level.WARNING)) {
-								log.log(Level.WARNING, e.getMessage(), e);
-							}
-						}
-					}
-				}
-			}
-		}
-		// Bail if we can't find dojo
-		if (dojoLoc == null) {
-			if (log.isLoggable(Level.WARNING)) {
-				log.warning(Messages.DojoHttpTransport_0);
-			}
-			return;
-		}
-		
-		if (paths != null && paths.get(dojoTextPluginFullPath, paths) != Scriptable.NOT_FOUND) {
-			// if config overrides dojo/text, then bail
-			if (log.isLoggable(Level.INFO)) {
-				log.info(MessageFormat.format(Messages.DojoHttpTransport_2,
-						new Object[]{dojoTextPluginFullPath}));
-			}
-			return;
-		}
-
-		Context context = Context.enter();
-		try {
-			// Create the paths and aliases config properties if necessary
-			if (paths == null) {
-				config.put(IConfig.PATHS_CONFIGPARAM, config, context.newObject(config));
-				paths = (Scriptable)config.get(IConfig.PATHS_CONFIGPARAM, null);
-			}
-			if (aliases == null) {
-				config.put(IConfig.ALIASES_CONFIGPARAM, config, context.newArray(config, 0));
-				aliases = (Scriptable)config.get(IConfig.ALIASES_CONFIGPARAM, null);
-			}
-			if (textPluginDelegators == null) {
-				config.put(IConfig.TEXTPLUGINDELEGATORS_CONFIGPARAM, config, context.newArray(config, 0));
-				textPluginDelegators = (Scriptable)config.get(IConfig.TEXTPLUGINDELEGATORS_CONFIGPARAM, null);
-			}
-			if (jsPluginDelegators == null) {
-				config.put(IConfig.JSPLUGINDELEGATORS_CONFIGPARAM, config, context.newArray(config, 0));
-				jsPluginDelegators = (Scriptable)config.get(IConfig.JSPLUGINDELEGATORS_CONFIGPARAM, null);
-			}
-	
-			// Specify paths entry to map dojo/text to our text plugin proxy
-			if (log.isLoggable(Level.INFO)) {
-				log.info(MessageFormat.format(
-						Messages.DojoHttpTransport_3,
-						new Object[]{dojoTextPluginFullPath, textPluginProxyUriStr}
-				));
-			}
-		
-			paths.put(dojoTextPluginFullPath, paths, textPluginProxyUriStr);
-			
-			// Specify paths entry to map the dojo text plugin alias name to the original
-			// dojo text plugin
-			Scriptable dojoTextPluginPath = context.newArray(config, 2);
-			URI primary = dojoLoc.getPrimary(), override = dojoLoc.getOverride(); 
-			primary = primary.resolve(dojoPluginUri);
-			if (override != null) {
-				override = override.resolve(dojoPluginUri);
-			}
-			dojoTextPluginPath.put(0, dojoTextPluginPath, primary.toString());
-			if (override != null) {
-				dojoTextPluginPath.put(1, dojoTextPluginPath, override.toString());
-			}
-			if (log.isLoggable(Level.INFO)) {
-				log.info(MessageFormat.format(
-						Messages.DojoHttpTransport_3,
-						new Object[]{dojoTextPluginAliasFullPath, Context.toString(dojoTextPluginPath)}
-				));
-			}
-			paths.put(dojoTextPluginAliasFullPath, paths, dojoTextPluginPath);
-			
-			// Specify an alias mapping for the static alias used
-			// by the proxy module to the name which includes the path dojo/ so that
-			// relative module ids in dojo/text will resolve correctly.
-			// 
-			// We need this in the server-side config so that the server can follow
-			// module dependencies from the plugin proxy
-			if (log.isLoggable(Level.INFO)) {
-				log.info(MessageFormat.format(
-						Messages.DojoHttpTransport_4,
-						new Object[]{dojoTextPluginAlias, dojoTextPluginAliasFullPath}
-				));
-			}
-			Scriptable alias = context.newArray(config, 3);
-			alias.put(0, alias, dojoTextPluginAlias);
-			alias.put(1, alias, dojoTextPluginAliasFullPath);
-			// Not easy to determine the size of an array using Scriptable
-			int max = -1;
-			for (Object id : aliases.getIds()) {
-				if (id instanceof Number) max = Math.max(max, (Integer)((Number)id));
-			}
-			aliases.put(max+1, aliases, alias);
-			
-			max = -1;
-			for (Object id : textPluginDelegators.getIds()) {
-				if (id instanceof Number) max = Math.max(max, (Integer)((Number)id));
-			}
-			textPluginDelegators.put(max+1, textPluginDelegators, "dojo/text"); //$NON-NLS-1$
-			jsPluginDelegators.put(max+1, jsPluginDelegators, "dojo/i18n"); //$NON-NLS-1$
-		} finally {
-			Context.exit();
-		}
-		
-		// Add alias definitions to be specified in client-side config
-		getClientConfigAliases().add(new String[]{dojoTextPluginAlias, dojoTextPluginAliasFullPath});
-		// Add alias mapping for aggregator text plugin alias used in the text plugin proxy
-		// to the actual aggregator text plugin name as determined from the module builder
-		// definitions
-		getClientConfigAliases().add(new String[]{aggregatorTextPluginAlias, getAggregatorTextPluginName()});
+	protected String getResourcePathId() {
+		return resourcePathId;
 	}
-	
-	/**
-	 * Resource factory that creates a
-	 * {@link AbstractHttpTransport.LoaderExtensionResource} for the dojo http
-	 * transport when the loader extension resource URI is requested
-	 */
-	private class LoaderExtensionResourceFactory implements IResourceFactory {
 
-		/* (non-Javadoc)
-		 * @see com.ibm.jaggr.service.resource.IResourceFactory#handles(java.net.URI)
-		 */
-		@Override
-		public boolean handles(URI uri) {
-			String path = uri.getPath();
-			if (path.equals(getLoaderExtensionPath())) {
-				if (uri.getScheme().equals(getComboUri().getScheme()) 
-						&& uri.getHost().equals(getComboUri().getHost())) {
-					return true;
-				}
-			}
-			return false;
-		}
-
-		/* (non-Javadoc)
-		 * @see com.ibm.jaggr.service.resource.IResourceFactory#newResource(java.net.URI)
-		 */
-		@Override
-		public IResource newResource(URI uri) {
-			String path = uri.getPath();
-			if (!path.equals(getLoaderExtensionPath())) {
-				throw new UnsupportedOperationException(uri.toString());
-			}
-			List<IResource> aggregate = new ArrayList<IResource>(2);
-			for (String res : getLoaderExtensionResources()) {
-				aggregate.add(getAggregator().newResource(uri.resolve(res)));
-			}
-			return new LoaderExtensionResource(new AggregationResource(uri, aggregate));
-		}
-	}
 }

--- a/jaggr-service/src/test/java/com/ibm/jaggr/service/EverythingSuite.java
+++ b/jaggr-service/src/test/java/com/ibm/jaggr/service/EverythingSuite.java
@@ -43,7 +43,7 @@ import com.ibm.jaggr.service.impl.modulebuilder.text.TxtModuleContentProviderTes
 import com.ibm.jaggr.service.impl.resource.BundleResourceFactoryTests;
 import com.ibm.jaggr.service.impl.resource.FileResourceTests;
 import com.ibm.jaggr.service.impl.transport.AbstractHttpTransportTest;
-import com.ibm.jaggr.service.impl.transport.DojoHttpTransportTest;
+import com.ibm.jaggr.service.impl.transport.AbstractDojoHttpTransportTest;
 import com.ibm.jaggr.service.util.BooleanTermTest;
 import com.ibm.jaggr.service.util.DependencyListTest;
 import com.ibm.jaggr.service.util.DependencyListTest_processDep;
@@ -70,7 +70,7 @@ import com.ibm.jaggr.service.util.DependencyListTest_processDep;
 	TxtModuleContentProviderTest.class,
 	RequireExpansionCompilerPassTest.class,
 	AbstractHttpTransportTest.class,
-	DojoHttpTransportTest.class,
+	AbstractDojoHttpTransportTest.class,
 	AggregatorImplTest.class,
 	BundleResourceFactoryTests.class,
 	FileResourceTests.class,

--- a/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/transport/AbstractHttpTransportTest.java
+++ b/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/transport/AbstractHttpTransportTest.java
@@ -70,7 +70,7 @@ public class AbstractHttpTransportTest {
 
 	/**
 	 * Test method for {@link com.ibm.jaggr.service.impl.layer.LayerImpl#getHasReaturesFromRequest(javax.servlet.http.HttpServletRequest)}.
-	 * @throws ServletException 
+	 * @throws ServletException
 	 */
 	@Test
 	public void testGetFeaturesFromRequest() throws Exception {
@@ -81,7 +81,7 @@ public class AbstractHttpTransportTest {
 		HttpServletRequest request = TestUtils.createMockRequest(null, requestAttributes, requestParameters, cookies, null);
 		EasyMock.replay(request);
 		assertNull(transport.getHasConditionsFromRequest(request));
-		
+
 		String hasConditions = "foo;!bar";
 		requestParameters.put("has", new String[]{hasConditions});
 		Features features = transport.getFeaturesFromRequest(request);
@@ -89,7 +89,7 @@ public class AbstractHttpTransportTest {
 		Assert.assertTrue(features.featureNames().contains("foo") && features.featureNames().contains("bar"));
 		Assert.assertTrue(features.isFeature("foo"));
 		Assert.assertFalse(features.isFeature("bar"));
-		
+
 		// Now try specifying the has conditions in the cookie
 		requestParameters.clear();
 		requestParameters.put("hashash", new String[]{"xxxx"}); // value not checked by server
@@ -99,7 +99,7 @@ public class AbstractHttpTransportTest {
 		Assert.assertTrue(features.featureNames().contains("foo") && features.featureNames().contains("bar"));
 		Assert.assertTrue(features.isFeature("foo"));
 		Assert.assertFalse(features.isFeature("bar"));
-		
+
 		// Make sure we handle null cookie values without throwing
 		requestParameters.put("hashash", new String[]{"xxxx"}); // value not checked by server
 		cookies[0] = new Cookie("has", null);
@@ -111,7 +111,7 @@ public class AbstractHttpTransportTest {
 		features = transport.getFeaturesFromRequest(request);
 		assertEquals(0, features.featureNames().size());
 	}
-	
+
 	@Test
 	public void testUnfoldModules() throws Exception {
 		AbstractHttpTransport transport = new TestHttpTransport();
@@ -119,33 +119,33 @@ public class AbstractHttpTransportTest {
 		JSONObject obj = new JSONObject("{foo:{bar:'0', baz:{xxx:'2', yyy:'1'}}, dir:'3'}");
 		String[] paths = transport.unfoldModules(obj, 4);
 		Assert.assertArrayEquals(new String[] {"foo/bar", "foo/baz/yyy", "foo/baz/xxx", "dir" }, paths);
-		
+
 		// folded paths with plugin prefixes
 		obj = new JSONObject("{'"+AbstractHttpTransport.PLUGIN_PREFIXES_PROP_NAME+"':{'combo/text':'0', abc:'1'},foo:{bar:'0', baz:{xxx.txt:'1-0', yyy.txt:'2-1'}}}");
 		paths = transport.unfoldModules(obj, 3);
 		Assert.assertArrayEquals(new String[] {"foo/bar",  "combo/text!foo/baz/xxx.txt", "abc!foo/baz/yyy.txt"}, paths);
-		
+
 		// make sure legacy format for specifying plugin prefixes works
 		obj = new JSONObject("{foo:{bar:'0', baz:{xxx.txt:'1-combo/text', yyy.txt:'2-abc'}}}");
 		paths = transport.unfoldModules(obj, 3);
-		Assert.assertArrayEquals(new String[] {"foo/bar",  "combo/text!foo/baz/xxx.txt", "abc!foo/baz/yyy.txt"}, paths);	
+		Assert.assertArrayEquals(new String[] {"foo/bar",  "combo/text!foo/baz/xxx.txt", "abc!foo/baz/yyy.txt"}, paths);
 	}
-	
+
 	@Test
 	public void testDecodeMopdules() throws Exception {
 		AbstractHttpTransport transport = new TestHttpTransport();
 		JSONObject decoded = transport.decodeModules("(foo!(bar!0*baz!(<|xxx>!2*yyy!1))*dir!3)");
 		Assert.assertEquals(new JSONObject("{foo:{bar:'0',baz:{'(!xxx)':'2',yyy:'1'}},dir:'3'}"), decoded);
-	
+
 		decoded = transport.decodeModules("("+AbstractHttpTransport.PLUGIN_PREFIXES_PROP_NAME+"!(combo/text!0*abc!1)*foo!(bar!0*baz!(xxx.txt!1-0*yyy.txt!2-1)))");
 		Assert.assertEquals(new JSONObject("{'"+AbstractHttpTransport.PLUGIN_PREFIXES_PROP_NAME+"':{'combo/text':'0', abc:'1'},foo:{bar:'0', baz:{xxx.txt:'1-0', yyy.txt:'2-1'}}}"), decoded);
-	
+
 	}
-	
+
 	@Test
 	public void testGetHasConditionsEncodedFromRequest() throws Exception{
 		CountDownLatch latch = new CountDownLatch(0);
-		AbstractHttpTransport transport = new TestHttpTransport(latch, featureList, 0L); 
+		AbstractHttpTransport transport = new TestHttpTransport(latch, featureList, 0L);
 		Map<String, String[]> requestParams = new HashMap<String, String[]>();
 		HttpServletRequest mockRequest = TestUtils.createMockRequest(null, new HashMap<String, Object>(), requestParams, new Cookie[0], new HashMap<String, String>());
 		EasyMock.replay(mockRequest);
@@ -161,12 +161,12 @@ public class AbstractHttpTransportTest {
 		Features result = transport.getFeaturesFromRequestEncoded(mockRequest);
 		System.out.println(result);
 		Assert.assertEquals(features, result);
-		
+
 		features = new Features();
 		requestParams.put(AbstractHttpTransport.ENCODED_FEATURE_MAP_REQPARAM, new String[]{encode(features)});
 		result = transport.getFeaturesFromRequestEncoded(mockRequest);
 		Assert.assertEquals(features, result);
-		
+
 		features = new Features();
 		for (String name : featureList) {features.put(name, true); }
 		requestParams.put(AbstractHttpTransport.ENCODED_FEATURE_MAP_REQPARAM, new String[]{encode(features)});
@@ -174,7 +174,7 @@ public class AbstractHttpTransportTest {
 		System.out.println(result);
 		Assert.assertEquals(features, result);
 	}
-	
+
 	@Test
 	public void testFeatureListResourceFactory_newResource() throws IOException {
 		URI uri = URI.create("namedbundleresource://com.ibm.jaggr-service/combo/featureList.js");
@@ -183,12 +183,12 @@ public class AbstractHttpTransportTest {
 			expected.append(i == 0 ? "" : ",").append("\"").append(featureList.get(i)).append("\"");
 		}
 		expected.append("]" + AbstractHttpTransport.FEATURE_LIST_PROLOGUE);
-		
+
 		final IAggregator mockAggregator = EasyMock.createMock(IAggregator.class);
 		IDependencies mockDependencies = EasyMock.createMock(IDependencies.class);
 		EasyMock.expect(mockDependencies.getLastModified()).andReturn(10L).anyTimes();
 		EasyMock.expect(mockAggregator.getDependencies()).andReturn(mockDependencies).anyTimes();
-		
+
 		EasyMock.replay(mockAggregator, mockDependencies);
 		AbstractHttpTransport transport = new TestHttpTransport(new CountDownLatch(0), featureList, 10L) {
 			@Override
@@ -200,7 +200,7 @@ public class AbstractHttpTransportTest {
 		StringWriter writer = new StringWriter();
 		CopyUtil.copy(resourceOut.getReader(), writer);
 		Assert.assertEquals(expected.toString(), writer.toString());
-		
+
 		resourceOut = factory.newResource(URI.create("namedbundleresource://com.ibm.jaggr-service/combo/foo.js"));
 		writer = new StringWriter();
 		try {
@@ -209,8 +209,8 @@ public class AbstractHttpTransportTest {
 		} catch (IOException e) {
 		}
 	}
-	
-	
+
+
 	class TestHttpTransport extends AbstractHttpTransport {
 		TestHttpTransport() {}
 		TestHttpTransport(CountDownLatch latch, List<String> dependentFeatures, long lastMod) {super(latch, dependentFeatures, lastMod);}
@@ -218,9 +218,10 @@ public class AbstractHttpTransportTest {
 		@Override public String getLayerContribution(HttpServletRequest request, LayerContributionType type, Object arg) { return null; }
 		@Override public boolean isServerExpandable(HttpServletRequest request, String mid) { return false; }
 		@Override public List<ICacheKeyGenerator> getCacheKeyGenerators() { return null; }
-		@Override protected String getPluginUniqueId() { return null; }
+		@Override protected String getTransportId() { return null; }
+		@Override protected String getResourcePathId() { return "combo"; }
 	};
-	
+
 	static List<String> featureList = Arrays.asList(new String[]{
 		 "0",  "1",  "2",  "3",  "4",  "5",  "6",  "7",  "8",  "9",
 		"10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
@@ -233,11 +234,11 @@ public class AbstractHttpTransportTest {
 		"80", "81", "82", "83", "84", "85", "86", "87", "88", "89",
 		"90", "91", "92", "93", "94", "95", "96", "97", "98", "99"
 	});
-	
+
 	/**
 	 * Method to encode a feature string the same way that the JavaScript code
 	 * in featureMap.js does it.
-	 * 
+	 *
 	 * @param featureString
 	 *            the '*' delimited list of features. Null features are
 	 *            preceeded by the '!' character.

--- a/jaggr-service/src/test/java/com/ibm/jaggr/service/test/TestUtils.java
+++ b/jaggr-service/src/test/java/com/ibm/jaggr/service/test/TestUtils.java
@@ -58,7 +58,7 @@ import com.ibm.jaggr.service.impl.modulebuilder.javascript.JavaScriptModuleBuild
 import com.ibm.jaggr.service.impl.modulebuilder.text.TextModuleBuilder;
 import com.ibm.jaggr.service.impl.options.OptionsImpl;
 import com.ibm.jaggr.service.impl.resource.FileResource;
-import com.ibm.jaggr.service.impl.transport.DojoHttpTransport;
+import com.ibm.jaggr.service.impl.transport.AbstractDojoHttpTransport;
 
 public class TestUtils {
 	public static String a = "define([\"./b\"], function(b) {\nalert(\"hello from a.js\");\nreturn null;\n});";
@@ -147,7 +147,7 @@ public class TestUtils {
 		createTestFile(p2p1p1, "foo", foo);
 		createTestFile(p1, "hello.txt", hello);
 	}
-	
+
 	static public long getDirListSize(File directory, FileFilter filter) {
 		File[] files = directory.listFiles(filter);
 		long result = 0;
@@ -183,24 +183,24 @@ public class TestUtils {
 	public static IAggregator createMockAggregator() throws Exception {
 		return createMockAggregator(null, null, null, null, null);
 	}
-	
+
 	public static IAggregator createMockAggregator(
 			Ref<IConfig> configRef,
 			File workingDirectory) throws Exception {
-		
+
 		return createMockAggregator(configRef, workingDirectory, null, null, null);
 	}
 
 	public static IAggregator createMockAggregator(
 			Ref<IConfig> configRef,
 			File workingDirectory, List<InitParam> initParams) throws Exception {
-		
+
 		return createMockAggregator(configRef, workingDirectory, initParams, null, null);
 	}
 
 	public static IAggregator createMockAggregator(
 			IHttpTransport transport) throws Exception {
-		
+
 		return createMockAggregator(null, null, null, null, transport);
 	}
 	public static IAggregator createMockAggregator(
@@ -222,14 +222,14 @@ public class TestUtils {
 			workingDirectory = new File(System.getProperty("java.io.tmpdir"));
 		}
 		final Ref<ICacheManager> cacheMgrRef = new Ref<ICacheManager>(null);
-		final Ref<IHttpTransport> transportRef = new Ref<IHttpTransport>(transport == null ? new DojoHttpTransport() : transport);
+		final Ref<IHttpTransport> transportRef = new Ref<IHttpTransport>(transport == null ? new TestDojoHttpTransport() : transport);
 		final Ref<IExecutors> executorsRef = new Ref<IExecutors>(new ExecutorsImpl(null,
-				new SynchronousExecutor(), 
-				null, 
-				new SynchronousScheduledExecutor(), 
+				new SynchronousExecutor(),
+				null,
+				new SynchronousScheduledExecutor(),
 				new SynchronousScheduledExecutor()));
 		final File workdir = workingDirectory;
-		
+
 		EasyMock.expect(mockAggregator.getWorkingDirectory()).andReturn(workingDirectory).anyTimes();
 		EasyMock.expect(mockAggregator.getName()).andReturn("test").anyTimes();
 		EasyMock.expect(mockAggregator.getOptions()).andReturn(options).anyTimes();
@@ -353,19 +353,19 @@ public class TestUtils {
 		}).anyTimes();
 		return mockAggregator;
 	}
-	
+
 	public static HttpServletRequest createMockRequest(IAggregator aggregator) {
 		return createMockRequest(aggregator, new HashMap<String, Object>());
 	}
-	
+
 	public static HttpServletRequest createMockRequest(IAggregator aggregator, Map<String, Object> requestAttributes) {
 		requestAttributes.put(IAggregator.AGGREGATOR_REQATTRNAME, aggregator);
 		return createMockRequest(aggregator, requestAttributes, null, null, null);
 	}
-	
+
 	public static HttpServletRequest createMockRequest(
 			IAggregator aggregator,
-			final Map<String, Object> requestAttributes, 
+			final Map<String, Object> requestAttributes,
 			final Map<String, String[]> requestParameters,
 			final Cookie[] cookies,
 			final Map<String, String> headers) {
@@ -421,7 +421,7 @@ public class TestUtils {
 		}
 		return mockRequest;
 	}
-	
+
 	public static HttpServletResponse createMockResponse(final Map<String, String> responseAttributes) {
 		HttpServletResponse mockResponse = EasyMock.createNiceMock(HttpServletResponse.class);
 		mockResponse.setContentLength(EasyMock.anyInt());
@@ -434,5 +434,23 @@ public class TestUtils {
 			}
 		}).anyTimes();
 		return mockResponse;
+	}
+
+	public static class TestDojoHttpTransport extends AbstractDojoHttpTransport {
+		public TestDojoHttpTransport() {
+			super();
+		}
+		@Override
+		protected URI getComboUri() {
+			return URI.create("namedbundleresource://com.ibm.jaggr.sample.dojo/WebContent");
+		}
+		@Override
+		protected String getTransportId() {
+			return "testTransportId";
+		}
+		@Override
+		protected String getResourcePathId() {
+			return "combo";
+		}
 	}
 }


### PR DESCRIPTION
Don't merge this pull request.  The rename of DojoHttpTransport.java to AbstractDojoHttpTransport.java did not work as expected and the file history was lost.  
