### PR TITLE
Text modules being incorrectly decorated in server-expanded layers,

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/DojoHttpTransport.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/DojoHttpTransport.java
@@ -31,7 +31,6 @@ import com.ibm.jaggr.core.resource.IResourceFactory;
 import com.ibm.jaggr.core.resource.IResourceFactoryExtensionPoint;
 import com.ibm.jaggr.core.transport.IHttpTransport;
 import com.ibm.jaggr.core.transport.IRequestedModuleNames;
-import com.ibm.jaggr.core.util.TypeUtil;
 
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
@@ -212,7 +211,7 @@ public class DojoHttpTransport extends AbstractHttpTransport implements IHttpTra
 			String plugin = mid.substring(0, idx);
 			IAggregator aggr = (IAggregator)request.getAttribute(IAggregator.AGGREGATOR_REQATTRNAME);
 			IConfig config = aggr.getConfig();
-			if (config.getTextPluginDelegators().contains(plugin)) {
+			if (getAggregatorTextPluginName().equals(plugin) || config.getTextPluginDelegators().contains(plugin)) {
 				result = "\"url:" + mid.substring(idx+1) + "\":"; //$NON-NLS-1$ //$NON-NLS-2$
 			} else if (config.getJsPluginDelegators().contains(plugin)) {
 				result = "\"" + mid.substring(idx+1) + "\":function(){"; //$NON-NLS-1$ //$NON-NLS-2$
@@ -241,7 +240,7 @@ public class DojoHttpTransport extends AbstractHttpTransport implements IHttpTra
 		if (plugin != null) {
 			IAggregator aggr = (IAggregator)request.getAttribute(IAggregator.AGGREGATOR_REQATTRNAME);
 			IConfig config = aggr.getConfig();
-			if (config.getTextPluginDelegators().contains(plugin)) {
+			if (getAggregatorTextPluginName().equals(plugin) || config.getTextPluginDelegators().contains(plugin)) {
 				result = ""; //$NON-NLS-1$
 			}
 		}
@@ -330,9 +329,8 @@ public class DojoHttpTransport extends AbstractHttpTransport implements IHttpTra
 		if (requestedModuleNames != null) {
 			isServerExpanded = !requestedModuleNames.getDeps().isEmpty() || !requestedModuleNames.getPreloads().isEmpty();
 		}
-		if (isServerExpanded && !TypeUtil.asBoolean(request.getAttribute(EXPORTMODULENAMES_REQATTRNAME))) {
+		if (isServerExpanded) {
 			// If we're building a server-expanded layer, then don't adorn text strings
-			// unless exporting module names by request.
 			request.setAttribute(IHttpTransport.NOTEXTADORN_REQATTRNAME, Boolean.TRUE);
 		}
 	}

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/transport/AbstractDojoHttpTransportTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/transport/AbstractDojoHttpTransportTest.java
@@ -216,11 +216,11 @@ public class AbstractDojoHttpTransportTest {
 		transport.decorateRequest(mockRequest);
 		Assert.assertTrue(TypeUtil.asBoolean(mockRequest.getAttribute(AbstractHttpTransport.NOTEXTADORN_REQATTRNAME)));
 
-		// but noTextAdorn should not be set if this is a server expanded layer and we're exporting module names
+		// noTextAdorn should be set even if this is a server expanded layer and we're exporting module names
 		mockRequest.removeAttribute(AbstractHttpTransport.NOTEXTADORN_REQATTRNAME);
 		requestParams.put("exportNames", new String[]{"1"});
 		transport.decorateRequest(mockRequest);
-		Assert.assertFalse(TypeUtil.asBoolean(mockRequest.getAttribute(AbstractHttpTransport.NOTEXTADORN_REQATTRNAME)));
+		Assert.assertTrue(TypeUtil.asBoolean(mockRequest.getAttribute(AbstractHttpTransport.NOTEXTADORN_REQATTRNAME)));
 	}
 
 	@Test


### PR DESCRIPTION
causing them to be requested again.