### PR TITLE
Treat undefined features as false when evaluating has! loader plugin

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerImpl.java
@@ -745,6 +745,14 @@ public class LayerImpl implements ILayer {
 								isDepExpLogging,	// include details
 								false  // include require deps
 								);
+						// When doing server expanded layers, we treat undefined features as false
+						// for the purpose of evaluating has! loader plugin conditionals.  We can do
+						// this because 1.) unlike with require list expansion, the feature values are
+						// less likely to change before being evaluated by the loader so an undefined
+						// feature is likely to be meant to represent false, and 2.) even if
+						// we get it wrong, there is no harm done other than including a module
+						// (and its dependencies) that won't get defined.
+						moduleList.setCoerceUndefinedToFalse(true);
 						dependentFeatures.addAll(moduleList.getDependentFeatures());
 
 						explicit.addAll(moduleList.getExplicitDeps());

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/DependencyList.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/DependencyList.java
@@ -115,6 +115,12 @@ public class DependencyList {
 	 */
 	private String label = null;
 
+	/**
+	 * If true, then undefined features should be treated as false for the purposes of
+	 * resolving has! loader plugin conditionals.
+	 */
+	private boolean coerceUndefinedToFalse = false;
+
 
 	/**
 	 * Object constructor. Note that resolution of expanded dependencies is not
@@ -311,6 +317,18 @@ public class DependencyList {
 		}
 	}
 
+	public void setCoerceUndefinedToFalse(boolean state) {
+		final boolean entryExitLogging = log.isLoggable(Level.FINER);
+		final String methodName = "setCoerceUndefinedToFalse"; //$NON-NLS-1$
+		if (entryExitLogging) {
+			log.entering(DependencyList.class.getName(), methodName, new Object[]{state});
+		}
+		this.coerceUndefinedToFalse = state;
+		if (entryExitLogging) {
+			log.exiting(DependencyList.class.getName(), methodName);
+		}
+	}
+
 	/**
 	 * Returns the label set by {@link #setLabel(String)}
 	 * @return The previously set label string
@@ -365,8 +383,8 @@ public class DependencyList {
 			// necessary because we don't specify features when doing has! plugin branching
 			// so that dependent features that are discovered by has! plugin branching don't
 			// vary based on the specified features.
-			explicitDeps.resolveWith(features);
-			expandedDeps.resolveWith(features);
+			explicitDeps.resolveWith(features, coerceUndefinedToFalse);
+			expandedDeps.resolveWith(features, coerceUndefinedToFalse);
 
 
 			if (traceLogging) {

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/util/DependencyListTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/util/DependencyListTest.java
@@ -160,4 +160,14 @@ public class DependencyListTest {
 		assertEquals(new HashSet<String>(Arrays.asList(new String[]{"has!test?has", "has!test?foo/dep2"})),depList.getExpandedDeps().getModuleIds());
 		assertEquals(new HashSet<String>(Arrays.asList(new String[]{"test", "yyy", "zzz"})), depList.getDependentFeatures());
 	}
+
+	@Test
+	public void testSetCoerceUndefinedToFalse() throws Exception {
+		Set<String> names = new HashSet<String>(Arrays.asList(new String[]{"has!test?:foo/test"}));
+		moduleDeps.put("foo/test", new String[]{"has!zzz?foo/dep1", "has!yyy?:foo/dep2"});
+		DependencyList depList = new DependencyList("test", names, mockAggregator, features, true, false);
+		depList.setCoerceUndefinedToFalse(true);
+		assertEquals(new HashSet<String>(Arrays.asList(new String[]{"has", "foo/test"})),depList.getExplicitDeps().getModuleIds());
+		assertEquals(new HashSet<String>(Arrays.asList(new String[]{"has", "foo/dep2"})),depList.getExpandedDeps().getModuleIds());
+	}
 }


### PR DESCRIPTION
conditionals when server-expanding layers.

We can do this because:

1. Unlike with require list expansion, the defined features are unlikely to change between the time the layer is requested and the time the module dependencies are evaluated on the client, so an undefined feature is likely to be meant to represent false, and
1. Even if we get it wrong, there's no harm done other than including modules (and their dependencies) that won't get defined.