### PR TITLE
Add support for includeRequireDeps and includeUndefinedFeatureDeps query args

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/IAggregator.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/IAggregator.java
@@ -23,6 +23,7 @@ import com.ibm.jaggr.core.config.IConfig;
 import com.ibm.jaggr.core.config.IConfigListener;
 import com.ibm.jaggr.core.deps.IDependencies;
 import com.ibm.jaggr.core.executors.IExecutors;
+import com.ibm.jaggr.core.impl.resource.NotFoundResource;
 import com.ibm.jaggr.core.layer.ILayerCache;
 import com.ibm.jaggr.core.module.IModule;
 import com.ibm.jaggr.core.module.IModuleCache;
@@ -31,6 +32,8 @@ import com.ibm.jaggr.core.options.IOptions;
 import com.ibm.jaggr.core.resource.IResource;
 import com.ibm.jaggr.core.resource.IResourceFactory;
 import com.ibm.jaggr.core.transport.IHttpTransport;
+
+import org.apache.commons.lang3.mutable.Mutable;
 
 import java.io.File;
 import java.io.IOException;
@@ -124,27 +127,23 @@ public interface IAggregator {
 	public IHttpTransport getTransport();
 
 	/**
-	 * Returns the resource factory for the specified URI, or null if no
-	 * resource factory can be found.
+	 * Returns the resource factory for the specified URI, or null if no resource factory can be
+	 * found.
 	 * <p>
-	 * The aggregator will select the factory from among the registered
-	 * {@link IResourceFactory} extensions by testing the provided {@code uri}
-	 * against the scheme attribute of each of the registered resource factories
-	 * as follows:
+	 * The aggregator will select the factory from among the registered {@link IResourceFactory}
+	 * extensions by testing the provided {@code uri} against the scheme attribute of each of the
+	 * registered resource factories as follows:
 	 * <p>
-	 * Iterate through the registered resource factory extensions looking for
-	 * extensions that specify a <code>scheme</code> attribute matching the
-	 * scheme of <code>uri</code> or a <code>scheme</code> attribute of
-	 * <code>*</code>. For each matching extension, call the
-	 * {@link IResourceFactory#handles(URI)} method and if the method returns
-	 * true, then call the {@link IResourceFactory#newResource(URI)} method to
-	 * create the new resource.
+	 * Iterate through the registered resource factory extensions looking for extensions that
+	 * specify a <code>scheme</code> attribute matching the scheme of <code>uri</code> or a
+	 * <code>scheme</code> attribute of <code>*</code>. For each matching extension, call the
+	 * {@link IResourceFactory#handles(URI)} method and if the method returns true, then call the
+	 * {@link IResourceFactory#newResource(URI)} method to create the new resource.
 	 * <p>
-	 * The iteration order of the resource factories is determined by the order
-	 * that <code>resourcefactories</code> init-params are declared within the
-	 * <code>servlet</code> element defining the aggregator servlet, the order
-	 * that the <code>factory</code> elements are declared in the resource
-	 * factory extensions within the plugin.xml{s}, and on the insertion
+	 * The iteration order of the resource factories is determined by the order that
+	 * <code>resourcefactories</code> init-params are declared within the <code>servlet</code>
+	 * element defining the aggregator servlet, the order that the <code>factory</code> elements are
+	 * declared in the resource factory extensions within the plugin.xml{s}, and on the insertion
 	 * positions of extensions registered programatically using
 	 * {@link IExtensionRegistrar#registerExtension}.
 	 * <p>
@@ -153,24 +152,26 @@ public interface IAggregator {
 	 * <p>
 	 * If a satisfactory resource factory cannot be found, then null is returned.
 	 *
-	 * @param uri
-	 *            The URI for the resource
+	 * @param uri (Input/Output)
+	 *            A mutable reference to the input uri which may be modified to reference a
+	 *            different uri for the same resource if the uri needs to be transformed in order to
+	 *            match to a resource factory (e.g. a relative uri transformed into an absolute
+	 *            uri).
 	 * @return The resource factory for the specified URI, or null
 	 */
-	public IResourceFactory getResourceFactory(URI uri);
+	public IResourceFactory getResourceFactory(Mutable<URI> uri);
 
 	/**
 	 * Returns a new {@link IResource} for the specified URI. The aggregator
 	 * will create the new resource using the resource factory obtained by
-	 * calling {@link #getResourceFactory(URI)}.
+	 * calling {@link #getResourceFactory(Mutable)}.
 	 * <p>
-	 * If {@link #getResourceFactory(URI)} returns null, then the unchecked
-	 * {@link UnsupportedOperationException} is thrown.
+	 * This method may return an instance of {@link NotFoundResource} if a resource factory
+	 * for the URI cannot be found.
 	 *
 	 * @param uri
 	 *            The URI for the resource
 	 * @return The newly created resource object.
-	 * @throws UnsupportedOperationException
 	 */
 	public IResource newResource(URI uri);
 

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/IAggregator.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/IAggregator.java
@@ -128,8 +128,6 @@ public interface IAggregator {
 	public IHttpTransport getTransport();
 
 	/**
-	 * Returns the resource factory for the specified URI, or null if no resource factory can be
-	 * found.
 	 * Command provider function for setting forced errors in development mode.
 	 *
 	 * @param forceError
@@ -141,7 +139,7 @@ public interface IAggregator {
 	public String setForceError(String forceError);
 
 	/**
-	 * Returns a new {@link IResource} for the specified URI. The aggregator
+	 * Returns a new {@link IResourceFactory} for the specified URI. The aggregator
 	 * will create the new resource using one of the registered resource
 	 * factories.
 	 * <p>

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/IAggregator.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/IAggregator.java
@@ -123,12 +123,9 @@ public interface IAggregator {
 	 */
 	public IHttpTransport getTransport();
 
-	public IResourceFactory getResourceFactory(URI uri);
-
 	/**
-	 * Returns a new {@link IResource} for the specified URI. The aggregator
-	 * will create the new resource using one of the registered resource
-	 * factories.
+	 * Returns the resource factory for the specified URI, or null if no
+	 * resource factory can be found.
 	 * <p>
 	 * The aggregator will select the factory from among the registered
 	 * {@link IResourceFactory} extensions by testing the provided {@code uri}
@@ -151,15 +148,29 @@ public interface IAggregator {
 	 * positions of extensions registered programatically using
 	 * {@link IExtensionRegistrar#registerExtension}.
 	 * <p>
-	 * The registered resource factory extension may be obtained by calling
+	 * The registered resource factory extensions may be obtained by calling
 	 * {@link IAggregator#getExtensions(String)};
 	 * <p>
-	 * If a satisfactory resource factory cannot be found, then the unchecked
+	 * If a satisfactory resource factory cannot be found, then null is returned.
+	 *
+	 * @param uri
+	 *            The URI for the resource
+	 * @return The resource factory for the specified URI, or null
+	 */
+	public IResourceFactory getResourceFactory(URI uri);
+
+	/**
+	 * Returns a new {@link IResource} for the specified URI. The aggregator
+	 * will create the new resource using the resource factory obtained by
+	 * calling {@link #getResourceFactory(URI)}.
+	 * <p>
+	 * If {@link #getResourceFactory(URI)} returns null, then the unchecked
 	 * {@link UnsupportedOperationException} is thrown.
 	 *
 	 * @param uri
 	 *            The URI for the resource
 	 * @return The newly created resource object.
+	 * @throws UnsupportedOperationException
 	 */
 	public IResource newResource(URI uri);
 

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/config/IConfig.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/config/IConfig.java
@@ -141,6 +141,10 @@ public interface IConfig {
 	public static final String CACHEBUST_CONFIGPARAM = "cacheBust"; //$NON-NLS-1$
 
 	/**
+	 * Static constant specifying the name of the {@code has} config property
+	 */
+	public static final String HAS_CONFIGPARAM = "has";  //$NON-NLS-1$
+	/**
 	 * Static constant specifying the name of the {@code textPluginDelegators}
 	 * config param.
 	 */
@@ -344,6 +348,23 @@ public interface IConfig {
 	 * @return The list of loader plugins that delegate to the javascript module loader.
 	 */
 	public Set<String> getJsPluginDelegators();
+
+	/**
+	 * Returns the default features specified using the {@link #HAS_CONFIGPARAM} config param. These
+	 * are default values for features that are overridden by any features defined in the request.
+	 * <p>
+	 * The default features are specified as a property map of name/value pairs. If the value of a
+	 * property is a JavaScript function, then the function is invoked at the time this method is
+	 * called to evalute the value of the feature. The function takes one formal parameter which is
+	 * the request URL, and the returned value will be coerced to a boolean before being assigned as
+	 * the value of the feature.
+	 *
+	 * @param url
+	 *            the request URL, or null.
+	 *
+	 * @return The default features.
+	 */
+	public Features getDefaultFeatures(String url);
 
 	/**
 	 * Returns the raw config data after the config has been modified by any {@link IConfigModifier}

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/deps/IDependencies.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/deps/IDependencies.java
@@ -72,6 +72,24 @@ public interface IDependencies {
 			throws ProcessingDependenciesException;
 
 	/**
+	 * Returns the list of modules specified in the dependency lists of any require calls contained
+	 * within the specified module. If the specified module does not contain any require calls, then
+	 * an empty list is returned.
+	 * <p>
+	 * Note that no attempt is made to determine if the require call will ever be executed by the
+	 * client by looking for dead code, etc. Any require calls that appear within the module will be
+	 * used in collecting require dependencies.
+	 *
+	 * @param mid
+	 *            The module id
+	 * @return An unmodifiable list of require call dependencies, or null if the specified module
+	 *         was not found when the dependencies were processed.
+	 * @throws ProcessingDependenciesException
+	 */
+	List<String> getRequireDependencies(String mid)
+			throws ProcessingDependenciesException;
+
+	/**
 	 * Returns the list of dependent features for the specified module. This
 	 * includes features specified as string literals in has() function calls,
 	 * as well as features specified using a has! loader plugin in require and

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/AbstractAggregatorImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/AbstractAggregatorImpl.java
@@ -45,6 +45,7 @@ import com.ibm.jaggr.core.impl.config.ConfigImpl;
 import com.ibm.jaggr.core.impl.deps.DependenciesImpl;
 import com.ibm.jaggr.core.impl.layer.LayerImpl;
 import com.ibm.jaggr.core.impl.module.ModuleImpl;
+import com.ibm.jaggr.core.impl.resource.NotFoundResource;
 import com.ibm.jaggr.core.layer.ILayer;
 import com.ibm.jaggr.core.layer.ILayerCache;
 import com.ibm.jaggr.core.layer.ILayerListener;
@@ -65,7 +66,9 @@ import com.ibm.jaggr.core.util.StringUtil;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.mutable.Mutable;
 import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.commons.lang3.mutable.MutableObject;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -620,16 +623,17 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IAgg
 	}
 
 	/* (non-Javadoc)
-	 * @see com.ibm.jaggr.core.IAggregator#getResourceFactory(java.net.URI)
+	 * @see com.ibm.jaggr.core.IAggregator#getResourceFactory(org.apache.commons.lang3.mutable.Mutable)
 	 */
 	@Override
-	public IResourceFactory getResourceFactory(URI uri) {
+	public IResourceFactory getResourceFactory(Mutable<URI> uriRef) {
 		final String sourceMethod = "getResourceFactory"; //$NON-NLS-1$
 		boolean isTraceLogging = log.isLoggable(Level.FINER);
 		if (isTraceLogging) {
-			log.entering(AbstractAggregatorImpl.class.getName(), sourceMethod, new Object[]{uri});
+			log.entering(AbstractAggregatorImpl.class.getName(), sourceMethod, new Object[]{uriRef});
 		}
 		IResourceFactory factory = null;
+		URI uri = uriRef.getValue();
 		if (!uri.isAbsolute()) {
 			if (uri.getPath().startsWith("/")) { //$NON-NLS-1$
 				// server relative URI not supported for server resources.  Probably meant
@@ -642,6 +646,10 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IAgg
 			// URI is not absolute, so make it absolute.
 			try {
 				uri = getPlatformServices().getAppContextURI().resolve(uri.getPath());
+				if (isTraceLogging) {
+					log.logp(Level.FINER, AbstractAggregatorImpl.class.getName(), sourceMethod,
+							"URI " + uriRef.getValue().toString() + " transformed to " + uri.toString()); //$NON-NLS-1$ //$NON-NLS-2$
+				}
 			} catch (URISyntaxException e) {
 				throw new IllegalArgumentException(e);
 			}
@@ -659,6 +667,9 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IAgg
 				}
 			}
 		}
+		if (factory != null) {
+			uriRef.setValue(uri);
+		}
 		if (isTraceLogging) {
 			log.exiting(AbstractAggregatorImpl.class.getName(), sourceMethod, factory);
 		}
@@ -675,14 +686,14 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IAgg
 		if (isTraceLogging) {
 			log.entering(AbstractAggregatorImpl.class.getName(), sourceMethod, new Object[]{uri});
 		}
-		IResourceFactory factory = getResourceFactory(uri);
-		if (factory == null) {
-			throw new UnsupportedOperationException(
-					"No resource factory for " + uri.toString() //$NON-NLS-1$
-					);
+		Mutable<URI> uriRef = new MutableObject<URI>(uri);
+		IResourceFactory factory = getResourceFactory(uriRef);
+		IResource result;
+		if (factory != null) {
+			result = factory.newResource(uriRef.getValue());
+		} else {
+			result = new NotFoundResource(uriRef.getValue());
 		}
-
-		IResource result = factory.newResource(uri);
 		if (isTraceLogging) {
 			log.exiting(AbstractAggregatorImpl.class.getName(), sourceMethod, result);
 		}

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/deps/DepTreeBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/deps/DepTreeBuilder.java
@@ -139,7 +139,7 @@ final class DepTreeBuilder implements Callable<DepTreeBuilder.Result> {
 					String extension = idx == -1 ? "" : resname.substring(idx+1); //$NON-NLS-1$
 					if (nonJSExtensions.contains(extension)) {
 						DepTreeNode node = root.createOrGet(pathname, resource.getURI());
-						node.setDependencies(null,  null,  resource.lastModified(), resource.lastModified());
+						node.setDependencies(null, null,  null,  resource.lastModified(), resource.lastModified());
 					}
 					return false;
 				}
@@ -153,7 +153,10 @@ final class DepTreeBuilder implements Callable<DepTreeBuilder.Result> {
 					cachedNode = (pathname.length() > 0) ? cached.getDescendent(pathname) : cached;
 				}
 				if (cachedNode != null) {
-					node.setDependencies(cachedNode.getDepArray(), cachedNode.getDependentFeatures(),
+					node.setDependencies(
+							cachedNode.getDefineDepArray(),
+							cachedNode.getRequireDepArray(),
+							cachedNode.getDependentFeatures(),
 							cachedNode.lastModified(), cachedNode.lastModifiedDep());
 				}
 				/*

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/deps/DependenciesImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/deps/DependenciesImpl.java
@@ -339,6 +339,32 @@ public class DependenciesImpl implements IDependencies, IConfigListener, IOption
 		return result;
 	}
 
+	/* (non-Javadoc)
+	 * @see com.ibm.jaggr.core.deps.IDependencies#getRequireDependencies(java.lang.String)
+	 */
+	@Override
+	public List<String> getRequireDependencies(String mid) throws ProcessingDependenciesException {
+		List<String> result = null;
+		try {
+			getReadLock();
+			try {
+				DepTreeNode.DependencyInfo depInfo = depMap.get(mid);
+				if (depInfo != null) {
+					result = depInfo.getRequireDependencies();
+				}
+			} finally {
+				releaseReadLock();
+			}
+		} catch (InterruptedException e) {
+			if (log.isLoggable(Level.SEVERE)) {
+				log.log(Level.SEVERE, e.getMessage(), e);
+			}
+		}
+		return result;
+	}
+
+
+
 	@Override
 	public URI getURI(String mid) throws ProcessingDependenciesException {
 		URI result = null;

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerImpl.java
@@ -42,6 +42,8 @@ import com.ibm.jaggr.core.util.Features;
 import com.ibm.jaggr.core.util.RequestUtil;
 import com.ibm.jaggr.core.util.TypeUtil;
 
+import org.apache.commons.lang3.mutable.MutableObject;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -803,7 +805,7 @@ public class LayerImpl implements ILayer {
 							if (prefixes == null ||		// condition is TRUE
 									RequestUtil.isIncludeUndefinedFeatureDeps(request) && !prefixes.isEmpty()) {
 								IModule module = newModule(request, name);
-								if (!explicit.containsKey(name) && aggr.getResourceFactory(module.getURI()) == null) {
+								if (!explicit.containsKey(name) && aggr.getResourceFactory(new MutableObject<URI>(module.getURI())) == null) {
 									// Module is server-expanded and it's not a server resource type that we
 									// know how handle, so just ignore it.
 									if (isTraceLogging) {

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerImpl.java
@@ -23,6 +23,7 @@ import com.ibm.jaggr.core.cachekeygenerator.AbstractCacheKeyGenerator;
 import com.ibm.jaggr.core.cachekeygenerator.FeatureSetCacheKeyGenerator;
 import com.ibm.jaggr.core.cachekeygenerator.ICacheKeyGenerator;
 import com.ibm.jaggr.core.cachekeygenerator.KeyGenUtil;
+import com.ibm.jaggr.core.deps.ModuleDepInfo;
 import com.ibm.jaggr.core.deps.ModuleDeps;
 import com.ibm.jaggr.core.layer.ILayer;
 import com.ibm.jaggr.core.layer.ILayerCache;
@@ -50,6 +51,7 @@ import java.io.StringReader;
 import java.io.Writer;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -92,6 +94,9 @@ public class LayerImpl implements ILayer {
 
 	static final String DEPSOURCE_REQDEPS = " URL - deps"; //$NON-NLS-1$
 	static final String DEPSOURCE_REQPRELOADS = "URL - preloads"; //$NON-NLS-1$
+	static final String DEPSOURCE_EXCLUDES = "URL - excludes";  //$NON-NLS-1$
+
+	static final Pattern nlsPat = Pattern.compile("^.*(^|\\/)nls(\\/|$)"); //$NON-NLS-1$
 
 	protected static final List<ICacheKeyGenerator> s_layerCacheKeyGenerators  = Collections.unmodifiableList(Arrays.asList(new ICacheKeyGenerator[]{
 			new AbstractCacheKeyGenerator() {
@@ -103,7 +108,9 @@ public class LayerImpl implements ILayer {
 					boolean showFilenames =  TypeUtil.asBoolean(request.getAttribute(IHttpTransport.SHOWFILENAMES_REQATTRNAME));
 					return new StringBuffer(eyeCatcher).append(":") //$NON-NLS-1$
 							.append(RequestUtil.isGzipEncoding(request) ? "1" : "0").append(":") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-							.append(showFilenames ? "1" : "0").toString(); //$NON-NLS-1$ //$NON-NLS-2$
+							.append(showFilenames ? "1" : "0").append(":") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+							.append(RequestUtil.isIncludeRequireDeps(request) ? "1" : "0").append(":") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+							.append(RequestUtil.isIncludeUndefinedFeatureDeps(request) ? "1" : "0").toString(); //$NON-NLS-1$ //$NON-NLS-2$
 
 				}
 				@Override
@@ -698,81 +705,125 @@ public class LayerImpl implements ILayer {
 				Features features = (Features)request.getAttribute(IHttpTransport.FEATUREMAP_REQATTRNAME);
 				Set<String> dependentFeatures = new HashSet<String>();
 				List<String> names = requestedModuleNames.getModules();
-				boolean isScripts = false;
-				if (names.isEmpty()) {
+				if (!names.isEmpty()) {
+					for (String name : names) {
+						if (name != null) {
+							name = aggr.getConfig().resolve(name, features, dependentFeatures, null,
+									false,	// Don't resolve aliases when locating modules requested by the loader
+									//  because the loader should have already done alias resolution and
+									//  we can't rename a requested module.
+									false	// Loader doesn't request modules with has! plugin
+									);
+							result.add(new ModuleList.ModuleListEntry(newModule(request, name), ModuleSpecifier.MODULES));
+						}
+					}
+				} else {
+					boolean includeRequireDeps = RequestUtil.isIncludeRequireDeps(request);
 					names = requestedModuleNames.getScripts();
-					isScripts = true;
-				}
-				for (String name : names) {
-					if (name != null) {
-						name = aggr.getConfig().resolve(name, features, dependentFeatures, null,
-								false,	// Don't resolve aliases when locating modules requested by the loader
-								//  because the loader should have already done alias resolution and
-								//  we can't rename a requested module.
-								true	// Resolve has! loader plugin
-								);
-						result.add(new ModuleList.ModuleListEntry(newModule(request, name), isScripts ? ModuleSpecifier.SCRIPTS : ModuleSpecifier.MODULES));
+					for (String name : names) {
+						if (name != null) {
+							name = aggr.getConfig().resolve(name, features, dependentFeatures, null,
+									false,	// Don't resolve aliases when locating modules requested by the loader
+									//  because the loader should have already done alias resolution and
+									//  we can't rename a requested module.
+									true	// Resolve has! loader plugin
+									);
+							result.add(new ModuleList.ModuleListEntry(newModule(request, name), ModuleSpecifier.SCRIPTS));
+						}
 					}
-				}
-				// See if we need to add required modules.
-				DependencyList requiredList = null, preloadList = null;
-				ModuleDeps combined = new ModuleDeps();
-				if (!requestedModuleNames.getDeps().isEmpty()) {
+					// See if we need to add required modules.
+					DependencyList requiredList = null, preloadList = null, excludeList = null;
+					ModuleDeps combined = new ModuleDeps(), explicit = new ModuleDeps();
+					if (!requestedModuleNames.getDeps().isEmpty()) {
 
-					// If there's a required module, then add it and its dependencies
-					// to the module list.
-					requiredList = new DependencyList(
-							DEPSOURCE_REQDEPS,
-							requestedModuleNames.getDeps(),
-							aggr,
-							features,
-							true, 	// resolveAliases
-							RequestUtil.isRequireExpLogging(request)	// include details
-							);
-					dependentFeatures.addAll(requiredList.getDependentFeatures());
-
-					result.setRequiredModules(requiredList.getExplicitDeps().getModuleIds());
-
-					combined.addAll(requiredList.getExplicitDeps());
-					combined.addAll(requiredList.getExpandedDeps());
-				}
-				if (!requestedModuleNames.getPreloads().isEmpty()) {
-					preloadList = new DependencyList(
-							DEPSOURCE_REQPRELOADS,
-							requestedModuleNames.getPreloads(),
-							aggr,
-							features,
-							true, 	// resolveAliases
-							RequestUtil.isRequireExpLogging(request)	// include details
-							);
-					dependentFeatures.addAll(preloadList.getDependentFeatures());
-
-					combined.addAll(preloadList.getExplicitDeps());
-					combined.addAll(preloadList.getExpandedDeps());
-				}
-				for (String name : combined.getModuleIds()) {
-					if (aggr.getTransport().isServerExpandable(request, name)) {
-						result.add(
-								new ModuleList.ModuleListEntry(
-										newModule(request, name),
-										ModuleSpecifier.LAYER
-										)
+						// If there's a required module, then add it and its dependencies
+						// to the module list.
+						requiredList = new DependencyList(
+								DEPSOURCE_REQDEPS,
+								requestedModuleNames.getDeps(),
+								aggr,
+								features,
+								true, 	// resolveAliases
+								RequestUtil.isRequireExpLogging(request),	// include details
+								includeRequireDeps
 								);
-					}
-				}
-				if ((requiredList != null || preloadList != null) && RequestUtil.isRequireExpLogging(request)) {
-					ModuleDeps explicit = new ModuleDeps(), expanded = new ModuleDeps();
-					if (requiredList != null) {
+						dependentFeatures.addAll(requiredList.getDependentFeatures());
+
+						result.setRequiredModules(requiredList.getExplicitDeps().getModuleIds());
+
 						explicit.addAll(requiredList.getExplicitDeps());
-						expanded.addAll(requiredList.getExpandedDeps());
+						combined.addAll(requiredList.getExplicitDeps());
+						combined.addAll(requiredList.getExpandedDeps());
 					}
-					if (preloadList != null) {
+					if (!requestedModuleNames.getPreloads().isEmpty()) {
+						preloadList = new DependencyList(
+								DEPSOURCE_REQPRELOADS,
+								requestedModuleNames.getPreloads(),
+								aggr,
+								features,
+								true, 	// resolveAliases
+								RequestUtil.isRequireExpLogging(request),	// include details
+								includeRequireDeps
+								);
+						dependentFeatures.addAll(preloadList.getDependentFeatures());
+
 						explicit.addAll(preloadList.getExplicitDeps());
-						expanded.addAll(preloadList.getExpandedDeps());
+						combined.addAll(preloadList.getExplicitDeps());
+						combined.addAll(preloadList.getExpandedDeps());
 					}
-					request.setAttribute(BOOTLAYERDEPS_PROPNAME, new DependencyList(explicit, expanded, dependentFeatures));
+					if (!requestedModuleNames.getExcludes().isEmpty()) {
+						excludeList = new DependencyList(
+								DEPSOURCE_EXCLUDES,
+								requestedModuleNames.getExcludes(),
+								aggr,
+								features,
+								true, 	// resolveAliases
+								RequestUtil.isRequireExpLogging(request),	// include details
+								false
+								);
+						dependentFeatures.addAll(excludeList.getDependentFeatures());
+						combined.subtractAll(excludeList.getExplicitDeps());
+						combined.subtractAll(excludeList.getExpandedDeps());
+					}
+					boolean isAssertNoNLS = RequestUtil.isAssertNoNLS(request);
+					for (Map.Entry<String, ModuleDepInfo> entry : combined.entrySet()) {
+						String name = entry.getKey();
+						if (isAssertNoNLS && nlsPat.matcher(name).find()) {
+							throw new BadRequestException("AssertNoNLS: " + name); //$NON-NLS-1$
+						}
+						ModuleDepInfo info = entry.getValue();
+						if (aggr.getTransport().isServerExpandable(request, name)) {
+							Collection<String> prefixes = info.getHasPluginPrefixes();
+							if (prefixes == null ||		// condition is TRUE
+									RequestUtil.isIncludeUndefinedFeatureDeps(request) && !prefixes.isEmpty()) {
+								result.add(
+										new ModuleList.ModuleListEntry(
+												newModule(request, name),
+												ModuleSpecifier.LAYER,
+												!explicit.containsKey(name)
+												)
+										);
+							}
+						}
+					}
+					if ((requiredList != null || preloadList != null) && RequestUtil.isRequireExpLogging(request)) {
+						ModuleDeps expanded = new ModuleDeps();
+						if (requiredList != null) {
+							expanded.addAll(requiredList.getExpandedDeps());
+						}
+						if (preloadList != null) {
+							expanded.addAll(preloadList.getExpandedDeps());
+						}
+						if (excludeList != null) {
+							explicit.subtractAll(excludeList.getExplicitDeps());
+							explicit.subtractAll(excludeList.getExpandedDeps());
+							expanded.subtractAll(excludeList.getExplicitDeps());
+							expanded.subtractAll(excludeList.getExpandedDeps());
+						}
+						request.setAttribute(BOOTLAYERDEPS_PROPNAME, new DependencyList(explicit, expanded, dependentFeatures));
+					}
+					result.setDependenentFeatures(dependentFeatures);
 				}
-				result.setDependenentFeatures(dependentFeatures);
 			}
 			if (result.isEmpty()) {
 				throw new BadRequestException(request.getQueryString());

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/ModuleList.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/ModuleList.java
@@ -34,7 +34,10 @@ class ModuleList extends LinkedList<ModuleList.ModuleListEntry> {
 	static class ModuleListEntry {
 		final IModule module;
 		final ModuleSpecifier source;
-		ModuleListEntry(IModule module, ModuleSpecifier source) {
+		final boolean isServerExpanded;
+		ModuleListEntry(IModule module, ModuleSpecifier source) { this(module, source, false); }
+		ModuleListEntry(IModule module, ModuleSpecifier source, boolean isServerExpanded) {
+			this.isServerExpanded = isServerExpanded;
 			this.module = module;
 			this.source = source;
 		}
@@ -43,6 +46,9 @@ class ModuleList extends LinkedList<ModuleList.ModuleListEntry> {
 		}
 		IModule getModule() {
 			return module;
+		}
+		boolean isServerExpanded() {
+			return isServerExpanded;
 		}
 	}
 	private Set<String> dependentFeatures = null;

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/i18n/I18nModuleBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/i18n/I18nModuleBuilder.java
@@ -121,7 +121,15 @@ extends JavaScriptModuleBuilder {
 			@SuppressWarnings("unchecked")
 			Collection<String> locales = (Collection<String>)request.getAttribute(IHttpTransport.REQUESTEDLOCALES_REQATTRNAME);
 			String bundleName = m.group(4);
+
 			if (locales != null && !locales.isEmpty()) {
+				// check for special case locales="*" meaning all available locales.
+				for (String locale : locales) {
+					if ("*".equals(locale)) { //$NON-NLS-1$
+						locales = new HashSet<String>(availableLocales);
+						break;
+					}
+				}
 				for (String locale : locales) {
 					processLocale(resource, result, m, availableLocales, added,
 							aggr, bundleName, locale);

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/transport/IHttpTransport.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/transport/IHttpTransport.java
@@ -103,13 +103,6 @@ public interface IHttpTransport extends IExtensionInitializer {
 
 	/**
 	 * Name of the request attribute specifying the Boolean flag indicating if
-	 * has! plugin branching should be performed during require list expansion.
-	 */
-	public static final String HASPLUGINBRANCHING_REQATTRNAME = IHttpTransport.class
-			.getName() + ".HasPluginBranching"; //$NON-NLS-1$
-
-	/**
-	 * Name of the request attribute specifying the Boolean flag indicating if
 	 * the response should be annotated with comments indicating the names of
 	 * the module source files.
 	 */
@@ -171,6 +164,52 @@ public interface IHttpTransport extends IExtensionInitializer {
 	 */
 	public static final String CONFIGVARNAME_REQATTRNAME = IHttpTransport.class
 			.getName() + ".ConfigVarName"; //$NON-NLS-1$
+
+	/**
+	 * Name of the request attribute specifying whether or not dependencies specified in require
+	 * calls that are contained within AMD modules should be expanded when performing server-side
+	 * expansion of dependent modules. Used only for application generated requests specifying the
+	 * <code>deps</code> and/or <code>preloads</code> request parameters.
+	 * <p>
+	 * This request attribute corresponds to the <code>includeRequireDeps</code> request parameter
+	 * and is set by the transport based on the value of the request parameter.
+	 */
+	public static final String INCLUDEREQUIREDEPS_REQATTRNAME = IHttpTransport.class
+			.getName() + ".IncludeRequireDeps";  //$NON-NLS-1$
+
+
+	/**
+	 * Name of the request attribute specifying whether or not dependencies specified using has!
+	 * loader plugin conditionals for undefined features (either in define or require dependencies)
+	 * should be included when performing server-side expansion of dependent modules. Used only for
+	 * application generated requests specifying the <code>deps</code> and/or <code>preloads</code>
+	 * request parameters.
+	 * <p>
+	 * If this attribute is true, then the modules specified by both branches of a has! plugin
+	 * conditional for an undefined feature will be added to the layer being built, along with both
+	 * of those modules' dependencies.
+	 * <p>
+	 * This request attribute corresponds to the <code>includeUndefinedFeatureDeps</code> request
+	 * parameter and is set by the transport based on the value of the request parameter.
+	 */
+	public static final String INCLUDEUNDEFINEDFEATUREDEPS_REQATTRNAME = IHttpTransport.class
+			.getName() + ".IncludeUndefinedFeatureDeps"; //$NON-NLS-1$
+
+
+	/**
+	 * Name of the request attribute specifying if the server should assert that the modules
+	 * specified by the <code>deps</code> and/or <code>preloads</code>
+	 * request parameters, plus their nested dependencies, include no nls modules.  This is
+	 * helpful for keeping nls resources out of the bootstrap layer in cases where code needs
+	 * to run on the client to determine the user's preferred locale.  If this options is
+	 * specified and the response would contain nls resources, then a 400 - Bad Request
+	 * response status is returned.
+	 * <p>
+	 * This request attribute corresponds to the <code>assertNoNLS</code> request
+	 * parameter and is set by the transport based on the value of the request parameter.
+	 */
+	public static final String ASSERTNONLS_REQATTRNAME = IHttpTransport.class
+			.getName() + "AssertNoNLS"; //$NON-NLS-1$
 
 	/**
 	 * Supported optimization levels. Module builders are not required to

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/transport/IRequestedModuleNames.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/transport/IRequestedModuleNames.java
@@ -45,9 +45,9 @@ public interface IRequestedModuleNames {
 
 	/**
 	 * Returns the list of modules specified by the <code>deps</code> request parameter. Deps are
-	 * specified in application generated requests to load a boot layer. Dep modules are included in
-	 * the boot layer and are automatically required by the loader. The name of this property was
-	 * chosen so as to mirror the <code>deps</code> AMD config property.
+	 * specified in application generated requests to load a server-expanded layer. Dep modules are
+	 * included in the layer and are automatically required by the loader. The name of this property
+	 * was chosen so as to mirror the <code>deps</code> AMD config property.
 	 *
 	 * @return the list of dep modules
 	 * @throws BadRequestException
@@ -56,8 +56,8 @@ public interface IRequestedModuleNames {
 
 	/**
 	 * Returns the list of modules specified by the <code>preloads</code> request parameter.
-	 * Preloads are specified in application generated requests to load a boot layer. Preload
-	 * modules are included in the boot layer but are not activated until required by the
+	 * Preloads are specified in application generated requests to load a server-expanded layer.
+	 * Preload modules are included in the layer but are not activated until required by the
 	 * application.
 	 *
 	 * @return the list of preload modules
@@ -68,15 +68,26 @@ public interface IRequestedModuleNames {
 	/**
 	 * Returns the list of script modules specified by the <code>scripts</code> request parameter.
 	 * Script modules are specified in application generated requests to load a boot layer. Script
-	 * modules are non-AMD modules that are included at the beginning of a boot layer. These
-	 * typically include the AMD loader config, the Aggregator loader config extension and the AMD
-	 * loader. It can also include any other non-AMD script files needed by the application, as long
-	 * as the file can be located using the AMD configuration.
+	 * modules are non-AMD modules that are included at the beginning of a layer. These typically
+	 * include the AMD loader config, the Aggregator loader config extension and the AMD loader. It
+	 * can also include any other non-AMD script files needed by the application, as long as the
+	 * file can be located using the AMD configuration.
 	 *
 	 * @return the list of script modules
 	 * @throws BadRequestException
 	 */
 	public List<String> getScripts() throws BadRequestException;
+
+	/**
+	 * Returns the list of modules specified by the <code>excludes</code> request parameter.
+	 * Excludes are specified in application generated requests to load a static layer.  The
+	 * excluded modules, and their expanded dependencies, will not be included in the aggregated
+	 * response.
+	 *
+	 * @return the list of excluded modules
+	 * @throws BadRequestException
+	 */
+	public List<String> getExcludes() throws BadRequestException;
 
 	/**
 	 * @return a (possibly encoded) string representation of the requested modules.

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/RequestUtil.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/RequestUtil.java
@@ -31,7 +31,7 @@ public class RequestUtil {
 	public static boolean isIgnoreCached(HttpServletRequest request) {
 		IAggregator aggr = (IAggregator)request.getAttribute(IAggregator.AGGREGATOR_REQATTRNAME);
 		IOptions options = aggr.getOptions();
-		return (options.isDevelopmentMode() || options.isDebugMode()) &&
+		return  options != null && (options.isDevelopmentMode() || options.isDebugMode()) &&
 				TypeUtil.asBoolean(request.getAttribute(IHttpTransport.NOCACHE_REQATTRNAME));
 
 	}
@@ -58,13 +58,16 @@ public class RequestUtil {
 	 * @return True if require list explosion should be performed.
 	 */
 	public static boolean isExplodeRequires(HttpServletRequest request) {
+		if (isIncludeRequireDeps(request)) {
+			// don't expand require deps if we're including them in the response.
+			return false;
+		}
 		boolean result = false;
 		IAggregator aggr = (IAggregator)request.getAttribute(IAggregator.AGGREGATOR_REQATTRNAME);
 		IOptions options = aggr.getOptions();
 		Boolean reqattr = TypeUtil.asBoolean(request.getAttribute(IHttpTransport.EXPANDREQUIRELISTS_REQATTRNAME));
 		result = (options == null || !options.isDisableRequireListExpansion())
-				&& reqattr != null && reqattr
-				&& aggr.getDependencies() != null;
+				&& reqattr != null && reqattr;
 		return result;
 	}
 
@@ -101,7 +104,34 @@ public class RequestUtil {
 	 * @return True if module names should be exported in the response
 	 */
 	public static boolean isExportModuleName(HttpServletRequest request) {
-		Boolean value = TypeUtil.asBoolean(request.getAttribute(IHttpTransport.EXPORTMODULENAMES_REQATTRNAME));
-		return value != null ? value : false;
+		return TypeUtil.asBoolean(request.getAttribute(IHttpTransport.EXPORTMODULENAMES_REQATTRNAME));
 	}
+
+	/**
+	 * @param request
+	 * @return True if require call dependencies should be included when expanding a modules's
+	 *         dependencies.
+	 */
+	public static boolean isIncludeRequireDeps(HttpServletRequest request) {
+		return TypeUtil.asBoolean(request.getAttribute(IHttpTransport.INCLUDEREQUIREDEPS_REQATTRNAME));
+	}
+
+	/**
+	 * @param request
+	 * @return True if both branches of a has! loader plugin expression for an undefined feature
+	 *         should be included when doing server-side expansion of module dependencies.
+	 */
+	public static boolean isIncludeUndefinedFeatureDeps(HttpServletRequest request) {
+		return TypeUtil.asBoolean(request.getAttribute(IHttpTransport.INCLUDEUNDEFINEDFEATUREDEPS_REQATTRNAME));
+	}
+
+	/**
+	 * @param request
+	 * @return True if an error response should be returned if the requested modules or their
+	 *         dependencies include nls modules.
+	 */
+	public static boolean isAssertNoNLS(HttpServletRequest request) {
+		return TypeUtil.asBoolean(request.getAttribute(IHttpTransport.ASSERTNONLS_REQATTRNAME));
+	}
+
 }

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/config/ConfigTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/config/ConfigTest.java
@@ -807,6 +807,25 @@ public class ConfigTest {
 	}
 
 	@Test
+	public void testGetDefaultFeatures() throws Exception {
+		String config = "{has:{foo:true, bar:false, fee:1, fie:0}}";
+		ConfigImpl cfg = new ConfigImpl(mockAggregator, tmpDir, config);
+		Features features = cfg.getDefaultFeatures(null);
+		Assert.assertTrue(features.isFeature("foo"));
+		Assert.assertTrue(features.isFeature("fee"));
+		Assert.assertTrue(features.contains("bar") && !features.isFeature("bar"));
+		Assert.assertTrue(features.contains("fie") && !features.isFeature("fie"));
+
+		config = "{has:{foo:function(url){return url.indexOf(\"foo=\") !== -1;}}}";
+		cfg = new ConfigImpl(mockAggregator, tmpDir, config);
+		features = cfg.getDefaultFeatures("http://server.com/?foo=1");
+		Assert.assertTrue(features.isFeature("foo"));
+
+		features = cfg.getDefaultFeatures("http://server.com/");
+		Assert.assertTrue(features.contains("foo") && !features.isFeature("foo"));
+	}
+
+	@Test
 	public void testResolve() throws Exception {
 		Features features = new Features();
 		Set<String> dependentFeatures = new HashSet<String>();

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/deps/DepTreeNodeTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/deps/DepTreeNodeTest.java
@@ -97,7 +97,7 @@ public class DepTreeNodeTest extends EasyMock {
 	public void testLastModified() {
 		DepTreeNode node = new DepTreeNode("foo", null);
 		assertEquals(node.lastModified(), -1);
-		node.setDependencies(new String[]{"dep1", "dep2"}, new String[0], 1234567890L, 0L);
+		node.setDependencies(new String[]{"dep1", "dep2"}, new String[0], new String[0], 1234567890L, 0L);
 		assertEquals(node.lastModified(), 1234567890L);
 	}
 
@@ -105,7 +105,7 @@ public class DepTreeNodeTest extends EasyMock {
 	public void testLastModifiedDep() {
 		DepTreeNode node = new DepTreeNode("foo", null);
 		assertEquals(node.lastModifiedDep(), -1);
-		node.setDependencies(new String[]{"dep1", "dep2"}, new String[0], 0L, 1234567890L);
+		node.setDependencies(new String[]{"dep1", "dep2"}, new String[0], new String[0], 0L, 1234567890L);
 		assertEquals(node.lastModifiedDep(), 1234567890L);
 	}
 
@@ -116,9 +116,9 @@ public class DepTreeNodeTest extends EasyMock {
 		DepTreeNode ab = new DepTreeNode("ab", null);
 		a.add(aa);
 		a.add(ab);
-		a.setDependencies(new String[]{"b", "c"}, new String[0], 1234567890L, 1234567890L);
-		aa.setDependencies(new String[]{"b", "c"}, new String[0], 1234567890L, 1234567890L);
-		ab.setDependencies(new String[]{"b", "c"}, new String[0], 1234567890L, 2000000000L);
+		a.setDependencies(new String[]{"b", "c"}, new String[0], new String[0], 1234567890L, 1234567890L);
+		aa.setDependencies(new String[]{"b", "c"}, new String[0], new String[0], 1234567890L, 1234567890L);
+		ab.setDependencies(new String[]{"b", "c"}, new String[0], new String[0], 1234567890L, 2000000000L);
 		assertEquals(a.lastModifiedDepTree(), 2000000000L);
 	}
 
@@ -144,11 +144,13 @@ public class DepTreeNodeTest extends EasyMock {
 	}
 
 	@Test
-	public void testGetDepArray() {
-		String[] deps = new String[] { "dep1", "dep2" };
+	public void testGetDepArrays() {
+		String[] defineDeps = new String[] { "dep1", "dep2" };
+		String[] requireDeps = new String[] { "req1", "req2" };
 		DepTreeNode node = new DepTreeNode("node", null);
-		node.setDependencies(deps, new String[0], 1234567890L, 1234567890L);
-		assert(Arrays.equals(node.getDepArray(), deps));
+		node.setDependencies(defineDeps, requireDeps, new String[0], 1234567890L, 1234567890L);
+		assert(Arrays.equals(node.getDefineDepArray(), defineDeps));
+		assert(Arrays.equals(node.getRequireDepArray(), requireDeps));
 	}
 
 	@Test
@@ -270,9 +272,9 @@ public class DepTreeNodeTest extends EasyMock {
 		root.createOrGet("a/b", null);
 		root.createOrGet("a/b/a", null);
 		root.createOrGet("a/b/b", URI.create("a/b/b"));
-		root.getDescendent("a/b").setDependencies(new String[]{"dep"}, new String[0], 0L, 0L);
-		root.getDescendent("c").setDependencies(new String[]{"dep"}, new String[0], 0L, 0L);
-		root.getDescendent("a/b/a").setDependencies(new String[]{"dep"}, new String[0], 0L, 0L);
+		root.getDescendent("a/b").setDependencies(new String[]{"dep"}, new String[0], new String[0], 0L, 0L);
+		root.getDescendent("c").setDependencies(new String[]{"dep"}, new String[0], new String[0], 0L, 0L);
+		root.getDescendent("a/b/a").setDependencies(new String[]{"dep"}, new String[0], new String[0], 0L, 0L);
 		root.prune();
 		assertNotNull(root.getChild("a"));
 		assertNotNull(root.getChild("c"));
@@ -287,9 +289,11 @@ public class DepTreeNodeTest extends EasyMock {
 	@Test
 	public void testSetDependencies() {
 		DepTreeNode root = new DepTreeNode("root", null);
-		String[] deps = new String[]{"dep1", "dep2"};
-		root.setDependencies(deps, new String[0], 0L, 1L);
-		assert(Arrays.equals(root.getDepArray(), deps));
+		String[] defineDeps = new String[]{"dep1", "dep2"};
+		String[] requireDeps = new String[]{"req1", "req2"};
+		root.setDependencies(defineDeps, requireDeps, new String[0], 0L, 1L);
+		assert(Arrays.equals(root.getDefineDepArray(), defineDeps));
+		assert(Arrays.equals(root.getRequireDepArray(), requireDeps));
 		assertEquals(root.lastModified(), 0L);
 		assertEquals(root.lastModifiedDep(), 1L);
 	}
@@ -297,41 +301,45 @@ public class DepTreeNodeTest extends EasyMock {
 	@Test
 	public void testToString() {
 		DepTreeNode root = new DepTreeNode("root", null);
-		root.setDependencies(new String[] {"a", "b"}, new String[0], 0L, 1L);
+		root.setDependencies(new String[] {"a", "b"}, new String[0], new String[0], 0L, 1L);
 		root.createOrGet("child", null);
 		String str = root.toString();
-		assertEquals(str, "root = [a, b]\n");
+		assertEquals(str, "root = define:[a, b], require:[]\n");
 	}
 
 	@Test
 	public void testToStringTree() {
 		DepTreeNode root = new DepTreeNode("root", null);
-		root.setDependencies(new String[] {"a", "b"}, new String[0], 0L, 1L);
+		root.setDependencies(new String[] {"a", "b"}, new String[0], new String[0], 0L, 1L);
 		DepTreeNode child = root.createOrGet("child", null);
-		child.setDependencies(new String[] {"b", "c"}, new String[0], 0L, 1L);
+		child.setDependencies(new String[] {"b", "c"}, new String[0], new String[0], 0L, 1L);
 		String str = root.toStringTree();
-		assertEquals("root = [a, b]\nroot/child = [b, c]\n", str);
+		assertEquals("root = define:[a, b], require:[]\nroot/child = define:[b, c], require:[]\n", str);
 	}
 
 	@Test
 	public void testClone() {
 		DepTreeNode root = new DepTreeNode("root", null);
 		DepTreeNode child = root.createOrGet("child", null);
-		root.setDependencies(new String[]{"a", "b"}, new String[0], 0L, 1L);
-		child.setDependencies(new String[]{"c", "d"}, new String[0], 0L, 1L);
+		root.setDependencies(new String[]{"a", "b"}, new String[]{"c", "d"}, new String[0], 0L, 1L);
+		child.setDependencies(new String[]{"e", "f"}, new String[]{"g", "h"}, new String[0], 0L, 1L);
 		DepTreeNode clone = null;
 		try {
 			clone = (DepTreeNode)root.clone();
 		} catch (CloneNotSupportedException e) {
 			fail(e.getMessage());
 		}
-		assertArrayEquals(root.getDepArray(), clone.getDepArray());
-		assertNotSame(root.getDepArray(), clone.getDepArray());
+		assertArrayEquals(root.getDefineDepArray(), clone.getDefineDepArray());
+		assertNotSame(root.getDefineDepArray(), clone.getDefineDepArray());
+		assertArrayEquals(root.getRequireDepArray(), clone.getRequireDepArray());
+		assertNotSame(root.getRequireDepArray(), clone.getRequireDepArray());
 		assertEquals(root.lastModified(), clone.lastModified());
 		assertEquals(root.lastModifiedDep(), clone.lastModifiedDep());
 		DepTreeNode clonedChild = clone.getChild("child");
-		assertArrayEquals(child.getDepArray(), clonedChild.getDepArray());
-		assertNotSame(child.getDepArray(), clonedChild.getDepArray());
+		assertArrayEquals(child.getDefineDepArray(), clonedChild.getDefineDepArray());
+		assertNotSame(child.getDefineDepArray(), clonedChild.getDefineDepArray());
+		assertArrayEquals(child.getRequireDepArray(), clonedChild.getRequireDepArray());
+		assertNotSame(child.getRequireDepArray(), clonedChild.getRequireDepArray());
 		assertEquals(child.lastModified(), clonedChild.lastModified());
 		assertEquals(child.lastModifiedDep(), clonedChild.lastModifiedDep());
 	}

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/deps/DepUtilsTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/deps/DepUtilsTest.java
@@ -20,8 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import com.ibm.jaggr.core.impl.deps.DepTreeNode;
-import com.ibm.jaggr.core.impl.deps.DepUtils;
+import com.ibm.jaggr.core.impl.deps.DepUtils.ParseResult;
 
 import com.google.javascript.jscomp.Compiler;
 import com.google.javascript.jscomp.JSSourceFile;
@@ -125,28 +124,29 @@ public class DepUtilsTest {
 
 		Compiler compiler = new Compiler();
 		Node node = compiler.parse(JSSourceFile.fromCode("js1", js1));
-		Collection<String> deps = DepUtils.parseDependencies(node, new HashSet<String>());
+		Collection<String> deps = DepUtils.parseDependencies(node, new HashSet<String>()).getDefineDependencies();
 		assertEquals(deps.toString(), "[a, b, c]");
 		node = compiler.parse(JSSourceFile.fromCode("js2", js2));
-		deps = DepUtils.parseDependencies(node, new HashSet<String>());
+		deps = DepUtils.parseDependencies(node, new HashSet<String>()).getDefineDependencies();
 		assertEquals(deps.toString(), "[a, b, c]");
 		node = compiler.parse(JSSourceFile.fromCode("js3", js3));
-		deps = DepUtils.parseDependencies(node, new HashSet<String>());
+		deps = DepUtils.parseDependencies(node, new HashSet<String>()).getDefineDependencies();
 		assertEquals(deps.size(), 0);
 		node = compiler.parse(JSSourceFile.fromCode("js4", js4));
-		deps = DepUtils.parseDependencies(node, new HashSet<String>());
+		deps = DepUtils.parseDependencies(node, new HashSet<String>()).getDefineDependencies();
 		assertEquals(deps.toString(), "[a, b, c]");
 		node = compiler.parse(JSSourceFile.fromCode("js5", js5));
-		deps = DepUtils.parseDependencies(node, new HashSet<String>());
+		deps = DepUtils.parseDependencies(node, new HashSet<String>()).getDefineDependencies();
 		assertNull(deps);
 		node = compiler.parse(JSSourceFile.fromCode("js6", js6));
-		deps = DepUtils.parseDependencies(node, new HashSet<String>());
+		deps = DepUtils.parseDependencies(node, new HashSet<String>()).getDefineDependencies();
 		assertNull(deps);
-		node = compiler.parse(JSSourceFile.fromCode("js6", js7));
+		node = compiler.parse(JSSourceFile.fromCode("js7", js7));
 		// Test dependent features
 		Set<String> dependentFeatures = new HashSet<String>();
-		deps = DepUtils.parseDependencies(node, dependentFeatures);
-		assertEquals("[dep1, dojo/has!hasTest1?hasTest2?dep1:dep2]", deps.toString());
+		ParseResult parseResult = DepUtils.parseDependencies(node, dependentFeatures);
+		assertEquals("[dep1, dojo/has!hasTest1?hasTest2?dep1:dep2]", parseResult.getDefineDependencies().toString());
+		assertEquals("[has!hasTest3?:dep3]", parseResult.getRequireDependencies().toString());
 		assertEquals(new HashSet<String>(Arrays.asList(new String[]{"hasTest1", "hasTest2", "hasTest3", "fooTest", "barTest"})), dependentFeatures);
 	}
 }

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/deps/DependenciesTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/deps/DependenciesTest.java
@@ -109,27 +109,28 @@ public class DependenciesTest extends EasyMock {
 		assertEquals(0, p2Node.getChild("p1").getChild("p1").getChild("foo").getChildren().size());
 
 		assertEquals("[./b]",
-				Arrays.asList(p1Node.getChild("a").getDepArray()).toString());
+				Arrays.asList(p1Node.getChild("a").getDefineDepArray()).toString());
 		assertEquals("[./c]",
-				Arrays.asList(p1Node.getChild("b").getDepArray()).toString());
+				Arrays.asList(p1Node.getChild("b").getDefineDepArray()).toString());
 		assertEquals("[./a, ./b, ./noexist]",
-				Arrays.asList(p1Node.getChild("c").getDepArray()).toString());
+				Arrays.asList(p1Node.getChild("c").getDefineDepArray()).toString());
 		assertEquals("[p1/a, p2/p1/b, p2/p1/p1/c, p2/noexist]",
-				Arrays.asList(p1Node.getChild("p1").getDepArray()).toString());
+				Arrays.asList(p1Node.getChild("p1").getDefineDepArray()).toString());
 		assertEquals("[./b]",
-				Arrays.asList(p2Node.getChild("a").getDepArray()).toString());
+				Arrays.asList(p2Node.getChild("a").getDefineDepArray()).toString());
 		assertEquals("[./c]",
-				Arrays.asList(p2Node.getChild("b").getDepArray()).toString());
+				Arrays.asList(p2Node.getChild("b").getDefineDepArray()).toString());
 		assertEquals("[./b]",
-				Arrays.asList(p2Node.getChild("p1").getChild("a").getDepArray()).toString());
+				Arrays.asList(p2Node.getChild("p1").getChild("a").getDefineDepArray()).toString());
 		assertEquals("[./c]",
-				Arrays.asList(p2Node.getChild("p1").getChild("p1").getDepArray()).toString());
+				Arrays.asList(p2Node.getChild("p1").getChild("p1").getDefineDepArray()).toString());
 		assertEquals("[p1/a, p2/p1/b, p2/p1/p1/c, p2/noexist]",
-				Arrays.asList(p2Node.getChild("p1").getChild("p1").getChild("foo").getDepArray()).toString());
-
+				Arrays.asList(p2Node.getChild("p1").getChild("p1").getChild("foo").getDefineDepArray()).toString());
+		assertEquals("[p2/a]",
+				Arrays.asList(p2Node.getChild("p1").getChild("p1").getChild("foo").getRequireDepArray()).toString());
 		DepTreeNode p1_a_node = p1Node.getChild("a");
 		long yesterday = new Date().getTime()- 24*60*60*1000;
-		p1_a_node.setDependencies(new String[]{"p2/p1/b", "p2/p1/p1/c", "p2/noexist"}, null, yesterday, yesterday);
+		p1_a_node.setDependencies(new String[]{"p2/p1/b", "p2/p1/p1/c", "p2/noexist"}, new String[0], null, yesterday, yesterday);
 
 	}
 
@@ -149,18 +150,18 @@ public class DependenciesTest extends EasyMock {
 		DepTreeNode p2Node = depMap.get(p2Path);
 
 		long yesterday = new Date().getTime() - 24*60*60*1000;
-		p1Node.getChild("a").setDependencies(new String[]{"foo/bar"}, new String[0], yesterday, yesterday);
+		p1Node.getChild("a").setDependencies(new String[]{"foo/bar"}, new String[0], new String[0], yesterday, yesterday);
 		// Leave deps the same to test that lastModifiedDep doesn't change
-		p1Node.getChild("b").setDependencies(p1Node.getChild("b").getDepArray(), new String[0], yesterday, yesterday);
+		p1Node.getChild("b").setDependencies(p1Node.getChild("b").getDefineDepArray(), new String[0], new String[0], yesterday, yesterday);
 		DepTreeNode p3Node = new DepTreeNode("p3", null);
 		p3Node.add(new DepTreeNode("a", null));
 		// create a node that is not on the file system
-		p3Node.getChild("a").setDependencies(new String[]{"./b"}, new String[0], yesterday, yesterday);
+		p3Node.getChild("a").setDependencies(new String[]{"./b"}, new String[0], new String[0], yesterday, yesterday);
 		depMap.put(p3Path, p3Node);
 		long p2_p1_a_lastMod = new File(tmpdir, "p2/p1/a.js").lastModified();
 		// change deps but leave timestamps the same so that the deps won't be updated by validation
 		// but will be updated by clean.
-		p2Node.getChild("p1").getChild("a").setDependencies(new String[]{"xxx"}, new String[0], p2_p1_a_lastMod, p2_p1_a_lastMod);
+		p2Node.getChild("p1").getChild("a").setDependencies(new String[]{"xxx"}, new String[0], new String[0], p2_p1_a_lastMod, p2_p1_a_lastMod);
 
 		File cacheFile = new File(tmpdir, "deps/depmap.cache");
 		String configJson = "{paths: {p1Alias:'p1', p2Alias:'p2'}}";
@@ -185,15 +186,15 @@ public class DependenciesTest extends EasyMock {
 		assertEquals("", root.getName());
 		assertEquals(3, root.getChildren().size());
 		assertEquals("[foo/bar]",
-				Arrays.asList(root.getChild("p1Alias").getChild("a").getDepArray()).toString());
+				Arrays.asList(root.getChild("p1Alias").getChild("a").getDefineDepArray()).toString());
 		assertEquals(yesterday, root.getChild("p1Alias").getChild("a").lastModified());
 		assertEquals(yesterday, root.getChild("p1Alias").getChild("a").lastModifiedDep());
 		assertEquals(yesterday, root.getChild("p1Alias").getChild("b").lastModified());
 		assertEquals(yesterday, root.getChild("p1Alias").getChild("b").lastModifiedDep());
 		assertEquals("[./b]",
-				Arrays.asList(root.getChild("p3Alias").getChild("a").getDepArray()).toString());
+				Arrays.asList(root.getChild("p3Alias").getChild("a").getDefineDepArray()).toString());
 		assertEquals("[xxx]",
-				Arrays.asList(root.getChild("p2Alias").getChild("p1").getChild("a").getDepArray()).toString());
+				Arrays.asList(root.getChild("p2Alias").getChild("p1").getChild("a").getDefineDepArray()).toString());
 		assertEquals(p2_p1_a_lastMod, root.getChild("p2Alias").getChild("p1").getChild("a").lastModified());
 		assertEquals(p2_p1_a_lastMod, root.getChild("p2Alias").getChild("p1").getChild("a").lastModifiedDep());
 
@@ -205,13 +206,13 @@ public class DependenciesTest extends EasyMock {
 		assertEquals(3, root.getChildren().size());
 		assertEquals(0, root.getChild("p3Alias").getChildren().size());
 		assertEquals("[./b]",
-				Arrays.asList(root.getChild("p1Alias").getChild("a").getDepArray()).toString());
+				Arrays.asList(root.getChild("p1Alias").getChild("a").getDefineDepArray()).toString());
 		assertEquals(new File(tmpdir, "p1/a.js").lastModified(), root.getChild("p1Alias").getChild("a").lastModified());
 		assertEquals(new File(tmpdir, "p1/a.js").lastModified(), root.getChild("p1Alias").getChild("a").lastModifiedDep());
 		assertEquals(new File(tmpdir, "p1/b.js").lastModified(), root.getChild("p1Alias").getChild("b").lastModified());
 		assertEquals(yesterday, root.getChild("p1Alias").getChild("b").lastModifiedDep());
 		assertEquals("[xxx]",
-				Arrays.asList(root.getChild("p2Alias").getChild("p1").getChild("a").getDepArray()).toString());
+				Arrays.asList(root.getChild("p2Alias").getChild("p1").getChild("a").getDefineDepArray()).toString());
 		assertEquals(p2_p1_a_lastMod, root.getChild("p2Alias").getChild("p1").getChild("a").lastModified());
 		assertEquals(p2_p1_a_lastMod, root.getChild("p2Alias").getChild("p1").getChild("a").lastModifiedDep());
 
@@ -221,7 +222,7 @@ public class DependenciesTest extends EasyMock {
 		deps = new TestDependenciesWrapper(tmpdir, mockAggregator, true, false);
 		deps.mapDependencies(root, map, true);
 		assertEquals("[./b]",
-				Arrays.asList(root.getChild("p2Alias").getChild("p1").getChild("a").getDepArray()).toString());
+				Arrays.asList(root.getChild("p2Alias").getChild("p1").getChild("a").getDefineDepArray()).toString());
 		assertEquals(p2_p1_a_lastMod, root.getChild("p2Alias").getChild("p1").getChild("a").lastModified());
 		assertEquals(p2_p1_a_lastMod, root.getChild("p2Alias").getChild("p1").getChild("a").lastModifiedDep());
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerTest.java
@@ -86,6 +86,8 @@ import java.util.zip.Deflater;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import junit.framework.Assert;
+
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(LayerImpl.class)
 public class LayerTest extends EasyMock {
@@ -537,7 +539,7 @@ public class LayerTest extends EasyMock {
 		in.close();
 		String s = layer.toString();
 		System.out.println(s);
-		assertTrue(Pattern.compile("\\s[0-9]+-expn:0;has\\{\\};lyr:0:0;js:S:0:0.*layer\\..*\\.cache").matcher(s).find());
+		assertTrue(Pattern.compile("\\s[0-9]+-expn:0;has\\{\\};lyr:0:0:0:0;js:S:0:0.*layer\\..*\\.cache").matcher(s).find());
 	}
 
 	/**
@@ -790,6 +792,20 @@ public class LayerTest extends EasyMock {
 		assertEquals("[hit_1]",layerCacheInfo.toString());
 		assertEquals("weighted size error", zipped.length + unzipped.length, cacheMap.weightedSize());
 		assertEquals("cache file size error", zipped.length + unzipped.length, TestUtils.getDirListSize(cacheDir, layerFilter));
+	}
+
+	@Test
+	public void testCacheKeyGenerator() throws Exception {
+		replay(mockAggregator, mockRequest);
+		Assert.assertEquals("lyr:0:0:0:0", LayerImpl.s_layerCacheKeyGenerators.get(0).generateKey(mockRequest));
+		requestHeaders.put("Accept-Encoding", "gzip");
+		Assert.assertEquals("lyr:1:0:0:0", LayerImpl.s_layerCacheKeyGenerators.get(0).generateKey(mockRequest));
+		mockRequest.setAttribute(IHttpTransport.SHOWFILENAMES_REQATTRNAME, true);
+		Assert.assertEquals("lyr:1:1:0:0", LayerImpl.s_layerCacheKeyGenerators.get(0).generateKey(mockRequest));
+		mockRequest.setAttribute(IHttpTransport.INCLUDEREQUIREDEPS_REQATTRNAME, true);
+		Assert.assertEquals("lyr:1:1:1:0", LayerImpl.s_layerCacheKeyGenerators.get(0).generateKey(mockRequest));
+		mockRequest.setAttribute(IHttpTransport.INCLUDEUNDEFINEDFEATUREDEPS_REQATTRNAME, true);
+		Assert.assertEquals("lyr:1:1:1:1", LayerImpl.s_layerCacheKeyGenerators.get(0).generateKey(mockRequest));
 	}
 
 	@SuppressWarnings("serial")

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/i18n/I18nModuleBuilderTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/i18n/I18nModuleBuilderTest.java
@@ -231,6 +231,20 @@ public class I18nModuleBuilderTest extends EasyMock {
 		Assert.assertEquals(1, build.getBefore().size());
 		Assert.assertEquals("nls/eb/strings", build.getBefore().get(0).getModuleId());
 		Assert.assertEquals(file.toURI(), build.getBefore().get(0).getURI());
+
+		requestAttributes.put(
+				IHttpTransport.REQUESTEDLOCALES_REQATTRNAME,
+				Arrays.asList(new String[]{"*"}));
+
+		s = KeyGenUtil.generateKey(mockRequest, keyGens);
+		System.out.println(s);
+		Assert.assertTrue(s.contains("i18n{*}"));
+		build = buildIt();
+		output = build.getBuildOutput().toString();
+		System.out.println(output);
+		Assert.assertEquals("define(\"nls/strings\",{locale_label:\"root\"});", output);
+		Assert.assertEquals(7, build.getBefore().size());
+
 	}
 
 	@Test

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/test/MockAggregatorWrapper.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/test/MockAggregatorWrapper.java
@@ -36,6 +36,7 @@ import com.ibm.jaggr.core.resource.IResourceFactory;
 import com.ibm.jaggr.core.test.TestUtils.Ref;
 import com.ibm.jaggr.core.transport.IHttpTransport;
 
+import org.apache.commons.lang3.mutable.Mutable;
 import org.easymock.EasyMock;
 
 import java.io.File;
@@ -182,7 +183,7 @@ public class MockAggregatorWrapper implements IAggregator {
 	}
 
 	@Override
-	public IResourceFactory getResourceFactory(URI uri) {
+	public IResourceFactory getResourceFactory(Mutable<URI> uri) {
 		// TODO Auto-generated method stub
 		return mock.getResourceFactory(uri);
 	}

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/test/MockRequestedModuleNames.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/test/MockRequestedModuleNames.java
@@ -26,6 +26,7 @@ public class MockRequestedModuleNames implements IRequestedModuleNames{
 	private List<String> deps = Collections.emptyList();
 	private List<String> preloads = Collections.emptyList();
 	private List<String> scripts = Collections.emptyList();
+	private List<String> excludes = Collections.emptyList();
 	private String strRep = null;
 
 	public List<String> getModules() {
@@ -72,6 +73,17 @@ public class MockRequestedModuleNames implements IRequestedModuleNames{
 		this.scripts = scripts;
 	}
 
+	public List<String> getExcludes() {
+		return excludes;
+	}
+
+	public void setExcludes(List<String> excludes) {
+		if (excludes == null) {
+			throw new NullPointerException();
+		}
+		this.excludes = excludes;
+	}
+
 	public void setString(String strRep) {
 		this.strRep = strRep;
 	}
@@ -94,6 +106,9 @@ public class MockRequestedModuleNames implements IRequestedModuleNames{
 			}
 			if (preloads != null && !preloads.isEmpty()) {
 				sb.append(sb.length() > 0 ? ";":"").append("preloads:").append(preloads); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			}
+			if (excludes != null && !excludes.isEmpty()) {
+				sb.append(sb.length() > 0 ? ";":"").append("excludes:").append(excludes); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			}
 			result = sb.toString();
 		}

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/test/TestUtils.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/test/TestUtils.java
@@ -46,6 +46,7 @@ import com.ibm.jaggr.core.resource.IResource;
 import com.ibm.jaggr.core.resource.IResourceFactory;
 import com.ibm.jaggr.core.transport.IHttpTransport;
 
+import org.apache.commons.lang3.mutable.Mutable;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 
@@ -306,9 +307,10 @@ public class TestUtils {
 				return mockAggregatorNewResource((URI)EasyMock.getCurrentArguments()[0], workdir);
 			}
 		}).anyTimes();
-		EasyMock.expect(mockAggregator.getResourceFactory(EasyMock.isA(URI.class))).andAnswer(new IAnswer<IResourceFactory>() {
+		EasyMock.expect(mockAggregator.getResourceFactory(EasyMock.isA(Mutable.class))).andAnswer(new IAnswer<IResourceFactory>() {
 			public IResourceFactory answer() throws Throwable {
-				URI uri = (URI)EasyMock.getCurrentArguments()[0];
+				Mutable<URI> uriRef = (Mutable<URI>)EasyMock.getCurrentArguments()[0];
+				URI uri = uriRef.getValue();
 				if (!uri.isAbsolute() && uri.getPath().startsWith("/")) return null;
 				return ("file".equals(uri.getScheme())) ? new FileResourceFactory() : null;
 			}


### PR DESCRIPTION
These args can be used to generate 'whole app' layers that contain all the code needed by the application in a single layer.  Useful for offline-manifests, etc.