### PR TITLE
Fixes to handling of cache bust query arg

### DIFF
--- a/jaggr-core/WebContent/dojo/_loaderExt.js
+++ b/jaggr-core/WebContent/dojo/_loaderExt.js
@@ -53,6 +53,12 @@ var depmap = {},
     // Map of module name to number id pairs
     moduleIdMap = {};
 
+    // Query arg from window.location
+    windowArgs = parseQueryArgs(window.location.href) || {};
+    
+    // Query arg from script tag used to load this code
+    scriptArgs = combo.scriptId && parseQueryArgs((document.getElementById(combo.scriptId)||{}).src) || {};
+
 // Copy config params from the combo config property
 for (var s in params) {
 	if (typeof combo[s] !== 'undefined') {
@@ -77,14 +83,27 @@ userConfig.has['dojo-combo-api'] = 1;
 userConfig.has['dojo-sync-loader'] = 0;
 
 /**
+ * url processor for handling cache bust query arg
+ */
+urlProcessors.push(function(url) {
+	cb = windowArgs.cachebust ||
+	     scriptArgs.cachebust || scriptArgs.cb ||
+	     combo.cacheBust || dojo.config.cacheBust;
+	if (cb) {
+		url += ('&cb=' + cb);
+	}
+	return url;
+});
+
+/**
  * urlProcessor to add query locale query arg
  */
 urlProcessors.push(function(url){
 	
-    if (typeof dojo !== 'undefined' && dojo.locale && !/[?&]locs=/.test(url)) {
-        url+=('&locs='+[dojo.locale].concat(userConfig.extraLocales || []).join(','));
-    }
-    return url;
+	if (typeof dojo !== 'undefined' && dojo.locale && !/[?&]locs=/.test(url)) {
+		url+=('&locs='+[dojo.locale].concat(userConfig.extraLocales || []).join(','));
+	}
+	return url;
 });
 
 // require.combo needs to be defined before this code is loaded

--- a/jaggr-core/WebContent/loaderExtCommon.js
+++ b/jaggr-core/WebContent/loaderExtCommon.js
@@ -32,9 +32,6 @@ var params = {
 		// optimize can equal "none" | "whitespace" | "simple"(default)
 		optimize: ["simple", "opt"],
 	
-		// cache bust string 
-		cacheBust: [null, "cb"],
-	
 		// show filenames in responses
 		showFilenames: [null, "fn"],
 	
@@ -413,6 +410,28 @@ var params = {
 				}
 			}
 		}
+	},
+	
+	/**
+	 * Parses the provided href and returns an object map of the query args in the href.
+	 * This routine does not support multivalued query args.  If a query arg appears more 
+	 * than once, the value of the last instance will be represented in the map.  
+	 * 
+	 * The names of query args are converted to lower case in the property map.
+	 */
+	parseQueryArgs = function(href) {
+		var result = {};
+		if (href) {
+			var args = href.split('?')[1];
+			if (args) {
+				var argsAry = args.split('&');
+				for (var i = 0; i < argsAry.length; i++) {
+					var argAry = argsAry[i].split('=');
+					result[argAry[0].toLowerCase()] = argAry[1];
+				}
+			}
+		}
+		return result;
 	};
 
 urlProcessors.push(function(url) {

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/AbstractHttpTransport.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/AbstractHttpTransport.java
@@ -718,7 +718,7 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IConfigMo
 		}
 		String cacheBust = AggregatorUtil.getCacheBust(aggregator);
 		if (cacheBust != null && cacheBust.length() > 0) {
-			sb.append("if (!require.combo.cacheBust){combo.cacheBust = '") //$NON-NLS-1$
+			sb.append("if (!require.combo.cacheBust){require.combo.cacheBust = '") //$NON-NLS-1$
 			.append(cacheBust).append("';}\r\n"); //$NON-NLS-1$
 		}
 		if (moduleIdListHash != null) {

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/util/BundleVersionsHashBase.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/util/BundleVersionsHashBase.java
@@ -23,7 +23,10 @@ import org.apache.commons.codec.binary.Base64;
 import org.osgi.framework.Bundle;
 
 import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Dictionary;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -109,10 +112,17 @@ public class BundleVersionsHashBase {
 		if (isTraceLogging) {
 			log.entering(BundleVersionsHashBase.class.getName(), sourceMethod);
 		}
+
+		// Sort the input lists so result is independent of the order the names are specified
+		List<String> sortedHeaderNames = Arrays.asList(headerNames);
+		List<String> sortedBundleNames = Arrays.asList(bundleNames);
+		Collections.sort(sortedHeaderNames);
+		Collections.sort(sortedBundleNames);
+
 		StringBuffer sb = new StringBuffer();
-		for (String bundleName : bundleNames) {
+		for (String bundleName : sortedBundleNames) {
 			Dictionary<?, ?> bundleHeaders = getBundleHeaders(bundleName);
-			for (String headerName : headerNames) {
+			for (String headerName : sortedHeaderNames) {
 				Object value = bundleHeaders.get(headerName);
 				if (isTraceLogging) {
 					log.finer("Bundle = " + bundleName + ", Header name = " + headerName + ", Header value = " + value); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$


### PR DESCRIPTION
When generating a jaggr request, the loader extension javascript will look for the cache bust string in the following locations:
- cachebust (case insensitive) query arg in window.location.href
- cachebust (case insenstive) query arg in URL used to load the loader extension javascript
- cb (case insensitive) query arg in URL used to load the loader extension javascript
- combo.cacheBust property in AMD loader config
- dojo.config.cacheBust property

The first value in the list above that is truthy will be used.
