### PR TITLE
Minor fixes

### DIFF
--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorCommandProvider.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorCommandProvider.java
@@ -76,7 +76,7 @@ public class AggregatorCommandProvider implements CommandProvider {
 	static final String CMD_GETSERVLETDIR = "getservletdir"; //$NON-NLS-1$
 	static final String CMD_FORCEERROR = "forceerror"; //$NON-NLS-1$
 	static final String CMD_PROCESSREQUEST = "processrequesturl"; //$NON-NLS-1$
-	static final String CMD_CREATECACHEBUNDLE = "createCacheBundle"; //$NON-NLS-1$
+	static final String CMD_CREATECACHEBUNDLE = "createcachebundle"; //$NON-NLS-1$
 	static final String NEWLINE = "\r\n"; //$NON-NLS-1$
 
 	static final String[] COMMANDS = new String[] {

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorCommandProviderGogo.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorCommandProviderGogo.java
@@ -176,7 +176,7 @@ public class AggregatorCommandProviderGogo extends AggregatorCommandProvider {
 	}
 
 	@Descriptor("creates a cache primer bundle")
-	public String createCacheBundle(CommandSession cs,
+	public String createcachebundle(CommandSession cs,
 			@Descriptor("<servlet>")String servlet,
 			@Descriptor("<symbolic-bunle-name>")String symbolicBundleName,
 			@Descriptor("<bundle-filename>")String bundleFilename
@@ -186,7 +186,7 @@ public class AggregatorCommandProviderGogo extends AggregatorCommandProvider {
 	}
 
 	@Descriptor("processes the specified request url (useful for cache priming)")
-	public String processconsolerequest(CommandSession cs,
+	public String processrequesturl(CommandSession cs,
 			@Descriptor("<servlet>")String servlet,
 			@Descriptor("<request-url")String requestUrl
 			) throws InvalidSyntaxException, IOException, ServletException {

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorImpl.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorImpl.java
@@ -170,6 +170,11 @@ public class AggregatorImpl extends AbstractAggregatorImpl implements IExecutabl
 				}
 			}
 		}
+		Properties dict = new Properties();
+		dict.put("name", getName()); //$NON-NLS-1$
+		registrations.add(new ServiceRegistrationOSGi(Activator.getBundleContext().registerService(
+				IAggregator.class.getName(), this, dict)));
+
 	}
 
 	public InitParams getConfigInitParams(IConfigurationElement configElem) {
@@ -258,10 +263,6 @@ public class AggregatorImpl extends AbstractAggregatorImpl implements IExecutabl
 					);
 		}
 
-		Properties dict = new Properties();
-		dict.put("name", getName()); //$NON-NLS-1$
-		registrations.add(new ServiceRegistrationOSGi(Activator.getBundleContext().registerService(
-				IAggregator.class.getName(), this, dict)));
 		if (isTraceLogging) {
 			log.exiting(sourceClass, sourceMethod);
 		}


### PR DESCRIPTION
Move initialization of the aggregator service in the OSGi service registry to the end of servlet init() processing so that the service won't be available before the servlet is initialized.

Fix command names (lowercase and consistent names between gogo and standard command handlers)