### PR TITLE
Fix handling of jaggr generated browser console messages for NotFoundException handling.

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/ModuleList.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/ModuleList.java
@@ -44,6 +44,7 @@ class ModuleList extends LinkedList<ModuleList.ModuleListEntry> {
 		IModule getModule() {
 			return module;
 		}
+		boolean isServerExpanded() { return false; }
 	}
 	private Set<String> dependentFeatures = null;
 	private Set<String> requiredModules = null;

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/module/ModuleImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/module/ModuleImpl.java
@@ -295,7 +295,7 @@ public class ModuleImpl extends ModuleIdentifier implements IModule, Serializabl
 							+ key);
 				}
 				ModuleBuildReader mbr = new ModuleBuildReader(reader,
-						cacheKeyGenerators, false);
+						cacheKeyGenerators, null);
 				processExtraModules(mbr, request, existingEntry);
 				return new CompletedFuture<ModuleBuildReader>(mbr);
 			}
@@ -317,7 +317,7 @@ public class ModuleImpl extends ModuleIdentifier implements IModule, Serializabl
 							+ key);
 				}
 				ModuleBuildReader mbr = new ModuleBuildReader(reader,
-						cacheKeyGenerators, false);
+						cacheKeyGenerators, null);
 				processExtraModules(mbr, request, existingEntry);
 				return new CompletedFuture<ModuleBuildReader>(mbr);
 			}
@@ -364,7 +364,7 @@ public class ModuleImpl extends ModuleIdentifier implements IModule, Serializabl
 										+ key);
 							}
 							ModuleBuildReader mbr = new ModuleBuildReader(reader,
-									_cacheKeyGenerators, false);
+									_cacheKeyGenerators, null);
 							processExtraModules(mbr, request, cacheEntry);
 							return mbr;
 						}
@@ -378,7 +378,7 @@ public class ModuleImpl extends ModuleIdentifier implements IModule, Serializabl
 						if (build.isError()) {
 							// Don't cache error results
 							return new ModuleBuildReader(new StringReader(build
-									.getBuildOutput().toString()), null, true);
+									.getBuildOutput().toString()), null, build.getErrorMessage());
 						}
 						cacheEntry.setData(build.getBuildOutput(), build.getBefore(), build.getAfter());
 
@@ -441,18 +441,19 @@ public class ModuleImpl extends ModuleIdentifier implements IModule, Serializabl
 							// In debug/development mode, don't throw an exception.
 							// Instead, log the
 							// error on the client.
+							String errorMsg = StringUtil.escapeForJavaScript(
+									ex.getClass().getName() +
+									": " + 	ex.getMessage() + //$NON-NLS-1$
+									"\r\n" + //$NON-NLS-1$
+									Messages.ModuleImpl_2
+							);
 							return new ModuleBuildReader(
 									new ErrorModuleReader(
-											StringUtil.escapeForJavaScript(
-													ex.getClass().getName() +
-													": " + 	ex.getMessage() + //$NON-NLS-1$
-													"\r\n" + //$NON-NLS-1$
-													Messages.ModuleImpl_2
-													),
-													getModuleName(),
-													request
-											), null, true
-									);
+											errorMsg,
+											getModuleName(),
+											request
+									), null, errorMsg
+								);
 
 						} else {
 							throw ex;
@@ -461,7 +462,7 @@ public class ModuleImpl extends ModuleIdentifier implements IModule, Serializabl
 				}
 				ModuleBuildReader mbr = new ModuleBuildReader(
 						cacheEntry.getReader(mgr.getCacheDir(), request),
-						newCacheKeyGenerators, false);
+						newCacheKeyGenerators, null);
 				processExtraModules(mbr, request, cacheEntry);
 				// return a build reader object
 				return mbr;

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/module/NotFoundModule.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/module/NotFoundModule.java
@@ -48,20 +48,21 @@ public class NotFoundModule extends ModuleIdentifier implements IModule, Cloneab
 	 */
 	@Override
 	public Future<ModuleBuildReader> getBuild(HttpServletRequest request) {
+		String errorMessage = MessageFormat.format(
+				Messages.NotFoundModule_0,
+				new Object[]{StringUtil.escapeForJavaScript(uri.toString())}
+		);
 		return
 			new CompletedFuture<ModuleBuildReader>(
 				new ModuleBuildReader(
 					new ErrorModuleReader(
-						ErrorModuleReader.ConsoleMethod.warn,
-						MessageFormat.format(
-								Messages.NotFoundModule_0,
-								new Object[]{StringUtil.escapeForJavaScript(uri.toString())}
-								),
-								getModuleName(),
-								request
+						ErrorModuleReader.ConsoleMethod.error,
+						errorMessage,
+						getModuleName(),
+						request
 					),
 					null,
-					true
+					errorMessage
 				)
 			);
 	}

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/i18n/I18nModuleBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/i18n/I18nModuleBuilder.java
@@ -96,7 +96,7 @@ extends JavaScriptModuleBuilder {
 			newKeyGens.add(new CacheKeyGenerator(availableLocales, false));
 			keyGens = newKeyGens;
 		}
-		ModuleBuild mb = new ModuleBuild(result.getBuildOutput(), keyGens, result.isError());
+		ModuleBuild mb = new ModuleBuild(result.getBuildOutput(), keyGens, result.getErrorMessage());
 		if (!result.isError()) {
 			for (IModule module : additionalModules) {
 				mb.addBefore(module);

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilder.java
@@ -414,18 +414,14 @@ public class JavaScriptModuleBuilder implements IModuleBuilder, IExtensionInitia
 				.append(" (").append(error.lineNumber).append(")."); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 			if (aggr.getOptions().isDevelopmentMode() || aggr.getOptions().isDebugMode()) {
-				// In development mode, return the error console output
+				// In development mode, return the error message
 				// together with the uncompressed source.
-				String escaped = StringUtil.escapeForJavaScript(sb.toString());
-				// Reuse the string buffer and output a console error message
-				// along with the uncompiled source files as the build output.
-				sb.replace(0, sb.length(), "\r\nconsole.error(\"") //$NON-NLS-1$
-				.append(escaped)
-				.append("\");\r\n"); //$NON-NLS-1$
+				String errorMsg = StringUtil.escapeForJavaScript(sb.toString());
+				StringBuffer code = new StringBuffer();
 				for (JSSourceFile sf : sources) {
-					sb.append(sf.getCode());
+					code.append(sf.getCode());
 				}
-				return new ModuleBuild(sb.toString(), null, true);
+				return new ModuleBuild(code.toString(), null, errorMsg);
 			} else {
 				throw new Exception(sb.toString());
 			}
@@ -436,7 +432,7 @@ public class JavaScriptModuleBuilder implements IModuleBuilder, IExtensionInitia
 						createNewKeyGen ?
 								getCacheKeyGenerators(discoveredHasConditionals) :
 									keyGens,
-									false);
+									null);
 	}
 
 	/**

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/text/TextModuleBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/text/TextModuleBuilder.java
@@ -73,7 +73,7 @@ public class TextModuleBuilder implements IModuleBuilder {
 				);
 		sb.append(writer.toString());
 		sb.append(noTextAdorn ? "'" : "');"); //$NON-NLS-1$ //$NON-NLS-2$
-		return new ModuleBuild(sb.toString(), keyGens, false);
+		return new ModuleBuild(sb.toString(), keyGens, null);
 	}
 
 	protected Reader getContentReader(String mid,	IResource resource,	HttpServletRequest request,	List<ICacheKeyGenerator> keyGens)	throws IOException {

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/modulebuilder/ModuleBuild.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/modulebuilder/ModuleBuild.java
@@ -38,7 +38,7 @@ public final class ModuleBuild {
 	private List<IModule> before;
 	private List<IModule> after;
 	private List<ICacheKeyGenerator> keyGenerators;
-	private boolean error;
+	private String error;
 
 	/**
 	 * Convenience constructor utilizing a null cache key generator and no
@@ -48,7 +48,7 @@ public final class ModuleBuild {
 	 *            The built output for the module
 	 */
 	public ModuleBuild(Object buildOutput) {
-		this(buildOutput, null, false);
+		this(buildOutput, null, null);
 	}
 
 	/**
@@ -64,9 +64,9 @@ public final class ModuleBuild {
 	 *            the built output for the module is invariant with regard to
 	 *            the request, then <code>keyGens</code> may be null.
 	 * @param error
-	 *            True if an error occurred while generating the build
+	 *            If not null, then a message describing the build error
 	 */
-	public ModuleBuild(Object buildOutput, List<ICacheKeyGenerator> keyGens, boolean error) {
+	public ModuleBuild(Object buildOutput, List<ICacheKeyGenerator> keyGens, String error) {
 		this.buildOutput = buildOutput;
 		this.keyGenerators = keyGens;
 		this.before = this.after = null;
@@ -105,6 +105,10 @@ public final class ModuleBuild {
 	 * @return True if a build error occurred
 	 */
 	public boolean isError() {
+		return error != null;
+	}
+
+	public String getErrorMessage() {
 		return error;
 	}
 

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/readers/JavaScriptEscapingReader.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/readers/JavaScriptEscapingReader.java
@@ -26,7 +26,7 @@ public class JavaScriptEscapingReader extends CharacterEscapingReader {
 	 * within javascript strings.
 	 */
 	public static final Collection<Character> escapeChars = Arrays
-			.asList(new Character[] { '\'', '\n', '\r', '\\' });
+			.asList(new Character[] { '\'', '"', '\n', '\r', '\\' });
 
 
 	public JavaScriptEscapingReader(Reader reader) {

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/readers/ModuleBuildReader.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/readers/ModuleBuildReader.java
@@ -41,7 +41,7 @@ public class ModuleBuildReader extends Reader {
 	private List<ModuleBuildFuture> before;
 	private List<ModuleBuildFuture> after;
 	private List<ICacheKeyGenerator> keyGenerators;
-	private boolean error;
+	private String error;
 
 	/**
 	 * Constructor for a Build object specifying a reader, key generator
@@ -49,9 +49,9 @@ public class ModuleBuildReader extends Reader {
 	 *
 	 * @param reader A {@link Reader} to the build content
 	 * @param keyGens The {@link ICacheKeyGenerator} list for this IModule
-	 * @param error True if this module build contains an error response
+	 * @param error If not null, then an message describing the error
 	 */
-	public ModuleBuildReader(Reader reader, List<ICacheKeyGenerator> keyGens, boolean error) {
+	public ModuleBuildReader(Reader reader, List<ICacheKeyGenerator> keyGens, String error) {
 		this.reader = reader;
 		this.keyGenerators = keyGens;
 		this.error = error;
@@ -67,7 +67,7 @@ public class ModuleBuildReader extends Reader {
 	 * @param reader A {@link Reader} to the build content
 	 */
 	public ModuleBuildReader(Reader reader) {
-		this(reader, null, false);
+		this(reader, null, null);
 	}
 
 	/**
@@ -98,6 +98,10 @@ public class ModuleBuildReader extends Reader {
 	 * @return The error flag for the build
 	 */
 	public boolean isError() {
+		return error != null;
+	}
+
+	public String getErrorMessage() {
 		return error;
 	}
 

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/DependencyList.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/DependencyList.java
@@ -372,7 +372,7 @@ public class DependencyList {
 
 		List<String> declaredDeps = aggr.getDependencies().getDelcaredDependencies(name);
 		if (traceLogging) {
-			log.finest("declaredDeps = " + declaredDeps); //$NON-NLS-1$
+			log.finest("declaredDeps for " + name + " = " + declaredDeps); //$NON-NLS-1$ //$NON-NLS-2$ $NON-NLS-2$
 		}
 		if (declaredDeps != null) {
 			for (String dep : declaredDeps) {

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/RequestUtil.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/RequestUtil.java
@@ -86,12 +86,10 @@ public class RequestUtil {
 	 */
 	public static boolean isRequireExpLogging(HttpServletRequest request) {
 		boolean result = false;
-		if (isExplodeRequires(request) ) {
-			IAggregator aggr = (IAggregator)request.getAttribute(IAggregator.AGGREGATOR_REQATTRNAME);
-			IOptions options = aggr.getOptions();
-			if (options.isDebugMode() || options.isDevelopmentMode()) {
-				result = TypeUtil.asBoolean(request.getAttribute(IHttpTransport.EXPANDREQLOGGING_REQATTRNAME));
-			}
+		IAggregator aggr = (IAggregator)request.getAttribute(IAggregator.AGGREGATOR_REQATTRNAME);
+		IOptions options = aggr.getOptions();
+		if (options.isDebugMode() || options.isDevelopmentMode()) {
+			result = TypeUtil.asBoolean(request.getAttribute(IHttpTransport.EXPANDREQLOGGING_REQATTRNAME));
 		}
 		return result;
 	}

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerBuilderTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerBuilderTest.java
@@ -721,7 +721,7 @@ public class LayerBuilderTest {
 				if (mbrKeygens != null) {
 					mbrKeygen = mbrKeygens.get(mid);
 				}
-				ModuleBuildReader mbr = new ModuleBuildReader(new StringReader(content.get(mid)), mbrKeygen, false);
+				ModuleBuildReader mbr = new ModuleBuildReader(new StringReader(content.get(mid)), mbrKeygen, null);
 				ModuleBuildFuture future = new ModuleBuildFuture(
 						new ModuleImpl(mid, entry.getModule().getURI()),
 						new CompletedFuture<ModuleBuildReader>(mbr),

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerTest.java
@@ -18,6 +18,7 @@ package com.ibm.jaggr.core.impl.layer;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
@@ -448,7 +449,8 @@ public class LayerTest extends EasyMock {
 		.append("\\\"p1/b\\\":function\\(\\)\\{.*?\\},")
 		.append("\\\"p1/c\\\":function\\(\\)\\{.*?\\},")
 		.append("\\\"p1/noexist\\\":function\\(\\)\\{.*?Module not found: .*?\\}")
-		.append("\\}\\}\\);require\\(\\{cache:\\{\\}\\}\\);require\\(\\[\\\"p1/a\\\"\\]\\);").toString());
+		.append("\\}\\}\\);require\\(\\{cache:\\{\\}\\}\\);require\\(\\[\\\"p1/a\\\"\\]\\);")
+		.append("\\s*console.error\\(\\\"Module not found:[^\\\"]*/p1/noexist.js\\\"\\);").toString());
 		assertTrue(p.matcher(result).find());
 
 		// Ensure that package name in require list get's translated to package main module
@@ -464,8 +466,10 @@ public class LayerTest extends EasyMock {
 		p = Pattern.compile(new StringBuffer()
 		.append("require\\(\\{cache:\\{")
 		.append("\\\"foo/main\\\":function\\(\\)\\{.*?Module not found: .*?\\}")
-		.append("\\}\\}\\);require\\(\\{cache:\\{\\}\\}\\);require\\(\\[\\\"foo/main\\\"\\]\\);").toString());
+		.append("\\}\\}\\);require\\(\\{cache:\\{\\}\\}\\);require\\(\\[\\\"foo/main\\\"\\]\\);")
+		.append("\\s*console.error\\(\\\"Module not found:[^\\\"]*/foo/main.js\\\"\\);").toString());
 		assertTrue(p.matcher(result).find());
+
 	}
 
 	/**

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilderTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilderTest.java
@@ -326,8 +326,9 @@ public class JavaScriptModuleBuilderTest extends EasyMock {
 		CopyUtil.copy(reader, writer);
 		compiled = writer.toString();
 		System.out.println(compiled);
-		Assert.assertTrue(Pattern.compile("\\sconsole\\.error\\(\\\"Error compiling module:[^\"]*\\\"\\);\\s*\\/\\* Comment \\*\\/").matcher(compiled).find());
-		Assert.assertTrue(compiled.endsWith(TestUtils.err));
+		Assert.assertEquals(compiled, TestUtils.err);
+		Assert.assertTrue(future.get().isError());
+		Assert.assertNotNull(future.get().getErrorMessage());
 
 	}
 


### PR DESCRIPTION
When running in Debug or Development mode, JAGGR will add console.error() calls in the returned layer to display the text of server-side errors in the browser console.  For certain errors (e.g. ModuleNotFound), the JavaScript emitted by JAGGR to display the console messages was causing JavaScript syntax errors.  This occurred with text resources that were not found due to the differences in the way text resources are declared vs. javascript resources.  This pull request resolves these issues.
