### PR TITLE
Consistent use of compiler options

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/deps/DepParser.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/deps/DepParser.java
@@ -18,6 +18,7 @@ package com.ibm.jaggr.core.impl.deps;
 
 import com.ibm.jaggr.core.impl.deps.DepUtils.ParseResult;
 import com.ibm.jaggr.core.resource.IResourceVisitor;
+import com.ibm.jaggr.core.util.CompilerUtil;
 
 import com.google.javascript.jscomp.Compiler;
 import com.google.javascript.jscomp.JSSourceFile;
@@ -72,6 +73,7 @@ final class DepParser implements Callable<URI> {
 		long lastModified = resource.lastModified();
 		// Parse the javascript code
 		Compiler compiler = new Compiler();
+		compiler.initOptions(CompilerUtil.getDefaultOptions());
 		InputStream in = resource.getInputStream();
 		Node node = null;
 		try {

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilder.java
@@ -38,6 +38,7 @@ import com.ibm.jaggr.core.transport.IHttpTransport;
 import com.ibm.jaggr.core.transport.IHttpTransport.OptimizationLevel;
 import com.ibm.jaggr.core.transport.IRequestedModuleNames;
 import com.ibm.jaggr.core.util.BooleanTerm;
+import com.ibm.jaggr.core.util.CompilerUtil;
 import com.ibm.jaggr.core.util.ConcurrentListBuilder;
 import com.ibm.jaggr.core.util.DependencyList;
 import com.ibm.jaggr.core.util.Features;
@@ -51,7 +52,6 @@ import com.google.javascript.jscomp.CheckLevel;
 import com.google.javascript.jscomp.CompilationLevel;
 import com.google.javascript.jscomp.Compiler;
 import com.google.javascript.jscomp.CompilerOptions;
-import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 import com.google.javascript.jscomp.CustomPassExecutionTime;
 import com.google.javascript.jscomp.DiagnosticGroups;
 import com.google.javascript.jscomp.JSError;
@@ -325,9 +325,8 @@ public class JavaScriptModuleBuilder implements IModuleBuilder, IExtensionInitia
 		String output = null;
 
 		Compiler compiler = new Compiler();
-		CompilerOptions compiler_options = new CompilerOptions();
+		CompilerOptions compiler_options = CompilerUtil.getDefaultOptions();
 		compiler_options.customPasses = HashMultimap.create();
-		compiler_options.setLanguageIn(LanguageMode.ECMASCRIPT5);
 		if (isHasFiltering && (level != null || keyGens == null)) {
 			// Run has filtering compiler pass if we are doing has filtering, or if this
 			// is the first build for this module (keyGens == null) so that we can get

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/CompilerUtil.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/CompilerUtil.java
@@ -1,0 +1,28 @@
+/*
+ * (C) Copyright 2012, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.jaggr.core.util;
+
+import com.google.javascript.jscomp.CompilerOptions;
+import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
+
+public class CompilerUtil {
+
+	public static CompilerOptions getDefaultOptions() {
+		CompilerOptions options = new CompilerOptions();
+		options.setLanguageIn(LanguageMode.ECMASCRIPT5);
+		return options;
+	}
+}


### PR DESCRIPTION
Both the JavaScript module builder and the dependency parser need to use the same compiler language options to avoid issues with syntax that's supported by one but not the other (e.g. trailing commas).