### PR TITLE
com.ibm.jaggr.core.impl.cache.AggregatorProxy using wrong classloader

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/cache/AggregatorProxy.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/cache/AggregatorProxy.java
@@ -36,7 +36,7 @@ public class AggregatorProxy implements java.lang.reflect.InvocationHandler {
 
 	public static IAggregator newInstance(IAggregator aggr, ICacheManager cacheMgr) {
 		return (IAggregator)java.lang.reflect.Proxy.newProxyInstance(
-				aggr.getClass().getClassLoader(),
+				cacheMgr.getClass().getClassLoader(),
 				new Class[]{IAggregator.class},
 				new AggregatorProxy(aggr, cacheMgr));
 	}


### PR DESCRIPTION
causing issues when trying to omit jaggr-core from Required-Bundles
