### PR TITLE
Remove unused depencdencies from jaggr-service pom.xml

### DIFF
--- a/jaggr-service/pom.xml
+++ b/jaggr-service/pom.xml
@@ -164,7 +164,7 @@
               !*
             </Import-Package>
             <!-- embed dependencies -->
-            <Embed-Dependency>wink-json4j,commons-io,commons-lang</Embed-Dependency>
+            <Embed-Dependency></Embed-Dependency>
             <Embed-Directory>lib</Embed-Directory>
             <Embed-StripGroup>true</Embed-StripGroup>
           </instructions>
@@ -228,38 +228,6 @@
     <dependency>
       <groupId>com.ibm.jaggr</groupId>
       <artifactId>jaggr-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.wink</groupId>
-      <artifactId>wink-json4j</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>rhino</groupId>
-      <artifactId>js</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
-      <artifactId>concurrentlinkedhashmap-lru</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
This contains changes being ported from #96
