### PR TITLE
Performance improvements in boolean simplify methods.

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/BooleanFormula.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/BooleanFormula.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -199,12 +198,11 @@ public class BooleanFormula implements Set<BooleanTerm>, Serializable {
 			return new BooleanFormula(false);
 		}
 		for (Term term : termList) {
-			byte[] varValues = term.getVarValues();
 			Set<BooleanVar> states = new HashSet<BooleanVar>();
 			for (Map.Entry<String, Integer> entry : names.entrySet()) {
-				if (varValues[entry.getValue()] == (byte)1) {
+				if (term.get(entry.getValue()) == (byte)1) {
 					states.add(new BooleanVar(entry.getKey(), true));
-				} else if (varValues[entry.getValue()] == (byte)0) {
+				} else if (term.get(entry.getValue()) == (byte)0) {
 					states.add(new BooleanVar(entry.getKey(), false));
 				}
 			}
@@ -574,12 +572,12 @@ public class BooleanFormula implements Set<BooleanTerm>, Serializable {
 	 * @return A new term list with don't cares expanded.
 	 */
 	private static List<Term> expandDontCares(int ord, List<Term> in) {
-		List<Term> result = new LinkedList<Term>();
 		Set<Integer> termInts = new HashSet<Integer>();
 		for (Term term : in) {
 			addExpandTerm(0, ord, 0, term, termInts);
 		}
 		// Now convert the termInts to Terms
+		List<Term> result = new ArrayList<Term>(termInts.size());
 		for (Integer termInt : termInts) {
 			byte[] varVals = new byte[ord];
 			for (int i = 0; i < ord; i++) {
@@ -607,7 +605,7 @@ public class BooleanFormula implements Set<BooleanTerm>, Serializable {
 	private static void addExpandTerm(int i, int ord, int byteValue, Term termValue, Set<Integer> terms) {
 		if (i < ord) {
 			int mask = 1 << i;
-			byte bitValue = termValue.getVarValues()[i];
+			byte bitValue = termValue.get(i);
 			if (bitValue == 1) {
 				byteValue |= (-1 & mask);
 				addExpandTerm(i+1, ord, byteValue, termValue, terms);

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/Formula.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/Formula.java
@@ -30,7 +30,9 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 
 class Formula {
@@ -63,26 +65,32 @@ class Formula {
 	    table[dontCares][ones].add(termList.get(i));
 	}
         for(int dontKnows=0; dontKnows <= numVars - 1; dontKnows++) {
+            // Use LinkedHashSet for output lists and copy final result to
+            // ArrayList so that we have more efficient operations involving
+            // element identity (contains, removes) while building the list.
+            Set<Term> terms = new LinkedHashSet<Term>(termList);
 	    for(int ones=0; ones <= numVars - 1; ones++) {
 	        ArrayList<Term> left   = table[dontKnows][ones];
 	        ArrayList<Term> right  = table[dontKnows][ones + 1];
-	        ArrayList<Term> out    = table[dontKnows+1][ones];
+	        Set<Term> out    = new LinkedHashSet<Term>();
 	        for(int leftIdx = 0; leftIdx < left.size(); leftIdx++) {
 	            for(int rightIdx = 0; rightIdx < right.size(); rightIdx++) {
 	                Term combined = left.get(leftIdx).combine(right.get(rightIdx));
 	                if (combined != null) {
 	                    if (!out.contains(combined)) {
-	                        out.add(combined); 
+	                        out.add(combined);
 	                    }
-	                    termList.remove(left.get(leftIdx));
-			    termList.remove(right.get(rightIdx));
-			    if (!termList.contains(combined)) {
-			        termList.add(combined);
+	                    terms.remove(left.get(leftIdx));
+			    terms.remove(right.get(rightIdx));
+			    if (!terms.contains(combined)) {
+			        terms.add(combined);
 			    }
 	                }
 	            }
 	        }
+	        table[dontKnows+1][ones] = new ArrayList<Term>(out);
 	    }
+	    termList = new ArrayList<Term>(terms);
 	}
     }
     public void reducePrimeImplicantsToSubset() {

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/Term.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/Term.java
@@ -30,13 +30,16 @@ import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-class Term {
+public final class Term {
     public static final byte DontCare = 2;
 
     public Term(byte[] varVals) {
         this.varVals = varVals;
+        // Terms are immutable, like Strings, so we can calculate the
+        // hash once and save it.
+        this.hash = Arrays.hashCode(varVals);
     }
-    
+
     public int getNumVars() {
         return varVals.length;
     }
@@ -86,16 +89,17 @@ class Term {
     public boolean equals(Object o) {
         if (o == this) {
             return true;
-        } else if (o == null || !getClass().equals(o.getClass())) {
-            return false;
-        } else {
-            Term rhs = (Term)o;
-            return Arrays.equals(this.varVals, rhs.varVals);
         }
+        if (o == null || !getClass().equals(o.getClass()) || hash != ((Term)o).hash) {
+            return false;
+        }
+        return Arrays.equals(this.varVals, ((Term)o).varVals);
     }
+
     public int hashCode() {
-        return varVals.hashCode();
+        return hash;
     }
+
     boolean implies(Term term) {
         for(int i=0; i<varVals.length; i++) {
             if (this.varVals[i] != DontCare &&
@@ -105,11 +109,11 @@ class Term {
         }
         return true;
     }
-    
-    byte[] getVarValues() {
-    	return varVals;
+
+    byte get(int i) {
+    	return varVals[i];
     }
-    
+
     public static Term read(Reader reader) throws IOException {
         int c = '\0';
         ArrayList<Byte> t = new ArrayList<Byte>();
@@ -132,6 +136,7 @@ class Term {
         }
     }
 
-    private byte[] varVals;
+    private final byte[] varVals;
+    private final int hash;
 }
 


### PR DESCRIPTION
Java profiling revealed hotspots in some methods use for simplifying boolean expressions.  Theses changes remove some inefficiencies and reduce the the CPU time used in BooleanFormula.simplify() by more than %50