### PR TITLE
Remove Context from IConfigScopeModifier interface because it isn't needed...

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/config/IConfigScopeModifier.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/config/IConfigScopeModifier.java
@@ -23,7 +23,7 @@ import com.ibm.jaggr.core.IAggregator;
  * which may be referenced by the config JavaScript.
  * <p>
  * Instances of this interface are registered as an OSGi service with the name property set to the
- * name of the aggregator. The {@link #modifyScope(IAggregator, Object, Object)} method is called
+ * name of the aggregator. The {@link #modifyScope(IAggregator, Object)} method is called
  * just before the config JavaScript is evaluated.
  */
 public interface IConfigScopeModifier {
@@ -33,12 +33,10 @@ public interface IConfigScopeModifier {
 	 *
 	 * @param aggregator
 	 *            The aggregator object
-	 * @param context
-	 *            The implementation specific context
 	 * @param scope
 	 *            the implementation specific scope object.  Add functions and/or properties to the scope
 	 *            to make them available to the config JavaScript.
 	 */
-	public void modifyScope(IAggregator aggregator, Object context, Object scope);
+	public void modifyScope(IAggregator aggregator, Object scope);
 
 }

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/config/ConfigImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/config/ConfigImpl.java
@@ -959,7 +959,7 @@ public class ConfigImpl implements IConfig, IShutdownListener, IOptionsListener 
 			ScriptableObject.putProperty(sharedScope, "console", jsConsole); //$NON-NLS-1$
 
 			// Call the registered scope modifiers
-			callConfigScopeModifiers(cx, sharedScope);
+			callConfigScopeModifiers(sharedScope);
 
 			cx.evaluateString(sharedScope, "var config = " +  //$NON-NLS-1$
 					aggregator.substituteProps(configScript, new IAggregator.SubstitutionTransformer() {
@@ -1333,12 +1333,10 @@ public class ConfigImpl implements IConfig, IShutdownListener, IOptionsListener 
 	 * Calls the registered config scope modifiers to give them an opportunity to
 	 * prepare the scope object prior to evaluating the config JavaScript
 	 *
-	 * @param context
-	 *            The JavaScript context object
 	 * @param scope
 	 *            The object representing the execution scope for the evaluation.
 	 */
-	protected void callConfigScopeModifiers(Context context, Scriptable scope) {
+	protected void callConfigScopeModifiers(Scriptable scope) {
 		if( aggregator.getPlatformServices() != null){
 			IServiceReference[] refs = null;
 			try {
@@ -1355,7 +1353,7 @@ public class ConfigImpl implements IConfig, IShutdownListener, IOptionsListener 
 							(IConfigScopeModifier) aggregator.getPlatformServices().getService(ref);
 					if (adaptor != null) {
 						try {
-							adaptor.modifyScope(getAggregator(), context, scope);
+							adaptor.modifyScope(getAggregator(), scope);
 						} catch (Exception e) {
 							if (log.isLoggable(Level.SEVERE)) {
 								log.log(Level.SEVERE, e.getMessage(), e);

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/config/BundleVersionsHash.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/config/BundleVersionsHash.java
@@ -78,11 +78,11 @@ public class BundleVersionsHash implements IExtensionInitializer, IConfigScopeMo
 	 * @see com.ibm.jaggr.core.config.IConfigScopeModifier#modifyScope(com.ibm.jaggr.core.IAggregator, org.mozilla.javascript.Context, org.mozilla.javascript.Scriptable)
 	 */
 	@Override
-	public void modifyScope(IAggregator aggregator, Object context, Object scope) {
+	public void modifyScope(IAggregator aggregator, Object scope) {
 		final String sourceMethod = "prepareEnv"; //$NON-NLS-1$
 		boolean isTraceLogging = log.isLoggable(Level.FINER);
 		if (isTraceLogging) {
-			log.entering(BundleVersionsHash.class.getName(), sourceMethod, new Object[]{aggregator, context, scope});
+			log.entering(BundleVersionsHash.class.getName(), sourceMethod, new Object[]{aggregator, scope});
 		}
 		FunctionObject fn = new FunctionObject((Scriptable)scope);
 		ScriptableObject.putProperty((Scriptable)scope, propName, fn);


### PR DESCRIPTION
and the context can always be obtained using the Context.enter()
static method (Rhino).
