### PR TITLE
Remove eclipse/osgi dependencies from jaggr-core pom.xml

### DIFF
--- a/jaggr-core/pom.xml
+++ b/jaggr-core/pom.xml
@@ -93,11 +93,9 @@
               ${project.groupId}.core;version="${project.version}",
               ${project.groupId}.core.*;version="${project.version}"
             </Export-Package>          
-            <Require-Bundle>org.eclipse.core.runtime</Require-Bundle>
             <Import-Package>
               javax.servlet;version="[2,4)",
               javax.servlet.http;version="[2,4)",
-              org.apache.felix.service.command;resolution:=optional,
               !*
             </Import-Package>
             <Embed-Dependency>
@@ -219,11 +217,6 @@
       <artifactId>concurrentlinkedhashmap-lru</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.felix</groupId>
-      <artifactId>org.apache.felix.gogo.command</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
@@ -231,6 +224,11 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This contains changes being ported from #96
