### PR TITLE
Add support for force error responses in development mode

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/IAggregator.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/IAggregator.java
@@ -23,6 +23,7 @@ import com.ibm.jaggr.core.config.IConfig;
 import com.ibm.jaggr.core.config.IConfigListener;
 import com.ibm.jaggr.core.deps.IDependencies;
 import com.ibm.jaggr.core.executors.IExecutors;
+import com.ibm.jaggr.core.impl.ForcedErrorResponse;
 import com.ibm.jaggr.core.layer.ILayerCache;
 import com.ibm.jaggr.core.module.IModule;
 import com.ibm.jaggr.core.module.IModuleCache;
@@ -122,6 +123,17 @@ public interface IAggregator {
 	 * @return the HTTP transport
 	 */
 	public IHttpTransport getTransport();
+
+	/**
+	 * Command provider function for setting forced errors in development mode.
+	 *
+	 * @param forceError
+	 *            the error parameters. See {@link ForcedErrorResponse#ForcedErrorResponse(String)}
+	 *            for description.
+	 *
+	 * @return a string that will be displayed on the console.
+	 */
+	public String setForceError(String forceError);
 
 	/**
 	 * Returns a new {@link IResource} for the specified URI. The aggregator

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/AbstractAggregatorImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/AbstractAggregatorImpl.java
@@ -164,6 +164,8 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IAgg
 	private boolean isShuttingDown = false;
 	protected IPlatformServices platformServices;
 
+	// Forced error handling
+	private ForcedErrorResponse forcedErrorResponse = null;
 
 	protected Map<String, URI> resourcePaths;
 
@@ -311,6 +313,30 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IAgg
 		}
 		req.setAttribute(AGGREGATOR_REQATTRNAME, this);
 		resp.addHeader("Server", "JavaScript Aggregator"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		// Check for forced error response in development mode
+		if (forcedErrorResponse != null && getOptions().isDevelopmentMode()) {
+			int status = forcedErrorResponse.getStatus();
+			if (status > 0) {
+				// return a forced error status
+				resp.setStatus(status);
+				URI uri = forcedErrorResponse.getResponseBody();
+				if (uri != null) {
+					resp.setContentType(getContentType(uri.getPath()));
+					try {
+						CopyUtil.copy(newResource(uri).getInputStream(), resp.getOutputStream());
+					} catch (IOException e) {
+						throw new ServletException(e);
+					}
+				}
+				log.logp(Level.WARNING, AbstractAggregatorImpl.class.getName(), sourceMethod, "Returning forced error status " + status); //$NON-NLS-1$
+				return;
+			} else if (status < 0) {
+				// Forced error response is spent.  Remove it.
+				forcedErrorResponse = null;
+			}
+		}
+
 		String pathInfo = req.getPathInfo();
 		if (pathInfo == null) {
 			processAggregatorRequest(req, resp);
@@ -1269,6 +1295,18 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IAgg
 	}
 
 	/**
+	 * Instantiates a new ForcedErrorResponse object
+	 *
+	 * @param info
+	 *            The configuration string
+	 * @return the new object
+	 * @throws URISyntaxException
+	 */
+	protected ForcedErrorResponse newForcedErrorResponse(String info) throws URISyntaxException {
+		return new ForcedErrorResponse(info);
+	}
+
+	/**
 	 * Instantiates a new cache manager
 	 * @param stamp
 	 *            the time stamp
@@ -1449,6 +1487,30 @@ public abstract class AbstractAggregatorImpl extends HttpServlet implements IAgg
 		dict.put("name", getName()); //$NON-NLS-1$
 		registrations.add(getPlatformServices().registerService(
 				ILayerListener.class.getName(), new AggregatorLayerListener(this), dict));
+	}
+
+
+	/* (non-Javadoc)
+	 * @see com.ibm.jaggr.core.IAggregator#setForceError(java.lang.String)
+	 */
+	@Override
+	public String setForceError(String forceError) {
+		String result = ""; //$NON-NLS-1$
+		// Listen for FORCE_ERROR option.  FORCED_ERROR is a transient options, so we
+		// can only learn that it is set in optionsUpdated.
+		if (getOptions().isDevelopmentMode()) {
+			ForcedErrorResponse resp;
+			try {
+				resp = newForcedErrorResponse(forceError);
+				result = MessageFormat.format(Messages.CommandProvider_27, new Object[]{resp.toString()});
+				forcedErrorResponse = resp;
+			} catch (Exception e) {
+				result = MessageFormat.format(Messages.CommandProvider_28, new Object[]{forceError});
+			}
+		} else {
+			result = Messages.CommandProvider_29;
+		}
+		return result;
 	}
 }
 

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/ForcedErrorResponse.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/ForcedErrorResponse.java
@@ -1,0 +1,133 @@
+/*
+ * (C) Copyright 2012, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.jaggr.core.impl;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This class encapsulates the forced error response processing for the Aggregator
+ */
+public class ForcedErrorResponse {
+	static Pattern pat = Pattern.compile("^(\\d*)\\s*(\\d*)?\\s*(\\d*)?\\s*(.*)$"); //$NON-NLS-1$
+
+	private int status = 0;
+	private AtomicInteger skip = new AtomicInteger(0);
+	private AtomicInteger count = new AtomicInteger(1);
+	private URI responseBody = null;
+
+	/**
+	 * Constructor
+	 *
+	 * @param info
+	 *            String of the form {@code <status> <count> <skip> <response>}
+	 *            </br></br> where {@code <status>} is required and is a number specifying
+	 *            the HTTP response code that should be returned for the next request.
+	 *            {@code <count>} is optional and specifies
+	 *            the number of times that the specified response status should be returned. If it
+	 *            is not specified, then the response status will be returned only once.
+	 *            {@code skip} is optional and specifies the number of requests to process normally
+	 *            before returning the specified response status.
+	 *            {@code <response text>} is optional and specifies the text that should be returned
+	 *            in the response body. If it is not specified, then no response text is include.
+	 *
+	 * @throws URISyntaxException
+	 * @throws NumberFormatException
+	 * @throws IllegalArgumentException
+	 */
+	public ForcedErrorResponse(String info) throws URISyntaxException {
+		Matcher m = pat.matcher(info);
+		if (m.find()) {
+			status = Integer.parseInt(m.group(1));
+			String s = m.group(2);
+			if (s != null && s.length() > 0) {
+				count.set(Integer.parseInt(s));
+			}
+			s = m.group(3);
+			if (s != null && s.length() > 0) {
+				skip.set(Integer.parseInt(s));
+			}
+			String rest = m.group(4);
+			if (rest != null && rest.length() > 0) {
+				responseBody = new URI(rest);
+			}
+			if (count.get() <= 0) {
+				status = 0;
+			}
+		} else {
+			throw new IllegalArgumentException(info);
+		}
+	}
+	/**
+	 * Returns the error response status that should be returned for the current
+	 * response.  If the value is zero, then the normal response should be returned
+	 * and this method should be called again for the next response.  If the value
+	 * is less than 0, then this error response status object is spent and may be
+	 * discarded.
+	 *
+	 * @return the error response status
+	 */
+	public int getStatus() {
+		int result = status;
+		if (status > 0) {
+			if (skip.getAndDecrement() <= 0) {
+				if (count.getAndDecrement() <= 0) {
+					result = status = -1;
+				}
+			} else {
+				result = 0;
+			}
+		}
+		return result;
+	}
+
+	int peekStatus() {
+		return status;
+	}
+
+	int getCount() {
+		return count.get();
+	}
+
+	int getSkip() {
+		return skip.get();
+	}
+
+	/**
+	 * @return the error response URI
+	 */
+	public URI getResponseBody() {
+		return responseBody;
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		StringBuffer sb = new StringBuffer();
+		sb.append("status:").append(status); //$NON-NLS-1$
+		sb.append(", count:").append(count); //$NON-NLS-1$
+		sb.append(", skip:").append(skip); //$NON-NLS-1$
+		if (responseBody != null) {
+			sb.append(", response:").append(responseBody); //$NON-NLS-1$
+		}
+		return sb.toString();
+	}
+}

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/Messages.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/Messages.java
@@ -48,9 +48,13 @@ public class Messages extends NLS {
 	public static String CommandProvider_18;
 	public static String CommandProvider_19;
 	public static String CommandProvider_20;
+	public static String CommandProvider_21;
 	public static String CommandProvider_22;
 	public static String CommandProvider_23;
 	public static String CommandProvider_26;
+	public static String CommandProvider_27;
+	public static String CommandProvider_28;
+	public static String CommandProvider_29;
 	public static String ConfigModified;
 	public static String CustomOptionsFile;
 	static {

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/messages.properties
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/messages.properties
@@ -36,6 +36,7 @@ CommandProvider_8=\t{0}{1}{2} <servlet> - displays the current options and their
 CommandProvider_9=\t{0}{1}{2} <servlet> <name> [<value>] - sets the specified option to the specified value or removes the option if value is not specified
 CommandProvider_17=\t{0}{1}{2} <servlet> - config for the servlet
 CommandProvider_18=\t{0}{1}{2} <servlet> - displays the location of the servlet directory for the specified servlet
+CommandProvider_21=\t{0}{1}{2} <servlet> <status> [<count> [<skip> [<response file>]]] - sets forced error response params (development mode must be enabled)
 # {0} = eyecatcher (e.g. aggregator)
 # {1} = command name (e.g. list)
 CommandProvider_10=Use the "{0} {1}" command to get a list of running servlets.
@@ -58,6 +59,11 @@ CommandProvider_22=Module not specified.
 CommandProvider_23=Defined features: {0}.
 # {0} = servlet name
 CommandProvider_26=Cleared cache for servlet {0} 
+# {0} is number
+CommandProvider_27=Response status = {0}
+# {0} is string the user input
+CommandProvider_28=Invalid value specified for forceError: {0}
+CommandProvider_29=Development mode is not enabled
 ConfigModified=The server side AMD config file has been modified.  Reloading the config and validating module dependencies...  Please clear your browser cache and reload the page after a few moments.\r\n\r\nThis message is being displayed by the AMD Aggregation servlet because the servlet is in development mode and the servlet has detected that the server-side AMD config file has been modified since it was last read.
 
 Activator_1=AMD Module Aggregator starting in development mode

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/messages_en.properties
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/messages_en.properties
@@ -36,6 +36,7 @@ CommandProvider_8=\t{0}{1}{2} <servlet> - displays the current options and their
 CommandProvider_9=\t{0}{1}{2} <servlet> <name> [<value>] - sets the specified option to the specified value or removes the option if value is not specified
 CommandProvider_17=\t{0}{1}{2} <servlet> - config for the servlet
 CommandProvider_18=\t{0}{1}{2} <servlet> - displays the location of the servlet directory for the specified servlet
+CommandProvider_21=\t{0}{1}{2} <servlet> <status> [<count> [<skip> [<response file>]]] - sets forced error response params (development mode must be enabled)
 # {0} = eyecatcher (e.g. aggregator)
 # {1} = command name (e.g. list)
 CommandProvider_10=Use the "{0} {1}" command to get a list of running servlets.
@@ -58,6 +59,11 @@ CommandProvider_22=Module not specified.
 CommandProvider_23=Defined features: {0}.
 # {0} = servlet name
 CommandProvider_26=Cleared cache for servlet {0} 
+# {0} is number
+CommandProvider_27=Response status = {0}
+# {0} is string the user input
+CommandProvider_28=Invalid value specified for forceError: {0}
+CommandProvider_29=Development mode is not enabled
 ConfigModified=The server side AMD config file has been modified.  Reloading the config and validating module dependencies...  Please clear your browser cache and reload the page after a few moments.\r\n\r\nThis message is being displayed by the AMD Aggregation servlet because the servlet is in development mode and the servlet has detected that the server-side AMD config file has been modified since it was last read.
 
 Activator_1=AMD Module Aggregator starting in development mode

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/ForcedErrorResponseTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/ForcedErrorResponseTest.java
@@ -1,0 +1,105 @@
+/*
+ * (C) Copyright 2012, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.jaggr.core.impl;
+
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import junit.framework.Assert;
+
+public class ForcedErrorResponseTest {
+
+	@Test
+	public void testConstructor() throws Exception {
+		ForcedErrorResponse test = new ForcedErrorResponse("500");
+		Assert.assertEquals(500, test.peekStatus());
+		Assert.assertEquals(1, test.getCount());
+		Assert.assertEquals(0, test.getSkip());
+		Assert.assertEquals(null, test.getResponseBody());
+
+		test = new ForcedErrorResponse("500 3");
+		Assert.assertEquals(500, test.peekStatus());
+		Assert.assertEquals(3, test.getCount());
+		Assert.assertEquals(0, test.getSkip());
+		Assert.assertEquals(null, test.getResponseBody());
+
+		test = new ForcedErrorResponse("500 3 5");
+		Assert.assertEquals(500, test.peekStatus());
+		Assert.assertEquals(3, test.getCount());
+		Assert.assertEquals(5, test.getSkip());
+		Assert.assertEquals(null, test.getResponseBody());
+
+		test = new ForcedErrorResponse("500 3 5 file://c:/error.html");
+		Assert.assertEquals(500, test.peekStatus());
+		Assert.assertEquals(3, test.getCount());
+		Assert.assertEquals(5, test.getSkip());
+		Assert.assertEquals(new URI("file://c:/error.html"), test.getResponseBody());
+
+		test = new ForcedErrorResponse("500 file://c:/error.html");
+		Assert.assertEquals(500, test.peekStatus());
+		Assert.assertEquals(1, test.getCount());
+		Assert.assertEquals(0, test.getSkip());
+		Assert.assertEquals(new URI("file://c:/error.html"), test.getResponseBody());
+
+		test = new ForcedErrorResponse("500 2 file://c:/error.html");
+		Assert.assertEquals(500, test.peekStatus());
+		Assert.assertEquals(2, test.getCount());
+		Assert.assertEquals(0, test.getSkip());
+		Assert.assertEquals(new URI("file://c:/error.html"), test.getResponseBody());
+
+	}
+
+	@Test (expected=URISyntaxException.class)
+	public void testConstructorErrors1() throws Exception {
+		new ForcedErrorResponse("500 file:// error.html");
+	}
+
+	@Test (expected=NumberFormatException.class)
+	public void testConstructorErrors2() throws Exception {
+		new ForcedErrorResponse("foo");
+	}
+
+	@Test (expected=NumberFormatException.class)
+	public void testConstructorErrors3() throws Exception {
+		new ForcedErrorResponse("");
+	}
+
+	@Test
+	public void testGetStatus() throws Exception{
+		ForcedErrorResponse test = new ForcedErrorResponse("500");
+		Assert.assertEquals(500, test.getStatus());
+		Assert.assertEquals(-1, test.getStatus());
+		Assert.assertEquals(-1, test.getStatus());
+
+		test = new ForcedErrorResponse("500 2");
+		Assert.assertEquals(500, test.getStatus());
+		Assert.assertEquals(500, test.getStatus());
+		Assert.assertEquals(-1, test.getStatus());
+		Assert.assertEquals(-1, test.getStatus());
+
+		test = new ForcedErrorResponse("500 2 1");
+		Assert.assertEquals(0, test.getStatus());
+		Assert.assertEquals(500, test.getStatus());
+		Assert.assertEquals(500, test.getStatus());
+		Assert.assertEquals(-1, test.getStatus());
+		Assert.assertEquals(-1, test.getStatus());
+
+
+	}
+
+}

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/test/MockAggregatorWrapper.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/test/MockAggregatorWrapper.java
@@ -180,4 +180,9 @@ public class MockAggregatorWrapper implements IAggregator {
 		return mock.getPlatformServices();
 	}
 
+	@Override
+	public String setForceError(String forceError) {
+		return mock.setForceError(forceError);
+	}
+
 }

--- a/jaggr-service/pom.xml
+++ b/jaggr-service/pom.xml
@@ -166,7 +166,7 @@
               !*
             </Import-Package>
             <!-- embed dependencies -->
-            <Embed-Dependency>commons-codec</Embed-Dependency>
+            <Embed-Dependency>commons-codec, commons-lang3</Embed-Dependency>
             <Embed-Directory>lib</Embed-Directory>
             <Embed-StripGroup>true</Embed-StripGroup>
           </instructions>
@@ -240,6 +240,10 @@
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.gogo.command</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorCommandProvider.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorCommandProvider.java
@@ -29,6 +29,7 @@ import com.ibm.jaggr.core.util.StringBufferWriter;
 
 import com.ibm.jaggr.service.util.CIConsoleWriter;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.osgi.framework.console.CommandInterpreter;
 import org.eclipse.osgi.framework.console.CommandProvider;
 import org.osgi.framework.BundleContext;
@@ -71,6 +72,7 @@ public class AggregatorCommandProvider implements CommandProvider {
 	static final String CMD_SHOWCONFIG = "showconfig"; //$NON-NLS-1$
 	static final String CMD_GETDEPSWITHHASBRANCHING = "getdepswithhasbranching"; //$NON-NLS-1$
 	static final String CMD_GETSERVLETDIR = "getservletdir"; //$NON-NLS-1$
+	static final String CMD_FORCEERROR = "forceerror"; //$NON-NLS-1$
 	static final String NEWLINE = "\r\n"; //$NON-NLS-1$
 
 	static final String[] COMMANDS = new String[] {
@@ -85,7 +87,8 @@ public class AggregatorCommandProvider implements CommandProvider {
 		CMD_SETOPTION,
 		CMD_SHOWCONFIG,
 		CMD_GETSERVLETDIR,
-		CMD_GETDEPSWITHHASBRANCHING
+		CMD_GETDEPSWITHHASBRANCHING,
+		CMD_FORCEERROR
 	};
 
 	static final String DEPSOURCE_CONSOLE = "console"; //$NON-NLS-1$
@@ -143,7 +146,10 @@ public class AggregatorCommandProvider implements CommandProvider {
 						new Object[]{EYECATCHER, scopeSep, CMD_SHOWCONFIG})).append(newline)
 				.append(MessageFormat.format(
 						Messages.CommandProvider_18,
-						new Object[]{EYECATCHER, scopeSep, CMD_GETSERVLETDIR})).append(newline);
+						new Object[]{EYECATCHER, scopeSep, CMD_GETSERVLETDIR})).append(newline)
+				.append(MessageFormat.format(
+						Messages.CommandProvider_21,
+						new Object[]{EYECATCHER, scopeSep, CMD_FORCEERROR})).append(newline);
 
 
 		return sb.toString();
@@ -186,6 +192,8 @@ public class AggregatorCommandProvider implements CommandProvider {
 				ci.println(showconfig(args));
 			} else if (command.equals(CMD_GETSERVLETDIR)) {
 				ci.println(getServletDir(args));
+			} else if (command.equals(CMD_FORCEERROR)) {
+				ci.println(setForceError(args));
 			} else {
 				ci.print(getHelp());
 			}
@@ -459,6 +467,21 @@ public class AggregatorCommandProvider implements CommandProvider {
 			IAggregator aggregator = (IAggregator)getBundleContext().getService(ref);
 			try {
 				sb.append(aggregator.getConfig().toString());
+			} finally {
+				getBundleContext().ungetService(ref);
+			}
+		}
+		return sb.toString();
+	}
+
+	protected String setForceError(Object[] args) throws InvalidSyntaxException {
+		StringBuffer sb = new StringBuffer();
+		ServiceReference ref = getServiceRef(new String[]{(String)args[0]}, sb);
+		if (ref != null) {
+			IAggregator aggregator = (IAggregator)getBundleContext().getService(ref);
+			try {
+				// Let aggregator process the args
+				sb.append(aggregator.setForceError(StringUtils.join(Arrays.copyOfRange(args, 1, args.length)," "))); //$NON-NLS-1$
 			} finally {
 				getBundleContext().ungetService(ref);
 			}

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorCommandProviderGogo.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorCommandProviderGogo.java
@@ -16,6 +16,7 @@ help * (C) Copyright 2012, IBM Corporation
 package com.ibm.jaggr.service.impl;
 
 import com.ibm.jaggr.core.util.ConsoleService;
+
 import com.ibm.jaggr.service.util.CSConsoleWriter;
 
 import org.apache.felix.service.command.CommandSession;
@@ -28,6 +29,7 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class AggregatorCommandProviderGogo extends AggregatorCommandProvider {
 
@@ -162,6 +164,14 @@ public class AggregatorCommandProviderGogo extends AggregatorCommandProvider {
 			) throws InvalidSyntaxException {
 		new ConsoleService(new CSConsoleWriter(cs));		// Saves the command session so it can be accessed by async thread
 		return super.getServletDir(new String[]{servlet});
+	}
+
+	@Descriptor("sets forced error options in development mode")
+	public String forceerror(CommandSession cs,
+			@Descriptor("<servlet>")String[] args
+			) throws InvalidSyntaxException {
+		new ConsoleService(new CSConsoleWriter(cs));		// Saves the command session so it can be accessed by async thread
+		return super.setForceError(args);
 	}
 
 	private String[] makeArgumentArray(Object... args) {


### PR DESCRIPTION
When developing an application, it is often useful to be able to force errors on the server to test/develop error handling code on the client.  This pull request adds the forceError aggregator console command which allows a developer with console access to set forced error conditions on the server in development mode. 

The syntax for the command is:
```
aggregator:forceError <servlet> <status> [<count> [<skip> [<response>]]]
```
Where &lt;status&gt; is the HTTP response status that should be returned for the next &lt;count&gt; requests after skipping &lt;skip&gt; number of requests.

Default values are count=1 and skip=0.

&lt;response&gt; is a URI that if specified points to a resource in the application or on the file system that should be used as the error response body.  
