### PR TITLE
Improve reuse of certain types of cached modules

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/AbstractHttpTransport.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/AbstractHttpTransport.java
@@ -157,6 +157,8 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IConfigMo
 		,"reqexp"	// backwards compatibility, to be removed. //$NON-NLS-1$
 	};
 
+	public static final String[] EXPORTMODULENAMES_REQPARAMS = {"exportNames", "en"}; //$NON-NLS-1$ //$NON-NLS-2$
+
 	public static final String[] SHOWFILENAMES_REQPARAMS = {"showFilenames", "fn"}; //$NON-NLS-1$ //$NON-NLS-2$
 
 	public static final String[] NOCACHE_REQPARAMS = {"noCache", "nocache", "nc"}; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
@@ -228,7 +230,7 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IConfigMo
 	public void decorateRequest(HttpServletRequest request) throws IOException {
 
 		// Get module lists from request
-		setRequestedModuleNames(request);
+		RequestedModuleNames requestedModuleNames = setRequestedModuleNames(request);
 
 		// Get the feature list, if any
 		request.setAttribute(FEATUREMAP_REQATTRNAME, getFeaturesFromRequest(request));
@@ -242,7 +244,10 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IConfigMo
 		} else {
 			request.setAttribute(EXPANDREQUIRELISTS_REQATTRNAME, TypeUtil.asBoolean(value));
 		}
-		request.setAttribute(EXPORTMODULENAMES_REQATTRNAME, true);
+
+		boolean exportModuleNamesDefault = requestedModuleNames.getPreloads().isEmpty() &&
+				                           requestedModuleNames.getDeps().isEmpty();
+		request.setAttribute(EXPORTMODULENAMES_REQATTRNAME, TypeUtil.asBoolean(getParameter(request, EXPORTMODULENAMES_REQPARAMS), exportModuleNamesDefault));
 
 		request.setAttribute(SHOWFILENAMES_REQATTRNAME, TypeUtil.asBoolean(getParameter(request, SHOWFILENAMES_REQPARAMS)));
 
@@ -297,7 +302,7 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IConfigMo
 		return null;
 	}
 
-	protected void setRequestedModuleNames(HttpServletRequest request) throws IOException {
+	protected RequestedModuleNames setRequestedModuleNames(HttpServletRequest request) throws IOException {
 		final String sourceMethod = "setRequestedModuleNames"; //$NON-NLS-1$
 		boolean isTraceLogging = log.isLoggable(Level.FINER);
 		if (isTraceLogging) {
@@ -314,6 +319,7 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IConfigMo
 		if (isTraceLogging) {
 			log.exiting(AbstractHttpTransport.class.getName(), sourceMethod);
 		}
+		return requestedModuleNames;
 	}
 
 	/**

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/DojoHttpTransport.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/DojoHttpTransport.java
@@ -31,6 +31,7 @@ import com.ibm.jaggr.core.resource.IResourceFactory;
 import com.ibm.jaggr.core.resource.IResourceFactoryExtensionPoint;
 import com.ibm.jaggr.core.transport.IHttpTransport;
 import com.ibm.jaggr.core.transport.IRequestedModuleNames;
+import com.ibm.jaggr.core.util.TypeUtil;
 
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
@@ -324,16 +325,15 @@ public class DojoHttpTransport extends AbstractHttpTransport implements IHttpTra
 	@Override
 	public void decorateRequest(HttpServletRequest request) throws IOException {
 		super.decorateRequest(request);
-		boolean isLayerBuild = false;
+		boolean isServerExpanded = false;
 		IRequestedModuleNames requestedModuleNames = (IRequestedModuleNames)request.getAttribute(IHttpTransport.REQUESTEDMODULENAMES_REQATTRNAME);
 		if (requestedModuleNames != null) {
-			isLayerBuild = !requestedModuleNames.getDeps().isEmpty() || !requestedModuleNames.getPreloads().isEmpty();
+			isServerExpanded = !requestedModuleNames.getDeps().isEmpty() || !requestedModuleNames.getPreloads().isEmpty();
 		}
-		if (isLayerBuild) {
-			// If we're building a pre-boot layer, then don't adorn text strings
-			// and don't export module names
+		if (isServerExpanded && !TypeUtil.asBoolean(request.getAttribute(EXPORTMODULENAMES_REQATTRNAME))) {
+			// If we're building a server-expanded layer, then don't adorn text strings
+			// unless exporting module names by request.
 			request.setAttribute(IHttpTransport.NOTEXTADORN_REQATTRNAME, Boolean.TRUE);
-			request.setAttribute(IHttpTransport.EXPORTMODULENAMES_REQATTRNAME, Boolean.FALSE);
 		}
 	}
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/css/CSSModuleBuilderTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/css/CSSModuleBuilderTest.java
@@ -523,15 +523,15 @@ public class CSSModuleBuilderTest extends EasyMock {
 	@Test
 	public void testCacheKeyGen() throws Exception {
 		List<ICacheKeyGenerator> keyGens = builder.getCacheKeyGenerators(mockAggregator);
-		Assert.assertEquals("expn:0;css:0:0:0", KeyGenUtil.generateKey(mockRequest, keyGens));
+		Assert.assertEquals("expn:0;txt:0;css:0:0:0", KeyGenUtil.generateKey(mockRequest, keyGens));
 		requestParams.put(CSSModuleBuilder.INLINEIMAGES_REQPARAM_NAME, new String[]{"true"});
-		Assert.assertEquals("expn:0;css:0:1:0", KeyGenUtil.generateKey(mockRequest, keyGens));
+		Assert.assertEquals("expn:0;txt:0;css:0:1:0", KeyGenUtil.generateKey(mockRequest, keyGens));
 		requestParams.put(CSSModuleBuilder.INLINEIMPORTS_REQPARAM_NAME, new String[]{"true"});
-		Assert.assertEquals("expn:0;css:1:1:0", KeyGenUtil.generateKey(mockRequest, keyGens));
+		Assert.assertEquals("expn:0;txt:0;css:1:1:0", KeyGenUtil.generateKey(mockRequest, keyGens));
 		requestAttributes.put(IHttpTransport.EXPORTMODULENAMES_REQATTRNAME, Boolean.TRUE);
-		Assert.assertEquals("expn:1;css:1:1:0", KeyGenUtil.generateKey(mockRequest, keyGens));
+		Assert.assertEquals("expn:1;txt:0;css:1:1:0", KeyGenUtil.generateKey(mockRequest, keyGens));
 		requestAttributes.put(IHttpTransport.SHOWFILENAMES_REQATTRNAME, Boolean.TRUE);
-		Assert.assertEquals("expn:1;css:1:1:1", KeyGenUtil.generateKey(mockRequest, keyGens));
+		Assert.assertEquals("expn:1;txt:0;css:1:1:1", KeyGenUtil.generateKey(mockRequest, keyGens));
 	}
 
 	@Test

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/test/TestUtils.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/test/TestUtils.java
@@ -427,6 +427,12 @@ public class TestUtils {
 					return ary != null && ary.length > 0 ? ary[0] : null;
 				}
 			}).anyTimes();
+			EasyMock.expect(mockRequest.getParameterMap()).andAnswer(new IAnswer<Map<String, String[]>>() {
+				@Override
+				public Map<String, String[]> answer() throws Throwable {
+					return requestParameters;
+				}
+			}).anyTimes();
 		}
 		if (cookies != null) {
 			EasyMock.expect(mockRequest.getCookies()).andAnswer(new IAnswer<Cookie[]>() {


### PR DESCRIPTION
Cached modules that don't contain expandable require calls can now be reused regardless of whether require list expansion is specified in the request.

Module name exporting in define functions can now be requested for server-expanded layers.  This can be useful for post-deployment, cache-priming requests intended to populate the module cache in order to reduce the overhead of building the initial application layers.