### PR TITLE
Performance improvements in Less/Css module builder initialization

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/IExtensionSingleton.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/IExtensionSingleton.java
@@ -1,0 +1,31 @@
+/*
+ * (C) Copyright 2012, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.jaggr.core;
+
+import com.ibm.jaggr.core.IExtensionInitializer.IExtensionRegistrar;
+
+/**
+ * Aggregator extensions implementing this interface will be treated as singletons when the
+ * extensions are created declaratively (e.g. from plugin.xml). This means that only one instance of
+ * the class will be created regardless of how many extension points use the class.
+ * <p>
+ * Note that the
+ * {@link IExtensionInitializer#initialize(IAggregator, IAggregatorExtension, IExtensionRegistrar)}
+ * method will still be called once for each extension point that is initialized (although, not
+ * concurrently) so extensions implementing this interface need to take steps to avoid duplicating
+ * work in their initializers.
+ */
+public interface IExtensionSingleton {}

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/less/LessModuleBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/less/LessModuleBuilder.java
@@ -17,6 +17,7 @@
 package com.ibm.jaggr.core.impl.modulebuilder.less;
 
 import com.ibm.jaggr.core.IAggregator;
+import com.ibm.jaggr.core.IExtensionSingleton;
 import com.ibm.jaggr.core.NotFoundException;
 import com.ibm.jaggr.core.impl.modulebuilder.css.CSSModuleBuilder;
 import com.ibm.jaggr.core.resource.IResource;
@@ -39,7 +40,7 @@ import java.util.regex.Pattern;
 /**
  * This class compiles LESS resources that are loaded by the AMD aggregator.
  */
-public class LessModuleBuilder extends CSSModuleBuilder {
+public class LessModuleBuilder extends CSSModuleBuilder implements IExtensionSingleton {
 	static final String sourceClass = LessModuleBuilder.class.getName();
 	static final Logger log = Logger.getLogger(sourceClass);
 


### PR DESCRIPTION
Added the `IExtensionSingleton` interface and make LessModuleBuilder and CssModuleBuilder implement the interface so as to avoid the duplicate initialization and associated creation of thread scopes caused by double instantiation.

Also added use of thread pool executor for creating thread scopes in CssModuleBuilder in order to leverage parallel processing capabilities of multi-core and multi-processor systems.