### PR TITLE
Fix alias order of evaluation to match dojo loader.

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/config/ConfigImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/config/ConfigImpl.java
@@ -291,7 +291,7 @@ public class ConfigImpl implements IConfig, IShutdownListener, IOptionsListener 
 	 */
 	@Override
 	public Map<String, IPackage> getPackages() {
-		return Collections.unmodifiableMap(packages);
+		return packages;
 	}
 
 	/* (non-Javadoc)
@@ -299,7 +299,7 @@ public class ConfigImpl implements IConfig, IShutdownListener, IOptionsListener 
 	 */
 	@Override
 	public Map<String, Location> getPaths() {
-		return Collections.unmodifiableMap(paths);
+		return paths;
 	}
 
 	/* (non-Javadoc)
@@ -307,7 +307,7 @@ public class ConfigImpl implements IConfig, IShutdownListener, IOptionsListener 
 	 */
 	@Override
 	public List<IAlias> getAliases() {
-		return Collections.unmodifiableList(aliases);
+		return aliases;
 	}
 
 	/* (non-Javadoc)
@@ -688,7 +688,11 @@ public class ConfigImpl implements IConfig, IShutdownListener, IOptionsListener 
 				m.appendTail(sbResult);
 				return sbResult.toString();
 			}
-			for (IAlias alias : getAliases()) {
+			List<IAlias> aliases = getAliases();
+			// Iterate through the list of aliases in reverse order so that last matching alias wins
+			// so as to emulate the behavior of dojo's loader.
+			for (int j = aliases.size()-1; j >= 0; j--) {
+				IAlias alias = aliases.get(j);
 				String nameToMatch = (result != null) ? result : name;
 				Object pattern = alias.getPattern();
 				if (pattern instanceof String) {

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/config/ConfigTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/config/ConfigTest.java
@@ -314,6 +314,14 @@ public class ConfigTest {
 		result = cfg.resolveAliases("p1/foo/p2", features, dependentFeatures, null);
 		Assert.assertEquals("p1/foo/p2", result);
 
+		// If more than one alias matches, then the last alias should win (to match the behavior of dojo's loader)
+		config = "{aliases:[[/^(.*)\\/foo\\/(.*)$/, '$2/bar/$1'],[/^(.*)\\/foo\\/baz\\/(.*)$/, '$2/yeah/$1']]}";
+		cfg = new ConfigImpl(mockAggregator, tmpDir, config);
+		result = cfg.resolveAliases("p1/foo/baz/p2", features, dependentFeatures, null);
+		Assert.assertEquals("p2/yeah/p1", result);
+		Assert.assertEquals(0, dependentFeatures.size());
+
+
 	}
 
 	@Test


### PR DESCRIPTION
This pull request fixes issue #167
