### PR TITLE
Fix issues with source map paths

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerBuilder.java
@@ -255,8 +255,8 @@ public class LayerBuilder {
 			// We may be re-building a layer for a source map request where the layer
 			// has been flushed from the cache.  If that's the case, then the context
 			// path will already include the source map path component, so just remove it.
-			if (contextPath.endsWith("/" + ILayer.SOURCEMAP_RESOURSE_PATHCOMP)) { //$NON-NLS-1$
-				contextPath = contextPath.substring(0, contextPath.length()-(ILayer.SOURCEMAP_RESOURSE_PATHCOMP.length()+1));
+			if (contextPath.endsWith(ILayer.SOURCEMAP_RESOURCE_PATH)) {
+				contextPath = contextPath.substring(0, contextPath.length()-(ILayer.SOURCEMAP_RESOURCE_PATHCOMP.length()+1));
 			}
 			// Because we're specifying a relative URL that is relative to the request for the
 			// layer and aggregator paths are assumed to NOT include a trailing '/', then we
@@ -272,7 +272,7 @@ public class LayerBuilder {
 		StringBuffer sb = new StringBuffer();
 		sb.append("//# sourceMappingURL=") //$NON-NLS-1$
 		  .append(root)
-	      .append(ILayer.SOURCEMAP_RESOURSE_PATHCOMP);
+	      .append(ILayer.SOURCEMAP_RESOURCE_PATHCOMP);
 		String queryString = request.getQueryString();
 		if (queryString != null) {
 			sb.append("?").append(queryString); //$NON-NLS-1$

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/layer/ILayer.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/layer/ILayer.java
@@ -76,7 +76,8 @@ public interface ILayer extends Serializable {
 	 * without the source map path component.  For example, if the aggregator url is
 	 * /foo/aggr, then resource maps would be obtained form /foo/aggr/_sourcemap
 	 */
-	public static final String SOURCEMAP_RESOURSE_PATHCOMP = "_sourcemap"; //$NON-NLS-1$
+	public static final String SOURCEMAP_RESOURCE_PATHCOMP = "_sourcemap"; //$NON-NLS-1$
+	public static final String SOURCEMAP_RESOURCE_PATH = "/" + SOURCEMAP_RESOURCE_PATHCOMP;  //$NON-NLS-1$
 
 	/**
 	 * Returns the {@link InputStream} for the assembled and gzipped layer build

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/RequestUtil.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/RequestUtil.java
@@ -185,7 +185,7 @@ public class RequestUtil {
 		String pathInfo = request.getPathInfo();
 		boolean result = false;
 		if (pathInfo != null && isSourceMapsEnabled(request)) {
-			if (pathInfo.endsWith("/" + ILayer.SOURCEMAP_RESOURSE_PATHCOMP)) { //$NON-NLS-1$
+			if (pathInfo.endsWith(ILayer.SOURCEMAP_RESOURCE_PATH)) {
 				result = true;
 			}
 		}

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerBuilderTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerBuilderTest.java
@@ -531,7 +531,7 @@ public class LayerBuilderTest {
 		System.out.println(output);
 		Assert.assertEquals(Arrays.asList("sourceMap1", "sourceMap2"), maps);
 		System.out.println(builder.getSourceMap());
-		Assert.assertEquals("[script1script2(\"<m1>foo<m1>\",\"<m2>bar<m2>\")]\n//# sourceMappingURL="+ILayer.SOURCEMAP_RESOURSE_PATHCOMP, output);
+		Assert.assertEquals("[script1script2(\"<m1>foo<m1>\",\"<m2>bar<m2>\")]\n//# sourceMappingURL="+ILayer.SOURCEMAP_RESOURCE_PATHCOMP, output);
 		Assert.assertEquals(
 				new JSONObject("{\"sourcesContent\":[\"script1\",\"script2\"],\"sources\":[\"s1\",\"s2\"]}"),
 				new JSONObject(builder.getSourceMap().substring(LayerBuilder.SOURCEMAP_XSSI_PREAMBLE.length())));

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerTest.java
@@ -887,7 +887,7 @@ public class LayerTest extends EasyMock {
 		Assert.assertEquals("application/javascript; charset=utf-8", contentType.getValue());
 
 		mockRequest = TestUtils.createMockRequest(mockAggregator);
-		EasyMock.expect(mockRequest.getPathInfo()).andReturn("/" + ILayer.SOURCEMAP_RESOURSE_PATHCOMP).anyTimes();
+		EasyMock.expect(mockRequest.getPathInfo()).andReturn(ILayer.SOURCEMAP_RESOURCE_PATH).anyTimes();
 		EasyMock.replay(mockRequest);
 		mockRequest.setAttribute(IHttpTransport.GENERATESOURCEMAPS_REQATTRNAME, true);
 		mockAggregator.getOptions().setOption(IOptions.SOURCE_MAPS, true);


### PR DESCRIPTION
Handle source map path contexts properly when using mapped paths for aggregator