### PR TITLE
Refactor BundleVersionsHash

### DIFF
--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/config/BundleVersionsHash.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/config/BundleVersionsHash.java
@@ -22,22 +22,18 @@ import com.ibm.jaggr.core.IServiceRegistration;
 import com.ibm.jaggr.core.NotFoundException;
 import com.ibm.jaggr.core.config.IConfigScopeModifier;
 
-import com.ibm.jaggr.service.IBundleResolver;
 import com.ibm.jaggr.service.impl.AggregatorImpl;
-import com.ibm.jaggr.service.util.BundleResolverFactory;
+import com.ibm.jaggr.service.util.BundleVersionsHashBase;
 
-import org.apache.commons.codec.binary.Base64;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.NativeArray;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
-import org.osgi.framework.Bundle;
 
 import java.lang.reflect.Method;
-import java.security.MessageDigest;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Dictionary;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -67,7 +63,7 @@ import java.util.logging.Logger;
  * An alternative name for the function may be specified by the <code>propName</code> init-param in
  * the plugin extension xml.
  */
-public class BundleVersionsHash implements IExtensionInitializer, IConfigScopeModifier {
+public class BundleVersionsHash extends BundleVersionsHashBase implements IExtensionInitializer, IConfigScopeModifier {
 	private static final Logger log = Logger.getLogger(BundleVersionsHash.class.getName());
 
 	private static final String DEFAULT_PROPNAME = "getBundleVersionsHash";  //$NON-NLS-1$
@@ -76,9 +72,6 @@ public class BundleVersionsHash implements IExtensionInitializer, IConfigScopeMo
 
 
 	private String propName = null;		// the name of the function (specified by plugin.xml)
-
-	private Bundle contributingBundle = null;
-	private IBundleResolver bundleResolver;
 
 	/* (non-Javadoc)
 	 * @see com.ibm.jaggr.core.config.IConfigScopeModifier#modifyScope(com.ibm.jaggr.core.IAggregator, org.mozilla.javascript.Context, org.mozilla.javascript.Scriptable)
@@ -118,39 +111,12 @@ public class BundleVersionsHash implements IExtensionInitializer, IConfigScopeMo
 			log.finer("propName = " + propName); //$NON-NLS-1$
 		}
 		if (aggregator instanceof AggregatorImpl) {		// can be an IAggregator mock when unit testing
-			contributingBundle = ((AggregatorImpl)aggregator).getContributingBundle();
+			setContributingBundle(((AggregatorImpl)aggregator).getContributingBundle());
 		}
-		bundleResolver = BundleResolverFactory.getResolver(contributingBundle);
 
 		if (isTraceLogging) {
 			log.exiting(BundleVersionsHash.class.getName(), sourceMethod);
 		}
-	}
-
-	/**
-	 * Returns the bundle headers for the specified bundle.
-	 *
-	 * @param bundleName
-	 *            the bundle name
-	 * @return the bundle headers for the bundle.
-	 * @throws NotFoundException if no matching bundle is found.
-	 */
-	private Dictionary<?, ?> getBundleHeaders(String bundleName) throws NotFoundException {
-		final String sourceMethod = "getBundleHeaders"; //$NON-NLS-1$
-		boolean isTraceLogging = log.isLoggable(Level.FINER);
-		if (isTraceLogging) {
-			log.entering(BundleVersionsHash.class.getName(), sourceMethod, new Object[]{bundleName});
-		}
-
-		Bundle result = ".".equals(bundleName) ? contributingBundle : bundleResolver.getBundle(bundleName); //$NON-NLS-1$
-
-		if (result == null) {
-			throw new NotFoundException("Bundle " + bundleName + " not found."); //$NON-NLS-1$ //$NON-NLS-2$
-		}
-		if (isTraceLogging) {
-			log.exiting(BundleVersionsHash.class.getName(), sourceMethod, result.getHeaders());
-		}
-		return result.getHeaders();
 	}
 
 	static private class FunctionObject extends org.mozilla.javascript.FunctionObject {
@@ -207,44 +173,29 @@ public class BundleVersionsHash implements IExtensionInitializer, IConfigScopeMo
 			if (isTraceLogging) {
 				log.entering(BundleVersionsHash.FunctionObject.class.getName(), sourceMethod, new Object[]{cx, thisObj, args, funObj});
 			}
-			Object result = Context.getUndefinedValue();
 			FunctionObject javaThis = (FunctionObject)funObj;
 			StringBuffer sb = new StringBuffer();
 			Set<String> headersToInclude = defaultHeaders;
 			int i = 0;
 			// args is an array of bundle names
+			List<String> bundleNames = new ArrayList<String>();
 			for (Object arg : args) {
 				if (i++ == 0 && arg instanceof NativeArray) {
 					headersToInclude = getHeaderNames((NativeArray)arg);
 					NativeArray nativeArray = (NativeArray)arg;
 					Object[] array = nativeArray.toArray(new Object[nativeArray.size()]);
 				} else if (arg instanceof String) {
-					Dictionary<?, ?> headers = javaThis.instance.getBundleHeaders(arg.toString());
-					for (String header : headersToInclude) {
-						Object obj = headers.get(header);
-						String value = obj.toString();
-						if (value != null) {
-							sb.append(sb.length() == 0 ? "" : ",").append(value); //$NON-NLS-1$ //$NON-NLS-2$
-						}
-						if (isTraceLogging) {
-							log.finer("bundle '" + arg.toString() + "': " + header + "=" + value); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-						}
-					}
+					bundleNames.add(arg.toString());
 				} else {
 					throw new IllegalArgumentException("Invalid argument type:" + arg.toString()); //$NON-NLS-1$
 				}
 			}
-			if (sb.length() > 0) {
-				MessageDigest md = null;
-				try {
-					md = MessageDigest.getInstance("MD5"); //$NON-NLS-1$
-					result = Base64.encodeBase64URLSafeString(md.digest(sb.toString().getBytes("UTF-8"))); //$NON-NLS-1$
-				} catch (Exception e) {
-					if (log.isLoggable(Level.SEVERE)) {
-						log.log(Level.SEVERE, e.getMessage(), e);
-					}
-					throw new RuntimeException(e);
-				}
+			Object result = javaThis.instance.generateHash(
+					headersToInclude.toArray(new String[headersToInclude.size()]),
+					bundleNames.toArray(new String[bundleNames.size()])
+			);
+			if (result == null) {
+				result = Context.getUndefinedValue();
 			}
 			if (isTraceLogging) {
 				log.exiting(BundleVersionsHash.FunctionObject.class.getName(), sourceMethod, result);
@@ -252,4 +203,5 @@ public class BundleVersionsHash implements IExtensionInitializer, IConfigScopeMo
 			return result;
 		}
 	}
+
 }

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/util/BundleVersionsHashBase.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/util/BundleVersionsHashBase.java
@@ -1,0 +1,144 @@
+/*
+ * (C) Copyright 2012, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.jaggr.service.util;
+
+import com.ibm.jaggr.core.NotFoundException;
+
+import com.ibm.jaggr.service.IBundleResolver;
+
+import org.apache.commons.codec.binary.Base64;
+import org.osgi.framework.Bundle;
+
+import java.security.MessageDigest;
+import java.util.Dictionary;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Base class providing core (non-mozilla) functionality for generating a hash based on
+ * the bundle header properties of a list of bundles.  This class is callable by
+ * external packages (e.g. servlets) that wish to generate cache bust strings
+ * in the same manner as the aggregator.
+ */
+public class BundleVersionsHashBase {
+	private static final Logger log = Logger.getLogger(BundleVersionsHashBase.class.getName());
+
+	private Bundle contributingBundle = null;		// The contributing bundle
+	private IBundleResolver bundleResolver;			// The bundle resolver
+
+	/**
+	 * Default constructor
+	 */
+	public BundleVersionsHashBase() {
+		bundleResolver = BundleResolverFactory.getResolver(null);
+	}
+
+	/**
+	 * @param contributingBundle
+	 */
+	public BundleVersionsHashBase(Bundle contributingBundle) {
+		setContributingBundle(contributingBundle);
+	}
+
+	/**
+	 * @return the contributing bundle
+	 */
+	public Bundle getContributingBundle() {
+		return contributingBundle;
+	}
+
+	/**
+	 * @param contributingBundle
+	 */
+	public void setContributingBundle(Bundle contributingBundle) {
+		this.contributingBundle = contributingBundle;
+		bundleResolver = BundleResolverFactory.getResolver(contributingBundle);
+	}
+
+	/**
+	 * Returns the bundle headers for the specified bundle.
+	 *
+	 * @param bundleName
+	 *            the bundle name
+	 * @return the bundle headers for the bundle.
+	 * @throws NotFoundException if no matching bundle is found.
+	 */
+	private Dictionary<?, ?> getBundleHeaders(String bundleName) throws NotFoundException {
+		final String sourceMethod = "getBundleHeaders"; //$NON-NLS-1$
+		boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(BundleVersionsHashBase.class.getName(), sourceMethod, new Object[]{bundleName});
+		}
+
+		Bundle result = ".".equals(bundleName) ? contributingBundle : bundleResolver.getBundle(bundleName); //$NON-NLS-1$
+
+		if (result == null) {
+			throw new NotFoundException("Bundle " + bundleName + " not found."); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+		if (isTraceLogging) {
+			log.exiting(BundleVersionsHashBase.class.getName(), sourceMethod, result.getHeaders());
+		}
+		return result.getHeaders();
+	}
+	/**
+	 * Returns an MD5 hash of the concatenated bundle header values from each of the specified bundles.
+	 * If any of the specified bundles are not found, a {@link NotFoundException} is thrown.
+	 *
+	 * @param headerNames the bundle header values to include in the hash
+	 * @param bundleNames the bundle names to include in the hash
+	 *
+	 * @return the computed hash
+	 * @throws NotFoundException
+	 */
+	public String generateHash(String[] headerNames, String[] bundleNames) throws NotFoundException {
+		final String sourceMethod = "generateCacheBustHash"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(BundleVersionsHashBase.class.getName(), sourceMethod);
+		}
+		StringBuffer sb = new StringBuffer();
+		for (String bundleName : bundleNames) {
+			Dictionary<?, ?> bundleHeaders = getBundleHeaders(bundleName);
+			for (String headerName : headerNames) {
+				Object value = bundleHeaders.get(headerName);
+				if (isTraceLogging) {
+					log.finer("Bundle = " + bundleName + ", Header name = " + headerName + ", Header value = " + value); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				}
+				sb.append(sb.length() == 0 ? "" : ",").append(value); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+		}
+
+		String result = null;
+		if (sb.length() > 0) {
+			MessageDigest md = null;
+			try {
+				md = MessageDigest.getInstance("MD5"); //$NON-NLS-1$
+				result = Base64.encodeBase64URLSafeString(md
+						.digest(sb.toString().getBytes("UTF-8"))); //$NON-NLS-1$
+			} catch (Exception e) {
+				if (log.isLoggable(Level.SEVERE)) {
+					log.log(Level.SEVERE, e.getMessage(), e);
+				}
+				throw new RuntimeException(e);
+			}
+		}
+		if (isTraceLogging) {
+			log.exiting(BundleVersionsHashBase.class.getName(), sourceMethod, result);
+			;
+		}
+		return result;
+	}
+}


### PR DESCRIPTION
to make it easier for external code to invoke the hash functionality.
Goal is to enable remote code (e.g. external servlets) to access cache bust generation logic used by aggregator.  This can be done by calling 

```
BundleVersionsHashBase.generateHash(String[] headerNames, String[] bundleNames)
```
