### PR TITLE
Cache primer bundles not recognized on some platforms

### DIFF
--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorImpl.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorImpl.java
@@ -773,8 +773,8 @@ public class AggregatorImpl extends AbstractAggregatorImpl implements IExecutabl
 		ZipUtil.Packer packer = new ZipUtil.Packer();
 		packer.open(bundleFile);
 		try {
-			packer.packDirectory(getWorkingDirectory(), JAGGR_CACHE_DIRECTORY);
 			packer.packEntryFromStream("META-INF/MANIFEST.MF", new ByteArrayInputStream(manifest.getBytes("UTF-8")), new Date().getTime()); //$NON-NLS-1$ //$NON-NLS-2$
+			packer.packDirectory(getWorkingDirectory(), JAGGR_CACHE_DIRECTORY);
 		} finally {
 			packer.close();
 		}


### PR DESCRIPTION
Some platforms (e.g. Karaf) require that MANIFEST/META-INF.MF be the first entry in the jar.