### PR TITLE
Various fixes and performance improvements relating to cache priming

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/cachekeygenerator/I18nCacheKeyGenerator.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/cachekeygenerator/I18nCacheKeyGenerator.java
@@ -60,30 +60,34 @@ public final class I18nCacheKeyGenerator implements ICacheKeyGenerator {
 		@SuppressWarnings("unchecked")
 		Collection<String> requestedLocales = (Collection<String>)request.getAttribute(IHttpTransport.REQUESTEDLOCALES_REQATTRNAME);
 		if (requestedLocales != null && requestedLocales.size() > 0) {
-			int i = 0;
-			for (String locale : requestedLocales) {
-				if (availableLocales == null) {
-					sb.append(i++ > 0 ? "," : "").append(locale); //$NON-NLS-1$ //$NON-NLS-2$
-				} else {
-					String[] a = locale.split("-"); //$NON-NLS-1$
-					String language = a[0].toLowerCase();
-					String country = (a.length > 1) ? a[1].toLowerCase() : ""; //$NON-NLS-1$
-					String varient = (a.length > 2) ? a[2].toLowerCase() : ""; //$NON-NLS-1$
-					if (
-							language.length() > 0 &&
-							country.length() > 0 &&
-							varient.length() > 0 &&
-							availableLocales.contains(language+"-"+country+"-"+varient)) { //$NON-NLS-1$ //$NON-NLS-2$
-						sb.append(i++ > 0 ? "," : "").append(language+"-"+country+"-"+varient); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-					} else if (
-							language.length() > 0 &&
-							country.length() > 0 &&
-							availableLocales.contains(language+"-"+country)) { //$NON-NLS-1$
-						sb.append(i++ > 0 ? "," : "").append(language+"-"+country); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-					} else if (
-							language.length() > 0 &&
-							availableLocales.contains(language)) {
-						sb.append(i++ > 0 ? "," : "").append(language); //$NON-NLS-1$ //$NON-NLS-2$
+			if (requestedLocales.contains("*")) { //$NON-NLS-1$
+				sb.append("*"); //$NON-NLS-1$
+			} else {
+				int i = 0;
+				for (String locale : requestedLocales) {
+					if (availableLocales == null) {
+						sb.append(i++ > 0 ? "," : "").append(locale); //$NON-NLS-1$ //$NON-NLS-2$
+					} else {
+						String[] a = locale.split("-"); //$NON-NLS-1$
+						String language = a[0].toLowerCase();
+						String country = (a.length > 1) ? a[1].toLowerCase() : ""; //$NON-NLS-1$
+						String varient = (a.length > 2) ? a[2].toLowerCase() : ""; //$NON-NLS-1$
+						if (
+								language.length() > 0 &&
+								country.length() > 0 &&
+								varient.length() > 0 &&
+								availableLocales.contains(language+"-"+country+"-"+varient)) { //$NON-NLS-1$ //$NON-NLS-2$
+							sb.append(i++ > 0 ? "," : "").append(language+"-"+country+"-"+varient); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+						} else if (
+								language.length() > 0 &&
+								country.length() > 0 &&
+								availableLocales.contains(language+"-"+country)) { //$NON-NLS-1$
+							sb.append(i++ > 0 ? "," : "").append(language+"-"+country); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+						} else if (
+								language.length() > 0 &&
+								availableLocales.contains(language)) {
+							sb.append(i++ > 0 ? "," : "").append(language); //$NON-NLS-1$ //$NON-NLS-2$
+						}
 					}
 				}
 			}

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/deps/ModuleDeps.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/deps/ModuleDeps.java
@@ -169,18 +169,29 @@ public class ModuleDeps extends LinkedHashMap<String, ModuleDepInfo> {
 	}
 
 	/**
-	 * Returns a set of module ids for the keys in this map. If the module dep
-	 * info objects associated with a key specifies has plugin prefixes, then
-	 * the entries will include the prefixes. Note that one map entry may result
-	 * in multiple (or zero) result entries depending on the evaluation of the
-	 * boolean formula which represents the has conditionals.
+	 * Provided for backwards compatibility
 	 *
 	 * @return The set of module ids
 	 */
 	public Set<String> getModuleIds() {
+		return getModuleIds(null);
+	}
+
+	/**
+	 * Returns a set of module ids for the keys in this map. If the module dep info objects associated
+	 * with a key specifies has plugin prefixes, then the entries will include the prefixes. Note that
+	 * one map entry may result in multiple (or zero) result entries depending on the evaluation of
+	 * the boolean formula which represents the has conditionals.
+	 *
+	 * @param formulaCache
+	 *          the formula cache or null
+	 *
+	 * @return The set of module ids
+	 */
+	public Set<String> getModuleIds(Map<?, ?> formulaCache) {
 		Set<String> result = new LinkedHashSet<String>();
 		for (Map.Entry<String, ModuleDepInfo> entry : entrySet()) {
-			Collection<String> prefixes = entry.getValue().getHasPluginPrefixes();
+			Collection<String> prefixes = entry.getValue().getHasPluginPrefixes(formulaCache);
 			if (prefixes == null) {
 				result.add(entry.getKey());
 			} else {
@@ -228,6 +239,20 @@ public class ModuleDeps extends LinkedHashMap<String, ModuleDepInfo> {
 	public ModuleDeps resolveWith(Features features) {
 		for (ModuleDepInfo info : values()) {
 			info.resolveWith(features);
+		}
+		return this;
+	}
+
+	/**
+	 * Simplifies the boolean formulas for each contained {@link ModuleDepInfo}
+	 *
+	 * @param formulaCache
+	 *          the formula cache
+	 * @return this object
+	 */
+	public ModuleDeps simplify(Map<?, ?> formulaCache) {
+		for (ModuleDepInfo info : values()) {
+			info.simplify(formulaCache);
 		}
 		return this;
 	}

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerBuilder.java
@@ -295,7 +295,7 @@ public class LayerBuilder {
 		if (reader.isError()) {
 			mid = future.getModule().getModuleName();
 		}
-		addTransportContribution(request, transport, sb, type, mid);
+		addTransportContribution(request, transport, sb, type, new IHttpTransport.ModuleInfo(mid, reader.isScript()));
 
 		count++;
 		// Add the reader to the result
@@ -309,7 +309,7 @@ public class LayerBuilder {
 		// Add post-module transport contribution
 		type = (source == ModuleSpecifier.LAYER || source == ModuleSpecifier.BUILD_ADDED && required) ?
 				LayerContributionType.AFTER_LAYER_MODULE : LayerContributionType.AFTER_MODULE;
-		addTransportContribution(request, transport, sb, type, mid);
+		addTransportContribution(request, transport, sb, type, new IHttpTransport.ModuleInfo(mid, reader.isScript()));
 
 		// Process any after modules by recursively calling this method
 		if (!TypeUtil.asBoolean(request.getAttribute(IHttpTransport.NOADDMODULES_REQATTRNAME))) {

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/module/NotFoundModule.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/module/NotFoundModule.java
@@ -60,7 +60,7 @@ public class NotFoundModule extends ModuleIdentifier implements IModule, Cloneab
 						errorMessage,
 						getModuleName(),
 						request
-					),
+					), true,
 					null,
 					errorMessage
 				)

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/RequireExpansionCompilerPass.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/RequireExpansionCompilerPass.java
@@ -45,6 +45,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * Custom Compiler pass for Google Closure compiler to do require list explosion.
  * Scans the AST for require calls and explodes any require lists it finds to
@@ -413,7 +415,9 @@ public class RequireExpansionCompilerPass implements CompilerPass {
 		expandedDeps.subtractAll(filter);
 
 		expandedDepsList.add(expandedDeps);
-		if (expandedDeps.getModuleIds().size() > 0) {
+		HttpServletRequest request = aggregator.getCurrentRequest();
+		Map<?,?> formulaCache = request != null ? (Map<?,?>)request.getAttribute(JavaScriptModuleBuilder.FORMULA_CACHE_REQATTR) : null;
+		if (expandedDeps.getModuleIds(formulaCache).size() > 0) {
 			int listIndex = expandedDepsList.size()-1;
 			if (logDebug) {
 				msg = new LinkedList<String>();

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/AbstractHttpTransport.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/AbstractHttpTransport.java
@@ -826,20 +826,20 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IConfigMo
 			break;
 		case BEFORE_FIRST_MODULE:
 			if (previousType != LayerContributionType.BEGIN_MODULES ||
-			!(arg instanceof String)) {
+			!(arg instanceof ModuleInfo)) {
 				throw new IllegalStateException();
 			}
 			break;
 		case BEFORE_SUBSEQUENT_MODULE:
 			if (previousType != LayerContributionType.AFTER_MODULE ||
-			!(arg instanceof String)) {
+			!(arg instanceof ModuleInfo)) {
 				throw new IllegalStateException();
 			}
 			break;
 		case AFTER_MODULE:
 			if (previousType != LayerContributionType.BEFORE_FIRST_MODULE &&
 			previousType != LayerContributionType.BEFORE_SUBSEQUENT_MODULE ||
-			!(arg instanceof String)) {
+			!(arg instanceof ModuleInfo)) {
 				throw new IllegalStateException();
 			}
 			break;
@@ -857,20 +857,20 @@ public abstract class AbstractHttpTransport implements IHttpTransport, IConfigMo
 			break;
 		case BEFORE_FIRST_LAYER_MODULE:
 			if (previousType != LayerContributionType.BEGIN_LAYER_MODULES ||
-			!(arg instanceof String)) {
+			!(arg instanceof ModuleInfo)) {
 				throw new IllegalStateException();
 			}
 			break;
 		case BEFORE_SUBSEQUENT_LAYER_MODULE:
 			if (previousType != LayerContributionType.AFTER_LAYER_MODULE ||
-			!(arg instanceof String)) {
+			!(arg instanceof ModuleInfo)) {
 				throw new IllegalStateException();
 			}
 			break;
 		case AFTER_LAYER_MODULE:
 			if (previousType != LayerContributionType.BEFORE_FIRST_LAYER_MODULE &&
 			previousType != LayerContributionType.BEFORE_SUBSEQUENT_LAYER_MODULE ||
-			!(arg instanceof String)) {
+			!(arg instanceof ModuleInfo)) {
 				throw new IllegalStateException();
 			}
 			break;

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/layer/ILayerListener.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/layer/ILayerListener.java
@@ -73,8 +73,8 @@ public interface ILayerListener {
 	 * @param modules
 	 *            The list of modules in the layer.  Note that modules added to
 	 *            the layer by module builders using the
-	 *            {@link ModuleBuild#addBefore(IModule)} and
-	 *            {@link ModuleBuild#addAfter(IModule)} methods are not included
+	 *            {@link ModuleBuild#addBefore(String)} and
+	 *            {@link ModuleBuild#addAfter(String)} methods are not included
 	 *            in the list.  For the BEGIN_MODULE event, the list contains
 	 *            only the single module that is being added to the layer.
 	 * @param dependentFeatures

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/modulebuilder/IModuleBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/modulebuilder/IModuleBuilder.java
@@ -217,5 +217,22 @@ public interface IModuleBuilder {
 	 */
 	public List<ICacheKeyGenerator> getCacheKeyGenerators(IAggregator aggregator);
 
+	/**
+	 * Returns true if this module builder handles the specified resource
+	 *
+	 * @param mid
+	 *            the module id
+	 * @param resource
+	 *            the resource for the module id
+	 * @return true if this builder can build the module
+	 */
 	public boolean handles(String mid, IResource resource);
+
+	/**
+	 * @param request
+	 *            the request object
+	 * @return true if the output of this builder for the specified request is executable script
+	 *         code
+	 */
+	public boolean isScript(HttpServletRequest request);
 }

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/modulebuilder/ModuleBuild.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/modulebuilder/ModuleBuild.java
@@ -19,7 +19,6 @@ package com.ibm.jaggr.core.modulebuilder;
 import com.ibm.jaggr.core.IAggregator;
 import com.ibm.jaggr.core.cachekeygenerator.ICacheKeyGenerator;
 import com.ibm.jaggr.core.cachekeygenerator.KeyGenUtil;
-import com.ibm.jaggr.core.module.IModule;
 import com.ibm.jaggr.core.resource.IResource;
 
 import java.util.Collections;
@@ -35,8 +34,8 @@ import javax.servlet.http.HttpServletRequest;
  */
 public final class ModuleBuild {
 	private Object buildOutput;
-	private List<IModule> before;
-	private List<IModule> after;
+	private List<String> before;
+	private List<String> after;
 	private List<ICacheKeyGenerator> keyGenerators;
 	private String error;
 
@@ -118,13 +117,13 @@ public final class ModuleBuild {
 	 * Before modules are included in the layer build that contains this
 	 * module build ahead of this module build.
 	 *
-	 * @param module The module to add to the before list
+	 * @param moduleId The module id to add to the before list
 	 */
-	public void addBefore(IModule module) {
+	public void addBefore(String moduleId) {
 		if (before == null) {
-			before = new LinkedList<IModule>();
+			before = new LinkedList<String>();
 		}
-		before.add(module);
+		before.add(moduleId);
 	}
 
 	/**
@@ -133,13 +132,13 @@ public final class ModuleBuild {
 	 * After modules are included in the layer build that contains this
 	 * module build following this module build.
 	 *
-	 * @param module The module to add to the after list
+	 * @param moduleId The module id to add to the after list
 	 */
-	public void addAfter(IModule module) {
+	public void addAfter(String moduleId) {
 		if (after == null) {
-			after = new LinkedList<IModule>();
+			after = new LinkedList<String>();
 		}
-		after.add(module);
+		after.add(moduleId);
 	}
 
 	/**
@@ -148,8 +147,8 @@ public final class ModuleBuild {
 	 *
 	 * @return The list of before modules.
 	 */
-	public List<IModule> getBefore() {
-		return before == null ? Collections.<IModule>emptyList() : Collections.unmodifiableList(before);
+	public List<String> getBefore() {
+		return before == null ? Collections.<String>emptyList() : Collections.unmodifiableList(before);
 	}
 
 	/**
@@ -158,7 +157,7 @@ public final class ModuleBuild {
 	 *
 	 * @return The list of after modules.
 	 */
-	public List<IModule> getAfter() {
-		return after == null ? Collections.<IModule>emptyList() : Collections.unmodifiableList(after);
+	public List<String> getAfter() {
+		return after == null ? Collections.<String>emptyList() : Collections.unmodifiableList(after);
 	}
 }

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/readers/ModuleBuildReader.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/readers/ModuleBuildReader.java
@@ -41,18 +41,21 @@ public class ModuleBuildReader extends Reader {
 	private List<ModuleBuildFuture> before;
 	private List<ModuleBuildFuture> after;
 	private List<ICacheKeyGenerator> keyGenerators;
-	private String error;
+	private final boolean isScript;
+	private final String error;
 
 	/**
 	 * Constructor for a Build object specifying a reader, key generator
 	 * and error flag.
 	 *
 	 * @param reader A {@link Reader} to the build content
+	 * @param isScript true if the reader content is executable script code
 	 * @param keyGens The {@link ICacheKeyGenerator} list for this IModule
 	 * @param error If not null, then an message describing the error
 	 */
-	public ModuleBuildReader(Reader reader, List<ICacheKeyGenerator> keyGens, String error) {
+	public ModuleBuildReader(Reader reader, boolean isScript, List<ICacheKeyGenerator> keyGens, String error) {
 		this.reader = reader;
+		this.isScript = isScript;
 		this.keyGenerators = keyGens;
 		this.error = error;
 		before = after = null;
@@ -65,18 +68,20 @@ public class ModuleBuildReader extends Reader {
 	 * Consturctor for a reader with no cache key generator and no error
 	 *
 	 * @param reader A {@link Reader} to the build content
+	 * @param isScript true if the reader content is executable script code
 	 */
-	public ModuleBuildReader(Reader reader) {
-		this(reader, null, null);
+	public ModuleBuildReader(Reader reader, boolean isScript) {
+		this(reader, isScript, null, null);
 	}
 
 	/**
 	 * Constructor for a build reader from a string
 	 *
 	 * @param str the string
+	 * @param isScript true if the string contains executable script code
 	 */
-	public ModuleBuildReader(String str) {
-		this(new StringReader(str));
+	public ModuleBuildReader(String str, boolean isScript) {
+		this(new StringReader(str), isScript);
 	}
 
 	/**
@@ -103,6 +108,13 @@ public class ModuleBuildReader extends Reader {
 
 	public String getErrorMessage() {
 		return error;
+	}
+
+	/**
+	 * @return true if the content is scirpt code
+	 */
+	public boolean isScript() {
+		return isScript;
 	}
 
 	/* (non-Javadoc)

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/transport/IHttpTransport.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/transport/IHttpTransport.java
@@ -346,7 +346,7 @@ public interface IHttpTransport extends IExtensionInitializer {
 	 * @param type
 	 *            The layer contribution type
 	 * @param arg
-	 *            This parameter specifies the module id as a string for the following
+	 *            This parameter specifies a {@link ModuleInfo} object for the following
 	 *            {@code type} values:
 	 *            <ul>
 	 *            <li>{@link LayerContributionType#BEFORE_FIRST_MODULE}</li>
@@ -450,5 +450,24 @@ public interface IHttpTransport extends IExtensionInitializer {
 	 * @return the plugin name
 	 */
 	public String getAggregatorTextPluginName();
+
+	public class ModuleInfo {
+		private final String mid;
+		private final boolean isScript;
+		public ModuleInfo(String mid, boolean isScript) {
+			this.mid = mid;
+			this.isScript = isScript;
+		}
+
+		/**
+		 * @return the module id
+		 */
+		public String getModuleId() { return mid; }
+
+		/**
+		 * @return true if the module is a script module
+		 */
+		public boolean isScript() { return isScript; }
+	}
 
 }

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/deps/ModuleDepsTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/deps/ModuleDepsTest.java
@@ -96,7 +96,7 @@ public class ModuleDepsTest {
 		Assert.assertTrue(deps.containsDep("module4", BooleanTerm.FALSE));
 
 		Assert.assertTrue(deps.add("module1", new ModuleDepInfo("has", new BooleanTerm("!A"), null)));
-		Assert.assertTrue(deps.containsDep("module1", BooleanTerm.TRUE));
+		Assert.assertTrue(deps.simplify(null).containsDep("module1", BooleanTerm.TRUE));
 	}
 
 	@Test

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/deps/DepTreeTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/deps/DepTreeTest.java
@@ -90,5 +90,6 @@ public class DepTreeTest {
 		@Override public ModuleBuild build(String mid, IResource resource, HttpServletRequest request, List<ICacheKeyGenerator> keyGens) throws Exception {	return null; }
 		@Override public List<ICacheKeyGenerator> getCacheKeyGenerators(IAggregator aggregator) { return null; }
 		@Override public boolean handles(String mid, IResource resource) { return false; }
+		@Override public boolean isScript(HttpServletRequest request) { return true; }
 	}
 }

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerBuilderTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerBuilderTest.java
@@ -47,6 +47,7 @@ import com.ibm.jaggr.core.test.TestCacheManager;
 import com.ibm.jaggr.core.test.TestUtils;
 import com.ibm.jaggr.core.transport.IHttpTransport;
 import com.ibm.jaggr.core.transport.IHttpTransport.LayerContributionType;
+import com.ibm.jaggr.core.transport.IHttpTransport.ModuleInfo;
 import com.ibm.jaggr.core.util.CopyUtil;
 
 import org.easymock.EasyMock;
@@ -124,21 +125,21 @@ public class LayerBuilderTest {
 							Assert.assertNull(arg);
 							return ")";
 						case BEFORE_FIRST_MODULE:
-							return "\"<"+arg+">";
+							return "\"<"+((ModuleInfo)arg).getModuleId()+">";
 						case BEFORE_SUBSEQUENT_MODULE:
-							return ",\"<"+arg+">";
+							return ",\"<"+((ModuleInfo)arg).getModuleId()+">";
 						case AFTER_MODULE:
-							return "<"+arg+">\"";
+							return "<"+((ModuleInfo)arg).getModuleId()+">\"";
 						case BEGIN_LAYER_MODULES:
 							return arg.toString()+"{";
 						case END_LAYER_MODULES:
 							return "}"+arg;
 						case BEFORE_FIRST_LAYER_MODULE:
-							return "'<"+arg+">";
+							return "'<"+((ModuleInfo)arg).getModuleId()+">";
 						case BEFORE_SUBSEQUENT_LAYER_MODULE:
-							return ",'<"+arg+">";
+							return ",'<"+((ModuleInfo)arg).getModuleId()+">";
 						case AFTER_LAYER_MODULE:
-							return "<"+arg+">'";
+							return "<"+((ModuleInfo)arg).getModuleId()+">'";
 						}
 						throw new IllegalArgumentException();
 					}
@@ -286,7 +287,7 @@ public class LayerBuilderTest {
 					mbr.addBefore(
 							new ModuleBuildFuture(
 									new ModuleImpl("mBefore", new URI("file:/c:/mBefore.js")),
-									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"))),
+									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"),true)),
 									ModuleSpecifier.BUILD_ADDED)
 							);
 				} catch (Exception e) {
@@ -313,7 +314,7 @@ public class LayerBuilderTest {
 					mbr.addBefore(
 							new ModuleBuildFuture(
 									new ModuleImpl("mBefore", new URI("file:/c:/mBefore.js")),
-									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"))),
+									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"), true)),
 									ModuleSpecifier.BUILD_ADDED)
 							);
 				} catch (Exception e) {
@@ -341,7 +342,7 @@ public class LayerBuilderTest {
 					mbr.addAfter(
 							new ModuleBuildFuture(
 									new ModuleImpl("mAfter", new URI("file:/c:/mAfter.js")),
-									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"))),
+									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"), true)),
 									ModuleSpecifier.BUILD_ADDED)
 							);
 				} catch (Exception e) {
@@ -368,7 +369,7 @@ public class LayerBuilderTest {
 					mbr.addAfter(
 							new ModuleBuildFuture(
 									new ModuleImpl("mAfter", new URI("file:/c:/mAfter.js")),
-									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"))),
+									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("bar"), true)),
 									ModuleSpecifier.BUILD_ADDED)
 							);
 				} catch (Exception e) {
@@ -409,14 +410,14 @@ public class LayerBuilderTest {
 					mbr.addAfter(
 							new ModuleBuildFuture(
 									new ModuleImpl("mAfter", new URI("file:/c:/mAfter.js")),
-									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("after"))),
+									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("after"), true)),
 									ModuleSpecifier.BUILD_ADDED)
 							);
 					mbr = futures.get(1).get();
 					mbr.addBefore(
 							new ModuleBuildFuture(
 									new ModuleImpl("mBefore", new URI("file:/c:/mBefore.js")),
-									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("before"))),
+									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("before"), true)),
 									ModuleSpecifier.BUILD_ADDED)
 							);
 				} catch (Exception e) {
@@ -446,14 +447,14 @@ public class LayerBuilderTest {
 					mbr.addAfter(
 							new ModuleBuildFuture(
 									new ModuleImpl("mAfter", new URI("file:/c:/mAfter.js")),
-									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("after"))),
+									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("after"), true)),
 									ModuleSpecifier.BUILD_ADDED)
 							);
 					mbr = futures.get(1).get();
 					mbr.addBefore(
 							new ModuleBuildFuture(
 									new ModuleImpl("mBefore", new URI("file:/c:/mBefore.js")),
-									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("before"))),
+									new CompletedFuture<ModuleBuildReader>(new ModuleBuildReader(new StringReader("before"), true)),
 									ModuleSpecifier.BUILD_ADDED)
 							);
 				} catch (Exception e) {
@@ -526,7 +527,7 @@ public class LayerBuilderTest {
 					throw new NotFoundException(module.getModuleName());
 				}
 				return new CompletedFuture<ModuleBuildReader>(
-						new ModuleBuildReader(new StringReader(module.getModuleId() + " build"))
+						new ModuleBuildReader(new StringReader(module.getModuleId() + " build"), true)
 						);
 			}
 		}).anyTimes();
@@ -739,7 +740,7 @@ public class LayerBuilderTest {
 				if (mbrKeygens != null) {
 					mbrKeygen = mbrKeygens.get(mid);
 				}
-				ModuleBuildReader mbr = new ModuleBuildReader(new StringReader(content.get(mid)), mbrKeygen, null);
+				ModuleBuildReader mbr = new ModuleBuildReader(new StringReader(content.get(mid)), true, mbrKeygen, null);
 				ModuleBuildFuture future = new ModuleBuildFuture(
 						new ModuleImpl(mid, entry.getModule().getURI()),
 						new CompletedFuture<ModuleBuildReader>(mbr),

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/css/CSSModuleBuilderTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/css/CSSModuleBuilderTest.java
@@ -564,15 +564,15 @@ public class CSSModuleBuilderTest extends EasyMock {
 	@Test
 	public void testCacheKeyGen() throws Exception {
 		List<ICacheKeyGenerator> keyGens = builder.getCacheKeyGenerators(mockAggregator);
-		Assert.assertEquals("expn:0;txt:0;css:0:0:0", KeyGenUtil.generateKey(mockRequest, keyGens));
+		Assert.assertEquals("txt:0:0;css:0:0:0", KeyGenUtil.generateKey(mockRequest, keyGens));
 		requestParams.put(CSSModuleBuilder.INLINEIMAGES_REQPARAM_NAME, new String[]{"true"});
-		Assert.assertEquals("expn:0;txt:0;css:0:1:0", KeyGenUtil.generateKey(mockRequest, keyGens));
+		Assert.assertEquals("txt:0:0;css:0:1:0", KeyGenUtil.generateKey(mockRequest, keyGens));
 		requestParams.put(CSSModuleBuilder.INLINEIMPORTS_REQPARAM_NAME, new String[]{"true"});
-		Assert.assertEquals("expn:0;txt:0;css:1:1:0", KeyGenUtil.generateKey(mockRequest, keyGens));
+		Assert.assertEquals("txt:0:0;css:1:1:0", KeyGenUtil.generateKey(mockRequest, keyGens));
 		requestAttributes.put(IHttpTransport.EXPORTMODULENAMES_REQATTRNAME, Boolean.TRUE);
-		Assert.assertEquals("expn:1;txt:0;css:1:1:0", KeyGenUtil.generateKey(mockRequest, keyGens));
+		Assert.assertEquals("txt:0:1;css:1:1:0", KeyGenUtil.generateKey(mockRequest, keyGens));
 		requestAttributes.put(IHttpTransport.SHOWFILENAMES_REQATTRNAME, Boolean.TRUE);
-		Assert.assertEquals("expn:1;txt:0;css:1:1:1", KeyGenUtil.generateKey(mockRequest, keyGens));
+		Assert.assertEquals("txt:0:1;css:1:1:1", KeyGenUtil.generateKey(mockRequest, keyGens));
 	}
 
 	@Test

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/i18n/I18nModuleBuilderTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/i18n/I18nModuleBuilderTest.java
@@ -174,7 +174,7 @@ public class I18nModuleBuilderTest extends EasyMock {
 		System.out.println(output);
 		Assert.assertEquals("define(\"nls/strings\",{locale_label:\"root\"});", output);
 		Assert.assertEquals(1, build.getBefore().size());
-		Assert.assertEquals("nls/en/strings", build.getBefore().get(0).getModuleId());
+		Assert.assertEquals("nls/en/strings", build.getBefore().get(0));
 
 		// Test with an unavailable locale
 		requestAttributes.put(
@@ -229,8 +229,7 @@ public class I18nModuleBuilderTest extends EasyMock {
 		System.out.println(output);
 		Assert.assertEquals("define(\"nls/strings\",{locale_label:\"root\"});", output);
 		Assert.assertEquals(1, build.getBefore().size());
-		Assert.assertEquals("nls/eb/strings", build.getBefore().get(0).getModuleId());
-		Assert.assertEquals(file.toURI(), build.getBefore().get(0).getURI());
+		Assert.assertEquals("nls/eb/strings", build.getBefore().get(0));
 
 		requestAttributes.put(
 				IHttpTransport.REQUESTEDLOCALES_REQATTRNAME,
@@ -263,7 +262,7 @@ public class I18nModuleBuilderTest extends EasyMock {
 		Assert.assertTrue(s.contains("i18n{en-us-var"));
 		Assert.assertEquals(expectedOutput, build.getBuildOutput());
 		Assert.assertEquals(1, build.getBefore().size());
-		Assert.assertEquals("nls/en-us-var/strings", build.getBefore().get(0).getModuleId());
+		Assert.assertEquals("nls/en-us-var/strings", build.getBefore().get(0));
 		requestAttributes.put(
 				IHttpTransport.REQUESTEDLOCALES_REQATTRNAME,
 				Arrays.asList(new String[]{"en-ca-var"}));
@@ -273,7 +272,7 @@ public class I18nModuleBuilderTest extends EasyMock {
 		build = buildIt();
 		Assert.assertEquals(expectedOutput, build.getBuildOutput());
 		Assert.assertEquals(1, build.getBefore().size());
-		Assert.assertEquals("nls/en-ca/strings", build.getBefore().get(0).getModuleId());
+		Assert.assertEquals("nls/en-ca/strings", build.getBefore().get(0));
 
 		requestAttributes.put(
 				IHttpTransport.REQUESTEDLOCALES_REQATTRNAME,
@@ -284,7 +283,7 @@ public class I18nModuleBuilderTest extends EasyMock {
 		build = buildIt();
 		Assert.assertEquals(expectedOutput, build.getBuildOutput());
 		Assert.assertEquals(1, build.getBefore().size());
-		Assert.assertEquals("nls/es/strings", build.getBefore().get(0).getModuleId());
+		Assert.assertEquals("nls/es/strings", build.getBefore().get(0));
 
 		requestAttributes.put(
 				IHttpTransport.REQUESTEDLOCALES_REQATTRNAME,
@@ -305,7 +304,7 @@ public class I18nModuleBuilderTest extends EasyMock {
 		build = buildIt();
 		Assert.assertEquals(expectedOutput, build.getBuildOutput());
 		Assert.assertEquals(1, build.getBefore().size());
-		Assert.assertEquals("nls/en-ca/strings", build.getBefore().get(0).getModuleId());
+		Assert.assertEquals("nls/en-ca/strings", build.getBefore().get(0));
 
 		requestAttributes.put(
 				IHttpTransport.REQUESTEDLOCALES_REQATTRNAME,
@@ -316,7 +315,7 @@ public class I18nModuleBuilderTest extends EasyMock {
 		build = buildIt();
 		Assert.assertEquals(expectedOutput, build.getBuildOutput());
 		Assert.assertEquals(1, build.getBefore().size());
-		Assert.assertEquals("nls/en/strings", build.getBefore().get(0).getModuleId());
+		Assert.assertEquals("nls/en/strings", build.getBefore().get(0));
 
 		requestAttributes.put(
 				IHttpTransport.REQUESTEDLOCALES_REQATTRNAME,
@@ -327,7 +326,7 @@ public class I18nModuleBuilderTest extends EasyMock {
 		build = buildIt();
 		Assert.assertEquals(expectedOutput, build.getBuildOutput());
 		Assert.assertEquals(1, build.getBefore().size());
-		Assert.assertEquals("nls/en/strings", build.getBefore().get(0).getModuleId());
+		Assert.assertEquals("nls/en/strings", build.getBefore().get(0));
 
 		requestAttributes.put(
 				IHttpTransport.REQUESTEDLOCALES_REQATTRNAME,
@@ -350,8 +349,8 @@ public class I18nModuleBuilderTest extends EasyMock {
 		Assert.assertEquals(expectedOutput, build.getBuildOutput());
 		Assert.assertEquals(3, build.getBefore().size());
 		Set<String> mids = new HashSet<String>();
-		for (IModule module : build.getBefore()) {
-			mids.add(module.getModuleId());
+		for (String mid : build.getBefore()) {
+			mids.add(mid);
 		}
 		Assert.assertEquals(
 				new HashSet<String>(Arrays.asList(new String[]{"nls/es/strings", "nls/en-us/strings", "nls/en-ca/strings"})),

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilderTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilderTest.java
@@ -303,6 +303,7 @@ public class JavaScriptModuleBuilderTest extends EasyMock {
 		// Now touch the source file and assert that the cached results are cleared
 		new File(tmpdir, "p1/p1.js").setLastModified(new Date().getTime());
 		requestAttributes.remove(IHttpTransport.FEATUREMAP_REQATTRNAME);
+		mockAggregator.getOptions().setOption("developmentMode", "true");
 		p1.getBuild(mockRequest).get().close();
 		cacheKeys = p1.getKeys();
 		System.out.println(cacheKeys);
@@ -312,6 +313,7 @@ public class JavaScriptModuleBuilderTest extends EasyMock {
 		TestUtils.createTestFile(new File(tmpdir, "p1"), "err", TestUtils.err);
 		p1 = new JsModuleTester("p1/err", new File(tmpdir, "p1/err.js").toURI());
 		requestAttributes.put(IHttpTransport.OPTIMIZATIONLEVEL_REQATTRNAME, OptimizationLevel.SIMPLE);
+		mockAggregator.getOptions().setOption("developmentMode", "false");
 		future = p1.getBuild(mockRequest);
 		boolean exceptionCaught = false;
 		try {

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/text/TxtModuleContentProviderTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/text/TxtModuleContentProviderTest.java
@@ -70,13 +70,13 @@ public class TxtModuleContentProviderTest extends EasyMock {
 		HttpServletRequest mockRequest = TestUtils.createMockRequest(TestUtils.createMockAggregator());
 		replay(mockRequest);
 		String key = KeyGenUtil.generateKey(mockRequest, generators);
-		Assert.assertEquals("expn:0;txt:0", key);
+		Assert.assertEquals("txt:0:0", key);
 		mockRequest.setAttribute(IHttpTransport.EXPORTMODULENAMES_REQATTRNAME, Boolean.TRUE);
 		key = KeyGenUtil.generateKey(mockRequest, generators);
-		Assert.assertEquals("expn:1;txt:0", key);
+		Assert.assertEquals("txt:0:1", key);
 		mockRequest.setAttribute(IHttpTransport.NOTEXTADORN_REQATTRNAME, Boolean.TRUE);
 		key = KeyGenUtil.generateKey(mockRequest, generators);
-		Assert.assertEquals("expn:1;txt:1", key);
+		Assert.assertEquals("txt:1:0", key);
 	}
 
 	@Test


### PR DESCRIPTION
* Fix bug in i18n cache key generator when '*' is specified for locale
* Remove simplifyInvariant() from ModuleDepInfo do to poor performance characteristics
* Implement a formula cache to avoid the need to recalculate identical formula expressions
* Move logic for wrapping AMD define calls around text strings from module builder to layer builder in order to improve reusability of cached module builds
* Change before/after module specifier (used for i18n locale expansion) from IModule to String (module id) because IModule is based on non-portable URI and fails when moved to another system (e.g when usind in a cache primer bundle)