### PR TITLE
Fix last-modified checking bug with NIO resources

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/resource/NIOFileResource.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/resource/NIOFileResource.java
@@ -86,7 +86,7 @@ public class NIOFileResource extends FileResource {
 		return new IResourceVisitor.Resource() {
 			@Override
 			public long lastModified() {
-				return attrs.lastModifiedTime().to(TimeUnit.MICROSECONDS);
+				return attrs.lastModifiedTime().to(TimeUnit.MILLISECONDS);
 			}
 			@Override
 			public boolean isFolder() {


### PR DESCRIPTION
NIOFileResource.getLastModified() needs to return the last modified time in milliseconds instead of microseconds.
