### PR TITLE
Layer builder performance improvements

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/messages.properties
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/messages.properties
@@ -25,3 +25,4 @@ LayerImpl_4=Explicitly requested modules for server expanded layer
 LayerImpl_5=Expanded modules for server expanded layer (minus excluded dependencies)
 # {0} = request URL
 LayerImpl_6=Expanding modules for server expanded layer requested with URL {0}
+LayerImpl_7=Waited {0} seconds for cache key generator mutex

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/messages_en.properties
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/messages_en.properties
@@ -25,3 +25,4 @@ LayerImpl_4=Explicitly requested modules for server expanded layer
 LayerImpl_5=Expanded modules for server expanded layer (minus excluded dependencies)
 # {0} = request URL
 LayerImpl_6=Expanding modules for server expanded layer requested with URL {0}
+LayerImpl_7=Waited {0} seconds for cache key generator mutex

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/module/ModuleImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/module/ModuleImpl.java
@@ -310,7 +310,7 @@ public class ModuleImpl extends ModuleIdentifier implements IModule {
 					.toString());
 		}
 
-		CacheEntry newEntry = new CacheEntry();
+		CacheEntry newEntry = null;
 		// Try to retrieve an existing cache entry using the blocking
 		// putIfAbsent. If the return
 		// value is null, then the newEntry was successfully added to the map,
@@ -318,7 +318,11 @@ public class ModuleImpl extends ModuleIdentifier implements IModule {
 		// existing entry is returned in the buildReader and newEntry was not
 		// added.
 		if (!ignoreCached) {
-			existingEntry = moduleBuilds.putIfAbsent(key, newEntry);
+			existingEntry = moduleBuilds.get(key);
+			if (existingEntry == null) {
+				newEntry = new CacheEntry();
+				existingEntry = moduleBuilds.putIfAbsent(key, newEntry);
+			}
 			if (existingEntry != null
 					&& (reader = existingEntry.tryGetReader(mgr.getCacheDir(), request)) != null) {
 				if (isLogLevelFiner) {

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerCacheTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerCacheTest.java
@@ -85,6 +85,7 @@ public class LayerCacheTest {
 	public static void setUpBeforeClass() throws Exception {
 		tmpdir = Files.createTempDir();
 		TestUtils.createTestFiles(tmpdir);
+		LayerImpl.LAYERBUILD_REMOVE_DELAY_SECONDS = 0;
 	}
 
 	@AfterClass


### PR DESCRIPTION
Avoid multiple concurrent builders for same layer when cache key generator has not yet been created.  