### PR TITLE
Add getdefaultoptions command

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/Messages.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/Messages.java
@@ -59,6 +59,7 @@ public class Messages extends NLS {
 	public static String CommandProvider_29;
 	public static String CommandProvider_30;
 	public static String CommandProvider_31;
+	public static String CommandProvider_32;
 	public static String ConfigModified;
 	static {
 		// initialize resource bundle

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/messages.properties
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/messages.properties
@@ -34,6 +34,7 @@ CommandProvider_6=\t{0}{1}{2} <servlet> - clears the cache for the specified ser
 CommandProvider_30=\t{0}{1}{2} <servlet> - serializes the cache for the specified servlet
 CommandProvider_7=\t{0}{1}{2} <servlet> {3}|{4} [<regular expression>] - outputs the cache metadata for the specified servlet, using the specified regular expression to filter the output by module names
 CommandProvider_8=\t{0}{1}{2} <servlet> - displays the current options and their values for the specified servlet.
+CommandProvider_32=\t{0}{1}{2} <servlet> - displays the default options and their values for the specified servlet.
 CommandProvider_9=\t{0}{1}{2} <servlet> <name> [<value>] - sets the specified option to the specified value or removes the option if value is not specified
 CommandProvider_17=\t{0}{1}{2} <servlet> - config for the servlet
 CommandProvider_18=\t{0}{1}{2} <servlet> - displays the location of the servlet directory for the specified servlet

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/messages_en.properties
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/messages_en.properties
@@ -34,6 +34,7 @@ CommandProvider_6=\t{0}{1}{2} <servlet> - clears the cache for the specified ser
 CommandProvider_30=\t{0}{1}{2} <servlet> - serializes the cache for the specified servlet
 CommandProvider_7=\t{0}{1}{2} <servlet> {3}|{4} [<regular expression>] - outputs the cache metadata for the specified servlet, using the specified regular expression to filter the output by module names
 CommandProvider_8=\t{0}{1}{2} <servlet> - displays the current options and their values for the specified servlet.
+CommandProvider_32=\t{0}{1}{2} <servlet> - displays the default options and their values for the specified servlet.
 CommandProvider_9=\t{0}{1}{2} <servlet> <name> [<value>] - sets the specified option to the specified value or removes the option if value is not specified
 CommandProvider_17=\t{0}{1}{2} <servlet> - config for the servlet
 CommandProvider_18=\t{0}{1}{2} <servlet> - displays the location of the servlet directory for the specified servlet

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/options/OptionsImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/options/OptionsImpl.java
@@ -79,6 +79,8 @@ public class OptionsImpl  implements IOptions, IShutdownListener {
 
 	private Properties defaultOptions;
 
+	private Map<String, String> defaultOptionsMap;
+
 	private IAggregator aggregator = null;
 
 	private Collection<IServiceRegistration> serviceRegistrations;
@@ -219,6 +221,11 @@ public class OptionsImpl  implements IOptions, IShutdownListener {
 	@Override
 	public String getName() {
 		return registrationName;
+	}
+
+	@Override
+	public Map<String, String> getDefaultOptionsMap() {
+		return defaultOptionsMap;
 	}
 
 	/**
@@ -455,6 +462,12 @@ public class OptionsImpl  implements IOptions, IShutdownListener {
 				loadFromUrl(defaultValues, url);
 			}
 		}
+		Map<String, String> map = new HashMap<String, String>();
+		for (String name : defaultValues.stringPropertyNames()) {
+			map.put(name, (String)defaultValues.getProperty(name));
+		}
+		defaultOptionsMap = Collections.unmodifiableMap(map);
+
 		return defaultValues;
 	}
 

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/options/IOptions.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/options/IOptions.java
@@ -318,6 +318,17 @@ public interface IOptions {
 	public Map<String, String> getOptionsMap();
 
 	/**
+	 * Returns an immutable map of the default options and their values.
+	 * The default options are initialized by the application and are not
+	 * affected by calls to {@link IOptions#setOption(String, boolean)}
+	 * or {@link #setOption(String, String)}.
+	 *
+	 * @return A map of the default option name/value pairs.
+	 *
+	 */
+	public Map<String, String> getDefaultOptionsMap();
+
+	/**
 	 * Returns the name that can be used to track this options object using the IOptionsListener
 	 * interface.
 	 *

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorCommandProvider.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorCommandProvider.java
@@ -71,6 +71,7 @@ public class AggregatorCommandProvider implements CommandProvider {
 	static final String CMD_SERIALIZECACHE = "serializecache"; //$NON-NLS-1$
 	static final String CMD_DUMPCACHE = "dumpcache"; //$NON-NLS-1$
 	static final String CMD_GETOPTIONS = "getoptions"; //$NON-NLS-1$
+	static final String CMD_GETDEFAULTOPTIONS = "getdefaultoptions"; //$NON-NLS-1$
 	static final String CMD_SETOPTION = "setoption"; //$NON-NLS-1$
 	static final String CMD_SHOWCONFIG = "showconfig"; //$NON-NLS-1$
 	static final String CMD_GETDEPSWITHHASBRANCHING = "getdepswithhasbranching"; //$NON-NLS-1$
@@ -90,6 +91,7 @@ public class AggregatorCommandProvider implements CommandProvider {
 		CMD_SERIALIZECACHE,
 		CMD_DUMPCACHE,
 		CMD_GETOPTIONS,
+		CMD_GETDEFAULTOPTIONS,
 		CMD_SETOPTION,
 		CMD_SHOWCONFIG,
 		CMD_GETSERVLETDIR,
@@ -150,6 +152,9 @@ public class AggregatorCommandProvider implements CommandProvider {
 						Messages.CommandProvider_8,
 						new Object[]{EYECATCHER, scopeSep, CMD_GETOPTIONS})).append(newline)
 				.append(MessageFormat.format(
+						Messages.CommandProvider_32,
+						new Object[]{EYECATCHER, scopeSep, CMD_GETDEFAULTOPTIONS})).append(newline)
+				.append(MessageFormat.format(
 						Messages.CommandProvider_9,
 						new Object[]{EYECATCHER, scopeSep, CMD_SETOPTION})).append(newline)
 				.append(MessageFormat.format(
@@ -205,6 +210,8 @@ public class AggregatorCommandProvider implements CommandProvider {
 				ci.println(dumpcache(args));
 			} else if (command.equals(CMD_GETOPTIONS)) {
 				ci.println(getoptions(args));
+			} else if (command.equals(CMD_GETDEFAULTOPTIONS)) {
+				ci.println(getdefaultoptions(args));
 			} else if (command.equals(CMD_SETOPTION)) {
 				ci.println(setoption(args));
 			} else if (command.equals(CMD_SHOWCONFIG)) {
@@ -473,6 +480,21 @@ public class AggregatorCommandProvider implements CommandProvider {
 						sb.append(newline).append(file.getAbsolutePath());
 					}
 				}  catch (Exception ignore) {}
+			} finally {
+				getBundleContext().ungetService(ref);
+			}
+		}
+		return sb.toString();
+	}
+
+	protected String getdefaultoptions(String[] args) throws InvalidSyntaxException {
+		StringBuffer sb = new StringBuffer();
+		ServiceReference ref = getServiceRef(args, sb);
+		if (ref != null) {
+			try {
+				IAggregator aggregator = (IAggregator)getBundleContext().getService(ref);
+				IOptions options = aggregator.getOptions();
+				sb.append(options.getDefaultOptionsMap().toString());
 			} finally {
 				getBundleContext().ungetService(ref);
 			}

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorCommandProviderGogo.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/AggregatorCommandProviderGogo.java
@@ -140,6 +140,14 @@ public class AggregatorCommandProviderGogo extends AggregatorCommandProvider {
 		return super.getoptions(new String[]{servlet});
 	}
 
+	@Descriptor("displays the default options and their values for the specified servlet")
+	public String getdefaultoptions(CommandSession cs,
+			@Descriptor("<servlet>")String servlet
+			) throws InvalidSyntaxException {
+		new ConsoleService(new CSConsoleWriter(cs));		// Saves the command session so it can be accessed by async thread
+		return super.getdefaultoptions(new String[]{servlet});
+	}
+
 	@Descriptor("resets the specified option to the default value")
 	public String setoption(CommandSession cs,
 			@Descriptor("<servlet>")String servlet,


### PR DESCRIPTION
Adds the `getdefaultoptions` command.  The goal is to provide a console driven way of determining if, and how, the options for the deployment have been modified from their default values.