### PR TITLE
Updates to allow aggregator to host non-aggregated app resources.

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/IAggregatorExtension.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/IAggregatorExtension.java
@@ -58,10 +58,10 @@ public interface IAggregatorExtension {
 	public Object getInstance();
 
 	/**
-	 * Returns the value of the specified attribute or init-param. These are the same as the
-	 * attribute and init-param values specified in the xml defining the extension, or in the
+	 * Returns the value of the specified attribute. These are the same as the
+	 * attributes specified in the xml defining the extension, or in the
 	 * case of extensions registered through
-	 * {@link IExtensionRegistrar#registerExtension(Object, Properties, String, String, IAggregatorExtension)},
+	 * {@link IExtensionRegistrar#registerExtension(Object, Properties, InitParams, String, String, IAggregatorExtension)},
 	 * they are the attributes provided in the properties object.
 	 *
 	 * @param name
@@ -72,9 +72,21 @@ public interface IAggregatorExtension {
 
 	/**
 	 * Returns the set of attribute names for which {@link #getAttribute(String)} will return
-	 * a value.
+	 * a value.  The extension attributes which are allowed are defined by the extension point.
+	 * For OSGi, they are specified in the extension point schema.  All extensions must
+	 * specify the (non-optional) attributes defined by the extension point and may not specify
+	 * any attributes which are not defined by the extension point.
 	 *
 	 * @return The attribute names
 	 */
 	public Set<String> getAttributeNames();
+
+	/**
+	 * Returns the init params for the extension.  Unlike attributes, init-params are <strong>not</strong>
+	 * defined by the extension point, but rather by the implementing extension.  Init-params
+	 * may be multi-valued.
+	 *
+	 * @return the init params
+	 */
+	public InitParams getInitParams();
 }

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/IExtensionInitializer.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/IExtensionInitializer.java
@@ -62,7 +62,9 @@ public interface IExtensionInitializer {
 		 *            an object which implements {@link IResourceFactory} or
 		 *            {@link IModuleBuilder}.
 		 * @param attributes
-		 *            the extension attributes and init-params
+		 *            the extension attributes
+		 * @param initParams
+		 *            the extension init-params
 		 * @param extensionPointId
 		 *            the extension point identifier
 		 * @param uniqueId
@@ -76,7 +78,7 @@ public interface IExtensionInitializer {
 		 *             If there are missing required attributes for the
 		 *             extension being registered.
 		 */
-		public void registerExtension(Object impl, Properties attributes,
+		public void registerExtension(Object impl, Properties attributes, InitParams initParams,
 				String extensionPointId, String uniqueId, IAggregatorExtension before)
 						throws IllegalStateException;
 	}

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/InitParams.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/InitParams.java
@@ -19,11 +19,14 @@ package com.ibm.jaggr.core;
 import com.ibm.jaggr.core.InitParams.InitParam;
 import com.ibm.jaggr.core.options.IOptions;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Wrapper class for aggregator init-params.
@@ -84,6 +87,24 @@ public class InitParams implements Iterable<InitParam>{
 	public static final String MAXLAYERCACHECAPACITY_MB_INITPARAM = "maxlayercachecapacity_mb"; //$NON-NLS-1$
 
 	/**
+	 * Name of the servlet init-param that specifies aggregator aliases within the servlet
+	 */
+	public static final String ALIAS_INITPARAM = "alias"; //$NON-NLS-1$
+
+	/**
+	 * Name of the servlet init-param that specifies resource ids.  Resource ids are used to
+	 * specify resource alias and base-name values using init-param names of the form
+	 * <resource id>:alias and <resource id>:base-name.  For example, the following init-params
+	 * would specify a resource with alias foo and base-name foopath:
+	 * <pre>
+	 * &lt;init-param name="resource-id" value="foores"/&gt;
+	 * &lt;init-param name="foores:alias" value="foo"/&gt;
+	 * &lt;init-param name="foores:base-name" value="foopath"/&gt;
+	 * </pre>
+	 */
+	public static final String RESOURCEID_INITPARAM = "resource-id";  //$NON-NLS-1$
+
+	/**
 	 * The init-params
 	 */
 	private List<InitParam> initParams;
@@ -138,6 +159,25 @@ public class InitParams implements Iterable<InitParam>{
 	}
 
 	/**
+	 * Returns the value of the first instance of the named init-param, or
+	 * null if the init-param is not found.
+	 *
+	 * @param name
+	 *            the init-param name
+	 * @return the value of the first init-param with the specified name or null
+	 */
+	public String getValue(String name) {
+		String result = null;
+		for (InitParam initParam : initParams) {
+			if (initParam.getName().equals(name)) {
+				result = initParam.getValue();
+				break;
+			}
+		}
+		return result;
+	}
+
+	/**
 	 * Returns a collection of the init-param names, or an empty collection
 	 * if there are no init-params
 	 *
@@ -157,5 +197,20 @@ public class InitParams implements Iterable<InitParam>{
 	@Override
 	public Iterator<InitParam> iterator() {
 		return initParams.iterator();
+	}
+
+	@Override
+	public String toString() {
+		Map<String, List<String>> map = new HashMap<String, List<String>>();
+		for (InitParam initParam : initParams) {
+			if (map.containsKey(initParam.name)) {
+				map.get(initParam.name).add(initParam.value);
+			} else {
+				List<String> value = new ArrayList<String>();
+				value.add(initParam.value);
+				map.put(initParam.name, value);
+			}
+		}
+		return map.toString();
 	}
 }

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/AbstractAggregatorImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/AbstractAggregatorImpl.java
@@ -30,7 +30,6 @@ import com.ibm.jaggr.core.IServiceRegistration;
 import com.ibm.jaggr.core.IShutdownListener;
 import com.ibm.jaggr.core.IVariableResolver;
 import com.ibm.jaggr.core.InitParams;
-import com.ibm.jaggr.core.InitParams.InitParam;
 import com.ibm.jaggr.core.NotFoundException;
 import com.ibm.jaggr.core.PlatformServicesException;
 import com.ibm.jaggr.core.ProcessingDependenciesException;
@@ -63,6 +62,7 @@ import com.ibm.jaggr.core.util.SequenceNumberProvider;
 import com.ibm.jaggr.core.util.StringUtil;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -71,19 +71,21 @@ import java.io.InputStream;
 import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.OutputStream;
 import java.io.StringReader;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Dictionary;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -148,6 +150,8 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IOpt
 	private LinkedList<IAggregatorExtension> serviceProviderExtensions = new LinkedList<IAggregatorExtension>();
 	private IAggregatorExtension httpTransportExtension = null;
 	protected IPlatformServices platformServices;
+
+	protected Map<String, IResource> resourcePaths;
 
 	enum RequestNotifierAction {
 		start,
@@ -233,9 +237,96 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IOpt
 	 */
 	@Override
 	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException {
-		if (log.isLoggable(Level.FINEST))
-			log.finest("doGet: URL=" + req.getRequestURI()); //$NON-NLS-1$
+		final String sourceMethod = "doGet"; //$NON-NLS-1$
+		boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(AbstractAggregatorImpl.class.getName(), sourceMethod, new Object[]{req, resp});
+			log.finer("Request URL=" + req.getRequestURI()); //$NON-NLS-1$
+			}
 
+		resp.addHeader("Server", "JavaScript Aggregator"); //$NON-NLS-1$ //$NON-NLS-2$
+		String pathInfo = req.getPathInfo();
+		if (pathInfo == null) {
+			processAggregatorRequest(req, resp);
+		} else {
+			boolean processed = false;
+			// search resource paths to see if we should treat as aggregator request or resource request
+			for (Map.Entry<String, IResource> entry : resourcePaths.entrySet()) {
+				String path = entry.getKey();
+				if (path.equals(pathInfo) && entry.getValue() == null) {
+					processAggregatorRequest(req, resp);
+					processed = true;
+					break;
+				}
+				if (pathInfo.startsWith(path)) {
+					if ((path.length() == pathInfo.length() || pathInfo.charAt(path.length()) == '/') && entry.getValue() != null) {
+						String resPath = path.length() == pathInfo.length() ? "" : pathInfo.substring(path.length()+1); //$NON-NLS-1$
+						IResource res = entry.getValue();
+						processResourceRequest(req, resp, res, resPath);
+						processed = true;
+						break;
+					}
+				}
+			}
+			if (!processed) {
+				resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
+			}
+		}
+		if (isTraceLogging) {
+			log.exiting(AbstractAggregatorImpl.class.getName(), sourceMethod);
+		}
+	}
+
+	protected void processResourceRequest(HttpServletRequest req, HttpServletResponse resp, IResource res, String path) {
+		final String sourceMethod = "processRequest"; //$NON-NLS-1$
+		boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(AbstractAggregatorImpl.class.getName(), sourceMethod, new Object[]{req, resp, res, path});
+		}
+		try {
+			URI uri = res.getURI();
+			if (path != null && path.length() > 0 && !uri.getPath().endsWith("/")) {
+				// Make sure we resolve against a folder path
+				uri =  new URI(uri.getScheme(), uri.getAuthority(),
+						uri.getPath() + "/", uri.getQuery(), uri.getFragment()); //$NON-NLS-1$
+				res = newResource(uri);
+			}
+			IResource resolved = res.resolve(path);
+			if (!resolved.exists()) {
+				throw new NotFoundException(resolved.getURI().toString());
+			}
+			resp.setDateHeader("Last-Modified", resolved.lastModified()); //$NON-NLS-1$
+			int expires = getConfig().getExpires();
+			resp.addHeader(
+					"Cache-Control", //$NON-NLS-1$
+					"public" + (expires > 0 ? (", max-age=" + expires) : "") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			);
+			InputStream is = res.resolve(path).getInputStream();
+			OutputStream os = resp.getOutputStream();
+			CopyUtil.copy(is, os);
+		} catch (NotFoundException e) {
+			if (log.isLoggable(Level.INFO)) {
+				log.log(Level.INFO, e.getMessage() + " - " + req.getRequestURI(), e); //$NON-NLS-1$
+			}
+			resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
+		} catch (Exception e) {
+			if (log.isLoggable(Level.WARNING)) {
+				log.log(Level.WARNING, e.getMessage() + " - " + req.getRequestURI(), e); //$NON-NLS-1$
+			}
+			resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+		}
+		if (isTraceLogging) {
+			log.exiting(AbstractAggregatorImpl.class.getName(), sourceMethod);
+		}
+
+	}
+
+	protected void processAggregatorRequest(HttpServletRequest req, HttpServletResponse resp) {
+		final String sourceMethod = "processAggregatorRequest"; //$NON-NLS-1$
+		boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(AbstractAggregatorImpl.class.getName(), sourceMethod, new Object[]{req, resp});
+		}
 		req.setAttribute(AGGREGATOR_REQATTRNAME, this);
 		ConcurrentMap<String, Object> concurrentMap = new ConcurrentHashMap<String, Object>();
 		req.setAttribute(CONCURRENTMAP_REQATTRNAME, concurrentMap);
@@ -360,6 +451,9 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IOpt
 		} finally {
 			concurrentMap.clear();
 		}
+		if (isTraceLogging) {
+			log.exiting(AbstractAggregatorImpl.class.getName(), sourceMethod);
+		}
 	}
 
 	/* (non-Javadoc)
@@ -434,6 +528,20 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IOpt
 	 */
 	@Override
 	public IResource newResource(URI uri) {
+		final String sourceMethod = "newResource"; //$NON-NLS-1$
+		boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(AbstractAggregatorImpl.class.getName(), sourceMethod, new Object[]{uri});
+		}
+		if (!uri.isAbsolute()) {
+			// URI is not absolute, so make it absolute.
+			try {
+				uri = getPlatformServices().getAppContextURI().resolve(uri.getPath());
+			} catch (URISyntaxException e) {
+				throw new IllegalArgumentException(e);
+			}
+		}
+
 		IResourceFactory factory = null;
 		String scheme = uri.getScheme();
 
@@ -452,7 +560,11 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IOpt
 					);
 		}
 
-		return factory.newResource(uri);
+		IResource result = factory.newResource(uri);
+		if (isTraceLogging) {
+			log.exiting(AbstractAggregatorImpl.class.getName(), sourceMethod, result);
+		}
+		return result;
 	}
 
 	/* (non-Javadoc)
@@ -993,28 +1105,6 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IOpt
 	}
 
 	/**
-	 * Returns the init params for this aggregator
-	 * <p>
-	 * This method is called during aggregator intialization.  Subclasses may
-	 * override this method to initialize the aggregator using different
-	 * init params.  Use the public {@link IAggregator#getInitParams()} method
-	 * to get the init params for an initialized aggregator.
-	 *
-	 * @param configMap
-	 *            A Map having key-value pairs denoting configuration init-params for the aggregator servlet
-	 * @return The init params
-	 */
-	protected InitParams getInitParams(Map<String, String> configMap) {
-		List<InitParam> initParams = new LinkedList<InitParam>();
-		for (Entry<String, String> child : configMap.entrySet()) {
-			String name = (String)child.getKey();
-			String value = (String)child.getValue();
-			initParams.add(new InitParam(name, value, this));
-		}
-		return new InitParams(initParams);
-	}
-
-	/**
 	 * Instantiates a new dependencies object
 	 * @param stamp
 	 *            the time stamp
@@ -1061,15 +1151,10 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IOpt
 	 * This method does some initialization for the aggregator servlet. This method is called from platform
 	 * dependent Aggregator implementation during its initialization.
 	 *
-	 *
-	 * @param configMap
-	 *            A Map having key-value pairs denoting configuration settings for the aggregator servlet
-	 * @param configInitParams
-	 *            A Map having key-value pairs denoting servlet init parameters for the aggregator servlet
 	 * @throws Exception
 	 */
 
-	public void initialize(Map<String, String> configMap, Map<String, String> configInitParams)
+	public void initialize()
 			throws Exception {
 
 		// create the config. Keep it local so it won't be seen by deps and cacheMgr
@@ -1085,8 +1170,95 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IOpt
 		walker.walkTree();
 		deps = newDependencies(walker.getLastModifiedJS());
 		cacheMgr = newCacheManager(walker.getLastModified());
+		resourcePaths = getPathsAndAliases(getInitParams());
 		this.config = config;
 
+	}
+
+	/**
+	 * Returns a mapping of resource aliases to IResources defined in the init-params.
+	 * If the IResource is null, then the alias is for the aggregator itself rather
+	 * than a resource location.
+	 *
+	 * @param initParams
+	 *            The aggregator init-params
+	 *
+	 * @return Mapping of aliases to IResources
+	 */
+	protected Map<String, IResource> getPathsAndAliases(InitParams initParams) {
+		final String sourceMethod = "getPahtsAndAliases"; //$NON-NLS-1$
+		boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(AbstractAggregatorImpl.class.getName(), sourceMethod, new Object[]{initParams});
+		}
+		Map<String, IResource> resourcePaths = new HashMap<String, IResource>();
+		List<String> aliases = initParams.getValues(InitParams.ALIAS_INITPARAM);
+		for (String alias : aliases) {
+			addAlias(alias, null, "alias", resourcePaths); //$NON-NLS-1$
+		}
+		List<String> resourceIds = initParams.getValues(InitParams.RESOURCEID_INITPARAM);
+		for (String resourceId : resourceIds) {
+			aliases = initParams.getValues(resourceId + ":alias"); //$NON-NLS-1$
+			List<String> baseNames = initParams.getValues(resourceId + ":base-name"); //$NON-NLS-1$
+			if (aliases == null || aliases.size() != 1) {
+				throw new IllegalArgumentException(resourceId + ":aliases"); //$NON-NLS-1$
+			}
+			if (baseNames == null || baseNames.size() != 1) {
+				throw new IllegalArgumentException(resourceId + ":base-name"); //$NON-NLS-1$
+			}
+			String alias = aliases.get(0);
+			String baseName = baseNames.get(0);
+
+			// make sure not root path
+			boolean isPathComp = false;
+			for (String part : alias.split("/")) { //$NON-NLS-1$
+				if (part.length() > 0) {
+					isPathComp = true;
+					break;
+				}
+			}
+			if (!isPathComp) {
+				throw new IllegalArgumentException(resourceId + ":alias = " + alias); //$NON-NLS-1$
+			}
+			IResource res = newResource(URI.create(baseName));
+			if (res == null) {
+				throw new NullPointerException();
+			}
+			addAlias(alias, res, resourceId + ":alias", resourcePaths); //$NON-NLS-1$
+		}
+		if (isTraceLogging) {
+			log.exiting(AbstractAggregatorImpl.class.getName(), sourceMethod, resourcePaths);
+		}
+		return Collections.unmodifiableMap(resourcePaths);
+	}
+
+	protected void addAlias(String alias, IResource res, String initParamName, Map<String, IResource> map) {
+		final String sourceMethod = "addAlias"; //$NON-NLS-1$
+		boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(AbstractAggregatorImpl.class.getName(), sourceMethod, new Object[]{alias, res, initParamName, map});
+		}
+		String[] parts;
+		if (alias == null || (parts = alias.split("/")).length == 0) { //$NON-NLS-1$
+			throw new IllegalArgumentException(initParamName + " = " + alias); //$NON-NLS-1$
+		}
+		List<String> nonEmptyParts = new ArrayList<String>(parts.length);
+		for (String part : parts) {
+			if (part != null && part.length() > 0) {
+				nonEmptyParts.add(part);
+			}
+		}
+		alias = "/" + StringUtils.join(nonEmptyParts, "/"); //$NON-NLS-1$ //$NON-NLS-2$
+		// Make sure no overlapping alias paths
+		for (String test : map.keySet()) {
+			if (alias.equals(test)) {
+				throw new IllegalArgumentException("Duplicate alias path: " + alias); //$NON-NLS-1$
+			} else if (alias.startsWith(test + "/") || test.startsWith(alias + "/")) { //$NON-NLS-1$ //$NON-NLS-2$
+				throw new IllegalArgumentException("Overlapping alias paths: " + alias + ", " + test); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+		}
+		map.put(alias, res);
+		log.exiting(AbstractAggregatorImpl.class.getName(), sourceMethod);
 	}
 
 	/**
@@ -1096,12 +1268,13 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IOpt
 		 boolean open = true;
 
 		/* (non-Javadoc)
-		 * @see com.ibm.jaggr.service.IExtensionInitializer.IExtensionRegistrar#registerExtension(java.lang.Object, java.util.Properties, java.lang.String, java.lang.String)
+		 * @see com.ibm.jaggr.service.IExtensionInitializer.IExtensionRegistrar#registerExtension(java.lang.Object, java.util.Properties, InitParams, java.lang.String, java.lang.String)
 		 */
 		@Override
 		public void registerExtension(
 				Object impl,
 				Properties attributes,
+				InitParams initParams,
 				String extensionPointId,
 				String uniqueId,
 				IAggregatorExtension before) {
@@ -1111,6 +1284,7 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IOpt
 			IAggregatorExtension extension = new AggregatorExtension(
 						impl,
 						new Properties(attributes),
+						initParams,
 						extensionPointId,
 						uniqueId,
 						AbstractAggregatorImpl.this

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/AggregatorExtension.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/AggregatorExtension.java
@@ -1,4 +1,5 @@
 /*
+
  * (C) Copyright 2012, IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +20,7 @@ package com.ibm.jaggr.core.impl;
 import com.ibm.jaggr.core.IAggregator;
 import com.ibm.jaggr.core.IAggregatorExtension;
 import com.ibm.jaggr.core.IServiceProviderExtensionPoint;
+import com.ibm.jaggr.core.InitParams;
 import com.ibm.jaggr.core.modulebuilder.IModuleBuilder;
 import com.ibm.jaggr.core.modulebuilder.IModuleBuilderExtensionPoint;
 import com.ibm.jaggr.core.resource.IResourceFactory;
@@ -42,6 +44,7 @@ public class AggregatorExtension  implements IAggregatorExtension {
 	private String contributorId;
 	private Object instance;
 	private Properties attributes;
+	private InitParams initParams;
 	private IAggregator aggregator;
 
 	/**
@@ -50,7 +53,9 @@ public class AggregatorExtension  implements IAggregatorExtension {
 	 * @param instance
 	 *            The instantiated object for this extension
 	 * @param attributes
-	 *            The attributes and init-params for this extension
+	 *            The attributes for this extension
+	 * @param initParams
+	 *            The init-params for this extension
 	 * @param extensionPointId
 	 *            the extension point id
 	 * @param uniqueId
@@ -58,7 +63,7 @@ public class AggregatorExtension  implements IAggregatorExtension {
 	 * @param aggregator
 	 *            the aggregator
 	 */
-	public AggregatorExtension(Object instance, Properties attributes, String extensionPointId, String uniqueId, IAggregator aggregator) {
+	public AggregatorExtension(Object instance, Properties attributes, InitParams initParams, String extensionPointId, String uniqueId, IAggregator aggregator) {
 		final String sourceMethod = "<ctor>"; //$NON-NLS-1$
 		boolean isTraceLogging = log.isLoggable(Level.FINER);
 		if (isTraceLogging) {
@@ -69,6 +74,7 @@ public class AggregatorExtension  implements IAggregatorExtension {
 		this.contributorId = null;
 		this.instance = instance;
 		this.attributes = attributes;
+		this.initParams = initParams;
 		this.aggregator = aggregator;
 		validate();
 		if (isTraceLogging) {
@@ -76,8 +82,8 @@ public class AggregatorExtension  implements IAggregatorExtension {
 		}
 	}
 
-	public AggregatorExtension(Object instance, Properties attributes, String extensionPointId, String uniqueId) {
-		this(instance, attributes, extensionPointId, uniqueId, null);
+	public AggregatorExtension(Object instance, Properties attributes, InitParams initParams, String extensionPointId, String uniqueId) {
+		this(instance, attributes, initParams, extensionPointId, uniqueId, null);
 	}
 
 	private void validate() {
@@ -229,6 +235,12 @@ public class AggregatorExtension  implements IAggregatorExtension {
 		    .append(", contributorId:").append(contributorId) //$NON-NLS-1$
 		    .append(", instance:").append(instance) //$NON-NLS-1$
 		    .append(", attributes:").append(attributes) //$NON-NLS-1$
+		    .append(", initParams:").append(initParams) //$NON-NLS-1$
 		    .append("}").toString(); //$NON-NLS-1$
+	}
+
+	@Override
+	public InitParams getInitParams() {
+		return initParams;
 	}
 }

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/config/ConfigImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/config/ConfigImpl.java
@@ -849,20 +849,12 @@ public class ConfigImpl implements IConfig, IShutdownListener, IOptionsListener 
 	 * @throws FileNotFoundException
 	 */
 	protected URI loadConfigUri() throws URISyntaxException, FileNotFoundException {
-		URI configUri = null;
 		Collection<String> configNames = getAggregator().getInitParams().getValues(InitParams.CONFIG_INITPARAM);
 		if (configNames.size() != 1) {
 			throw new IllegalArgumentException(InitParams.CONFIG_INITPARAM);
 		}
 		String configName = configNames.iterator().next();
-		configUri = new URI(configName);
-		if (!configUri.isAbsolute()) {
-			configUri = aggregator.getPlatformServices().getAppContextURI().resolve(configName);
-			if (!getAggregator().newResource(configUri).exists()) {
-				throw new FileNotFoundException(configName);
-			}
-		}
-		return configUri;
+		return new URI(configName);
 	}
 
 	/**

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/resource/ExceptionResource.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/resource/ExceptionResource.java
@@ -84,4 +84,9 @@ public class ExceptionResource implements IResource, IResourceVisitor.Resource {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
+	public String toString() {
+		return super.toString() + ": " + ex.getMessage() + " - " + uri.toString(); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
 }

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/resource/FileResource.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/resource/FileResource.java
@@ -153,6 +153,11 @@ public class FileResource implements IResource {
 		return new VisitorResource(file, file.lastModified());
 	}
 
+	@Override
+	public String toString() {
+		return super.toString() + ": " + file.toString(); //$NON-NLS-1$
+	}
+
 	/**
 	 * Internal method for recursing sub directories.
 	 *

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/resource/NotFoundResource.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/resource/NotFoundResource.java
@@ -76,4 +76,9 @@ public class NotFoundResource implements IResource {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
+	public String toString() {
+		return super.toString() + ": " + "Not found: " + uri.toString(); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
 }

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/resource/ResolverResource.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/resource/ResolverResource.java
@@ -94,4 +94,9 @@ public class ResolverResource implements IResource {
 		return res.asVisitorResource();
 	}
 
+	@Override
+	public String toString() {
+		return super.toString() + " - " + res.getURI();
+	}
+
 }

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/AbstractHttpTransport.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/AbstractHttpTransport.java
@@ -21,6 +21,8 @@ import com.ibm.jaggr.core.IAggregator;
 import com.ibm.jaggr.core.IAggregatorExtension;
 import com.ibm.jaggr.core.IServiceRegistration;
 import com.ibm.jaggr.core.IShutdownListener;
+import com.ibm.jaggr.core.InitParams;
+import com.ibm.jaggr.core.InitParams.InitParam;
 import com.ibm.jaggr.core.ProcessingDependenciesException;
 import com.ibm.jaggr.core.cachekeygenerator.ICacheKeyGenerator;
 import com.ibm.jaggr.core.config.IConfigModifier;
@@ -570,6 +572,7 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IConfigMo
 			reg.registerExtension(
 					newFeatureListResourceFactory(featureListResourceUri),
 					props,
+					new InitParams(Collections.<InitParam>emptyList()),
 					IResourceFactoryExtensionPoint.ID,
 					getTransportId(),
 					first);

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/DojoHttpTransport.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/DojoHttpTransport.java
@@ -19,6 +19,8 @@ package com.ibm.jaggr.core.impl.transport;
 import com.ibm.jaggr.core.IAggregator;
 import com.ibm.jaggr.core.IAggregatorExtension;
 import com.ibm.jaggr.core.IExtensionInitializer;
+import com.ibm.jaggr.core.InitParams;
+import com.ibm.jaggr.core.InitParams.InitParam;
 import com.ibm.jaggr.core.cachekeygenerator.ICacheKeyGenerator;
 import com.ibm.jaggr.core.config.IConfig;
 import com.ibm.jaggr.core.config.IConfig.Location;
@@ -38,6 +40,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
@@ -351,6 +354,7 @@ public class DojoHttpTransport extends AbstractHttpTransport implements IHttpTra
 		reg.registerExtension(
 				new LoaderExtensionResourceFactory(),
 				attributes,
+				new InitParams(Collections.<InitParam>emptyList()),
 				IResourceFactoryExtensionPoint.ID,
 				getTransportId(),
 				first);

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/resource/IResourceFactory.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/resource/IResourceFactory.java
@@ -20,6 +20,7 @@ import com.ibm.jaggr.core.IAggregator;
 import com.ibm.jaggr.core.IAggregatorExtension;
 import com.ibm.jaggr.core.IExtensionInitializer;
 import com.ibm.jaggr.core.IExtensionInitializer.IExtensionRegistrar;
+import com.ibm.jaggr.core.InitParams;
 
 import java.net.URI;
 import java.util.Properties;
@@ -32,7 +33,7 @@ import java.util.Properties;
  * for Aggregator extensions that implement the
  * {@code com.ibm.jaggr.core.resourcefactory} extension point.
  * Aggregator extensions may also register resource factories by calling
- * {@link IExtensionRegistrar#registerExtension(Object, Properties, String, String, IAggregatorExtension)}
+ * {@link IExtensionRegistrar#registerExtension(Object, Properties, InitParams, String, String, IAggregatorExtension)}
  * when the extension's
  * {@link IExtensionInitializer#initialize(IAggregator, IAggregatorExtension, IExtensionRegistrar)}
  * method is called (assuming the extension implements the

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/resource/StringResource.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/resource/StringResource.java
@@ -91,4 +91,9 @@ public class StringResource implements IResource, IResourceVisitor.Resource {
 		return new StringResource("", uri.resolve(relative)); //$NON-NLS-1$
 	}
 
+	@Override
+	public String toString() {
+		return super.toString() + " - " + uri.toString(); //$NON-NLS-1$
+	}
+
 }

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/config/ConfigTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/config/ConfigTest.java
@@ -749,29 +749,6 @@ public class ConfigTest {
 		Assert.assertEquals(cfgUri, cfg.getConfigUri());
 	}
 
-	// Make sure that if the uri to the config is relative, then getConfigUri returns
-	// a namedbundleresource uri
-	@Test
-	public void testGetConfigUriRelative() throws Exception {
-		String config = "{paths:{foo:'fooloc'}}";
-		URI cfgUri = tmpDir.resolve("config.js");
-		Writer fileWriter = new FileWriter(new File(cfgUri));
-		fileWriter.append(config);
-		fileWriter.close();
-
-		List<InitParams.InitParam> initParams = new LinkedList<InitParams.InitParam>();
-		initParams.add(new InitParams.InitParam(InitParams.CONFIG_INITPARAM, "config.js"));
-		mockAggregator = TestUtils.createMockAggregator(null, new File(tmpDir), initParams);
-
-		IPlatformServices mockPlatformServices = EasyMock.createMock(IPlatformServices.class);
-		EasyMock.expect(mockPlatformServices.getAppContextURI()).andReturn(new URI("namedbundleresource://org.mock.name/")).anyTimes();;
-		EasyMock.replay(mockPlatformServices);
-		EasyMock.expect(mockAggregator.getPlatformServices()).andReturn(mockPlatformServices).anyTimes();
-		EasyMock.replay(mockAggregator);
-		ConfigImpl cfg = new ConfigImpl(mockAggregator, true);
-		Assert.assertEquals(new URI("namedbundleresource://org.mock.name/config.js"), cfg.getConfigUri());
-	}
-
 	@Test
 	public void testGetRawConfig() throws Exception {
 		String config = "(function(){ return{ paths: {'foo': 'fooloc'}};})()";

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/deps/DepTreeTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/deps/DepTreeTest.java
@@ -77,10 +77,10 @@ public class DepTreeTest {
 
 		Properties props = new Properties();
 		props.put(IModuleBuilderExtensionPoint.EXTENSION_ATTRIBUTE, "ext1");
-		moduleBuilderExtensions.add(new AggregatorExtension(new DummyModuleBuilder(), props, IModuleBuilderExtensionPoint.ID, "1"));
+		moduleBuilderExtensions.add(new AggregatorExtension(new DummyModuleBuilder(), props, null, IModuleBuilderExtensionPoint.ID, "1"));
 		props = new Properties();
 		props.put(IModuleBuilderExtensionPoint.EXTENSION_ATTRIBUTE, "ext2");
-		moduleBuilderExtensions.add(new AggregatorExtension(new DummyModuleBuilder(), props, IModuleBuilderExtensionPoint.ID, "2"));
+		moduleBuilderExtensions.add(new AggregatorExtension(new DummyModuleBuilder(), props, null, IModuleBuilderExtensionPoint.ID, "2"));
 		exts = depTree.getNonJSExtensions(mockAggregator);
 		expected.addAll(Arrays.asList(new String[]{"ext1", "ext2"}));
 		Assert.assertEquals(expected, exts);

--- a/jaggr-sample/WebContent/js/loaderConfig.js
+++ b/jaggr-sample/WebContent/js/loaderConfig.js
@@ -19,7 +19,7 @@
 	
 	// make sure we use the global require object
 	this.require = {
-		baseUrl: '/test',
+		baseUrl: '..',
 		packages: [
 				{
 					name: 'dojo',
@@ -64,7 +64,7 @@
 		waitSeconds: 10,
 	
 		combo: {
-			contextPath: "/test/aggr",
+			contextPath: "../aggr",
 			expandRequire: true,
 			// This is a maven variable, replaced at build time (see pom file for filtered resources).
 			cacheBust: '${project.version}'

--- a/jaggr-sample/WebContent/test.html
+++ b/jaggr-sample/WebContent/test.html
@@ -61,7 +61,7 @@
 		}
 	}
 	// write out the script tag to use the aggregator to load our modules
-	document.write('<script src="../../test/aggr');
+	document.write('<script src="../aggr');
 	var delim = "?";
 	for (var s in params) {
 		document.write(delim + s + "=" + encodeURIComponent(params[s]));

--- a/jaggr-sample/plugin.xml
+++ b/jaggr-sample/plugin.xml
@@ -22,6 +22,22 @@
            in the same resource bundle as this file -->
       <init-param name="config" value="testaggr-config.js"/>
       <init-param name="serviceproviders" value="com.ibm.jaggr.service.configextension.bundleVersionsHash"/>
+      
+      <!-- The following init-params define internally scoped aliases and resource paths for the application, -->
+      <!-- allowing the aggregator to serve as the resource servlet for all the application's resources       -->
+      <!-- (aggregatored and non-aggregated).  This is an alternative to using the equinox resource servlet   -->
+      <!-- to serve non-aggregated resources out of the application's OSGi bundles.                           -->
+      <!--                                                                                                    -->
+      <!-- The internally scoped version of the sample application can be loaded using the URL                -->
+      <!-- http://<server>/test/aggr/app/res/test.html                                                   -->
+      
+      <init-param name="alias" value="/app/aggr"/>
+      <init-param name="resource-id" value="res"/>
+      <init-param name="resource-id" value="dojo"/>
+      <init-param name="res:alias" value="/app/res"/>
+      <init-param name="res:base-name" value="/WebContent"/> 
+      <init-param name="dojo:alias" value="/app/dojo-1.8.0"/>
+      <init-param name="dojo:base-name" value="namedbundleresource://com.ibm.jaggr.sample.dojo/WebContent/source_1.8.0-20120830-IBM_dojo"/>
     </servlet>
   </extension>
 

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/config/BundleVersionsHash.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/config/BundleVersionsHash.java
@@ -104,7 +104,7 @@ public class BundleVersionsHash implements IExtensionInitializer, IConfigScopeMo
 			log.entering(BundleVersionsHash.class.getName(), sourceMethod, new Object[]{aggregator, extension, registrar});
 		}
 		// get the name of the function from the extension attributes
-		propName = extension.getAttribute("propName"); //$NON-NLS-1$
+		propName = extension.getInitParams().getValue("propName"); //$NON-NLS-1$
 		if (propName == null) {
 			propName = DEFAULT_PROPNAME;
 		}

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/resource/BundleResource.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/resource/BundleResource.java
@@ -179,6 +179,11 @@ public class BundleResource implements IResource {
 		return getURI().getPath();
 	}
 
+	@Override
+	public String toString() {
+		return super.toString() + ": " +  (symname != null ? symname  : "null") + " - " + uri.toString(); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	}
+
 	private static class VisitorResource implements IResourceVisitor.Resource {
 
 		URL url;

--- a/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/config/BundleVersionsHashTest.java
+++ b/jaggr-service/src/test/java/com/ibm/jaggr/service/impl/config/BundleVersionsHashTest.java
@@ -19,6 +19,8 @@ import com.ibm.jaggr.core.IAggregator;
 import com.ibm.jaggr.core.IAggregatorExtension;
 import com.ibm.jaggr.core.IPlatformServices;
 import com.ibm.jaggr.core.IServiceReference;
+import com.ibm.jaggr.core.InitParams;
+import com.ibm.jaggr.core.InitParams.InitParam;
 import com.ibm.jaggr.core.NotFoundException;
 import com.ibm.jaggr.core.config.IConfigScopeModifier;
 import com.ibm.jaggr.core.impl.config.ConfigImpl;
@@ -38,6 +40,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
@@ -51,6 +54,7 @@ public class BundleVersionsHashTest {
 	public void testBundleVersionsHash() throws Exception {
 		URI tmpDir = new File(System.getProperty("user.dir")).toURI();
 		IAggregator mockAggregator = TestUtils.createMockAggregator();
+		InitParams initParams = new InitParams(Arrays.asList(new InitParam[]{new InitParam("propName", "getBundleVersionsHash", mockAggregator)}));
 		BundleVersionsHash bvh = new BundleVersionsHash();
 		IServiceReference mockServiceReference = EasyMock.createNiceMock(IServiceReference.class);
 		IServiceReference[] serviceReferences = new IServiceReference[]{mockServiceReference};
@@ -61,7 +65,7 @@ public class BundleVersionsHashTest {
 		Dictionary<String, String> dict = new Hashtable<String, String>();
 		dict.put("name", mockAggregator.getName());
 		EasyMock.expect(mockPlatformServices.getService(mockServiceReference)).andReturn(bvh).anyTimes();
-		EasyMock.expect(mockExtension.getAttribute("propName")).andReturn("getBundleVersionsHash").anyTimes();
+		EasyMock.expect(mockExtension.getInitParams()).andReturn(initParams).anyTimes();
 		EasyMock.expect(mockPlatformServices.getServiceReferences(IConfigScopeModifier.class.getName(), "(name="+mockAggregator.getName()+")")).andReturn(serviceReferences).anyTimes();
 		EasyMock.replay(mockServiceReference, mockPlatformServices, mockExtension);
 		bvh.initialize(mockAggregator, mockExtension, null);


### PR DESCRIPTION
This update enables defining resource alias paths to be served by the aggregator, thus allowing both aggregated and non-aggregated static resources to reside beneath the aggregator servlet alias namespace, eliminating the need for externally defined resource servlets (e.g. org.eclipse.equinox.http.registry.resources).

The sample app has been updated to support both modes of operation.  The traditional mode uses the aggregator only for aggregating resources and serves non-aggregated resources (e.g. when using test-no-aggr.html) from the resource servlets defined in the resource bundles.  This mode is loaded with the URLs [http://localhost/test/res/test.html](http://localhost/test/res/test.html) and [http://localhost/test/res/test-no-aggr.html](http://localhost/test/res/test-no-aggr.html).  Using the new mode, the app namespace resides entirely within the test/aggr namespace, with the aggregator serving both aggregated and non-aggregated resources.  This mode is loaded with the URLs [http://localhost/test/aggr/app/res/test.html](http://localhost/test/aggr/app/res/test.html) and [http://localhost/test/aggr/app/res/test-no-aggr.html](http://localhost/test/aggr/app/res/test-no-aggr.html).  Both modes of operation are supported concurrently.

This pull request includes some interface changes relating to aggregator initialization and InitParams.  This was necessary to support multi-valued init-params, which the previous interface did not allow and which is needed for defining aggregator resource aliases.
