### PR TITLE
Use both MimetypeFileTypeMap and FileNameMap (from URLConnection) to get

### DIFF
--- a/jaggr-core/.gitignore
+++ b/jaggr-core/.gitignore
@@ -1,4 +1,3 @@
-/META-INF
 /.classpath
 /.project
 /lib

--- a/jaggr-core/META-INF/.gitignore
+++ b/jaggr-core/META-INF/.gitignore
@@ -1,0 +1,1 @@
+/MANIFEST.MF

--- a/jaggr-core/META-INF/mime.types
+++ b/jaggr-core/META-INF/mime.types
@@ -1,0 +1,5 @@
+# Make sure standard types we use are defined
+application/javascript js JS
+text/css css CSS less LESS
+text/html html HTML htm HTM
+

--- a/jaggr-core/pom.xml
+++ b/jaggr-core/pom.xml
@@ -90,6 +90,7 @@
         <filtering>false</filtering>
         <includes>
           <include>WebContent/**</include>
+          <include>META-INF/mime.types</include>
         </includes>
       </resource>
     </resources>

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorImpl.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorImpl.java
@@ -141,7 +141,7 @@ public class AggregatorImpl extends AbstractAggregatorImpl implements IExecutabl
 			try {
 				StringWriter writer = new StringWriter();
 				CopyUtil.copy(url.openStream(), writer);
-				super.mimeTypes.addMimeTypes(writer.toString());
+				super.fileTypeMap.addMimeTypes(writer.toString());
 			} catch (IOException e) {
 				if (log.isLoggable(Level.WARNING)) {
 					log.log(Level.WARNING, e.getMessage(), e);


### PR DESCRIPTION
content type.

Use both MimetypeFileTypeMap and FileNameMap (from URLConnection) because MimetypeFileTypeMap provides a convenient way for the application to add new mappings, but doesn't provide any default mappings, while FileNameMap, from URLConnection, provides default mappings (via &lt;java_home&gt;/lib/content-types.properties) but without easy extensibility.
