### PR TITLE
LESS CSS performance improvements

### DIFF
--- a/jaggr-core/pom.xml
+++ b/jaggr-core/pom.xml
@@ -184,7 +184,6 @@
               guava,
               rhino,
               wink-json4j,
-              lesscss,
               commons-logging
             </Embed-Dependency>
             <Embed-Directory>lib</Embed-Directory>
@@ -219,6 +218,21 @@
               <outputDirectory>lib</outputDirectory>
             </configuration>
           </execution>
+          <execution>
+            <id>copy less css parser</id>
+            <phase>generate-sources</phase>
+            <goals><goal>unpack</goal></goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.lesscss</groupId>
+                  <artifactId>lesscss</artifactId>
+                  <includes>**/less-rhino*.js</includes>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${project.build.directory}/lesscss</outputDirectory>
+            </configuration>
+          </execution>
           <execution><!-- For testing has feature encoding. -->
             <id>unpack-dojo</id>
             <phase>generate-test-resources</phase>
@@ -248,6 +262,7 @@
             <exclude>src/main/java/com/ibm/jaggr/core/util/Formula.java</exclude>
             <exclude>src/main/java/com/ibm/jaggr/core/util/NLS.java</exclude>
             <exclude>WebContent/postcss/postcss.js</exclude>
+            <exclude>src/main/resources/less-rhino-1.7.0.js</exclude>
             <exclude>src/test/resources/specRunner.htmltemplate</exclude>
           </excludes>
         </configuration>
@@ -270,6 +285,7 @@
               <directory>.</directory>
               <includes>
                 <include>lib/**</include>
+                <include>src/main/resources/less*.js</include>
               </includes>
               <followSymlinks>false</followSymlinks>
             </fileset>
@@ -310,6 +326,22 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
           <executions>
+            <execution>
+              <id>copy less parser</id>
+              <phase>generate-resources</phase>
+              <goals>
+                <goal>run</goal>
+              </goals>
+              <configuration>
+                <target>
+                  <move tofile="${basedir}/src/main/resources/less-rhino-1.7.0.js">
+                    <fileset dir="${project.build.directory}/lesscss">
+                      <include name="**/less-rhino*.js" />
+                    </fileset>
+                  </move>
+                </target>  
+              </configuration>
+            </execution>
             <execution>
               <id>rename-dojo-test-dir</id>
               <phase>generate-test-resources</phase>

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/options/OptionsImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/options/OptionsImpl.java
@@ -26,7 +26,7 @@ import com.ibm.jaggr.core.options.IOptions;
 import com.ibm.jaggr.core.options.IOptionsListener;
 import com.ibm.jaggr.core.util.SequenceNumberProvider;
 
-import org.lesscss.deps.org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.FilenameUtils;
 
 import java.io.File;
 import java.io.FileWriter;

--- a/jaggr-core/src/main/resources/.gitignore
+++ b/jaggr-core/src/main/resources/.gitignore
@@ -1,0 +1,1 @@
+/less-rhino-1.7.0.js

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/less/LessModuleBuilderTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/less/LessModuleBuilderTest.java
@@ -110,13 +110,13 @@ public class LessModuleBuilderTest extends EasyMock {
 	@Test
 	public void testLessCompilationWithImport() throws Exception {
 		String output;
-		URI resUri = testdir.toURI();
+		URI resUri = new File(testdir, "colors.less").toURI();
 		output = buildLess(new StringResource(LESS, resUri));
 		Assert.assertEquals("body{background:#ff0000}", output);
 	}
 
 	private String buildLess(StringResource less) throws IOException {
-		Reader reader = builder.getContentReader("test", less, mockRequest,
+		Reader reader = builder.getContentReader("colors.less", less, mockRequest,
 				keyGens);
 		StringWriter writer = new StringWriter();
 		CopyUtil.copy(reader, writer);

--- a/jaggr-service/plugin.xml
+++ b/jaggr-service/plugin.xml
@@ -56,7 +56,7 @@
 		<builder extension="js"
 		         class="com.ibm.jaggr.core.impl.modulebuilder.javascript.JavaScriptModuleBuilder"/>
 		<builder extension="css"
-		         class="com.ibm.jaggr.core.impl.modulebuilder.css.CSSModuleBuilder"/>
+		         class="com.ibm.jaggr.core.impl.modulebuilder.less.LessModuleBuilder"/>
 		<builder extension="less"
 		         class="com.ibm.jaggr.core.impl.modulebuilder.less.LessModuleBuilder"/>
 		<builder extension="*"

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorCommandProviderGogo.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorCommandProviderGogo.java
@@ -29,7 +29,6 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 public class AggregatorCommandProviderGogo extends AggregatorCommandProvider {
 


### PR DESCRIPTION
Remove serialization around invokation of LESS CSS parser.  LESS parser now uses CSS module builder thread scopes for running the parser JavaScript code.