### PR TITLE
Module cache optimization with source maps

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilder.java
@@ -27,7 +27,6 @@ import com.ibm.jaggr.core.cachekeygenerator.ExportNamesCacheKeyGenerator;
 import com.ibm.jaggr.core.cachekeygenerator.FeatureSetCacheKeyGenerator;
 import com.ibm.jaggr.core.cachekeygenerator.ICacheKeyGenerator;
 import com.ibm.jaggr.core.cachekeygenerator.ServerExpandLayersCacheKeyGenerator;
-import com.ibm.jaggr.core.cachekeygenerator.SourceMapsCacheKeyGenerator;
 import com.ibm.jaggr.core.deps.ModuleDepInfo;
 import com.ibm.jaggr.core.deps.ModuleDeps;
 import com.ibm.jaggr.core.impl.transport.AbstractHttpTransport;
@@ -138,9 +137,6 @@ public class JavaScriptModuleBuilder implements IModuleBuilder, IExtensionInitia
 
 	private static final ICacheKeyGenerator serverExpandLayersCacheKeyGenerator =
 			new ServerExpandLayersCacheKeyGenerator();
-
-	private static final ICacheKeyGenerator sourceMapsCacheKeyGenerator =
-			new SourceMapsCacheKeyGenerator();
 
 	static {
 		Logger.getLogger("com.google.javascript.jscomp.Compiler").setLevel(Level.WARNING); //$NON-NLS-1$
@@ -302,7 +298,7 @@ public class JavaScriptModuleBuilder implements IModuleBuilder, IExtensionInitia
 		CompilationLevel level = getCompilationLevel(request);
 		boolean createNewKeyGen = (keyGens == null);
 		boolean isHasFiltering = RequestUtil.isHasFiltering(request);
-		boolean isSourceMaps = RequestUtil.isSourceMapsEnabled(request);
+		boolean isSourceMaps = aggr.getOptions().isSourceMapsEnabled();
 		// If the source doesn't exist, throw an exception.
 		if (!resource.exists()) {
 			if (log.isLoggable(Level.WARNING)) {
@@ -546,7 +542,6 @@ public class JavaScriptModuleBuilder implements IModuleBuilder, IExtensionInitia
 		ArrayList<ICacheKeyGenerator> keyGens = new ArrayList<ICacheKeyGenerator>();
 		keyGens.add(exportNamesCacheKeyGenerator);
 		keyGens.add(serverExpandLayersCacheKeyGenerator);
-		keyGens.add(sourceMapsCacheKeyGenerator);
 		keyGens.add(new CacheKeyGenerator(dependentFeatures, hasExpandableRequires, dependentFeatures == null));
 		return keyGens;
 	}
@@ -792,7 +787,6 @@ public class JavaScriptModuleBuilder implements IModuleBuilder, IExtensionInitia
 			boolean requireListExpansion = RequestUtil.isExplodeRequires(request);
 			boolean reqExpLogging = RequestUtil.isDependencyExpansionLogging(request);
 			boolean hasFiltering = RequestUtil.isHasFiltering(request);
-			//boolean isSourceMapsEnabled = RequestUtil.isSourceMapsEnabled(request);
 
 			if (log.isLoggable(Level.FINEST)) {
 				log.finest("Creating cache key: level=" +  //$NON-NLS-1$

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/module/ModuleImplTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/module/ModuleImplTest.java
@@ -153,8 +153,8 @@ public class ModuleImplTest {
 		ModuleImpl module = (ModuleImpl)mockAggregator.newModule("p1/p1", mockAggregator.getConfig().locateModuleResource("p1/p1"));
 		Reader reader  = module.getBuild(mockRequest).get();
 		System.out.println(module.toString());
-		Assert.assertEquals("[expn, sexp, sm, js:(has:[conditionFalse, conditionTrue, foo])]", module.getCacheKeyGenerators().toString());
-		Assert.assertTrue(module.getKeys().size() == 1 && module.getKeys().containsAll(Arrays.asList(new String[]{"expn:0;sexp:0;sm:0;js:S:1:0:1;has{foo}"})));
+		Assert.assertEquals("[expn, sexp, js:(has:[conditionFalse, conditionTrue, foo])]", module.getCacheKeyGenerators().toString());
+		Assert.assertTrue(module.getKeys().size() == 1 && module.getKeys().containsAll(Arrays.asList(new String[]{"expn:0;sexp:0;js:S:1:0:1;has{foo}"})));
 		StringWriter writer = new StringWriter();
 		CopyUtil.copy(reader, writer);
 		String compiled = writer.toString();
@@ -167,9 +167,9 @@ public class ModuleImplTest {
 		features.put("foo", false);
 		reader = module.getBuild(mockRequest).get();
 		System.out.println(module.toString());
-		Assert.assertEquals("[expn, sexp, sm, js:(has:[bar, conditionFalse, conditionTrue, foo])]", module.getCacheKeyGenerators().toString());
+		Assert.assertEquals("[expn, sexp, js:(has:[bar, conditionFalse, conditionTrue, foo])]", module.getCacheKeyGenerators().toString());
 		Assert.assertTrue(module.getKeys().size() == 2 && module.getKeys().containsAll(Arrays.asList(
-				new String[]{"expn:0;sexp:0;sm:0;js:S:1:0:1;has{foo}", "expn:0;sexp:0;sm:0;js:S:1:0:1;has{bar,!foo}"})));
+				new String[]{"expn:0;sexp:0;js:S:1:0:1;has{foo}", "expn:0;sexp:0;js:S:1:0:1;has{bar,!foo}"})));
 		writer = new StringWriter();
 		CopyUtil.copy(reader, writer);
 		compiled = writer.toString();
@@ -182,12 +182,12 @@ public class ModuleImplTest {
 		reader = module.getBuild(mockRequest).get();
 		System.out.println(module.toString());
 		List<ICacheKeyGenerator> cacheKeyGenerators = module.getCacheKeyGenerators();
-		Assert.assertEquals("[expn, sexp, sm, js:(has:[bar, conditionFalse, conditionTrue, foo, non])]", module.getCacheKeyGenerators().toString());
+		Assert.assertEquals("[expn, sexp, js:(has:[bar, conditionFalse, conditionTrue, foo, non])]", module.getCacheKeyGenerators().toString());
 		Assert.assertTrue(module.getKeys().size() == 3 && module.getKeys().containsAll(Arrays.asList(
 				new String[]{
-						"expn:0;sexp:0;sm:0;js:S:1:0:1;has{foo}",
-						"expn:0;sexp:0;sm:0;js:S:1:0:1;has{bar,!foo}",
-						"expn:0;sexp:0;sm:0;js:S:1:0:1;has{!bar,!foo}"
+						"expn:0;sexp:0;js:S:1:0:1;has{foo}",
+						"expn:0;sexp:0;js:S:1:0:1;has{bar,!foo}",
+						"expn:0;sexp:0;js:S:1:0:1;has{!bar,!foo}"
 				}
 				)));
 		writer = new StringWriter();
@@ -206,9 +206,9 @@ public class ModuleImplTest {
 		Assert.assertTrue(cacheKeyGenerators == module.getCacheKeyGenerators());
 		Assert.assertTrue(module.getKeys().size() == 3 && module.getKeys().containsAll(Arrays.asList(
 				new String[]{
-						"expn:0;sexp:0;sm:0;js:S:1:0:1;has{foo}",
-						"expn:0;sexp:0;sm:0;js:S:1:0:1;has{bar,!foo}",
-						"expn:0;sexp:0;sm:0;js:S:1:0:1;has{!bar,!foo}"
+						"expn:0;sexp:0;js:S:1:0:1;has{foo}",
+						"expn:0;sexp:0;js:S:1:0:1;has{bar,!foo}",
+						"expn:0;sexp:0;js:S:1:0:1;has{!bar,!foo}"
 				}
 				)));
 		writer = new StringWriter();
@@ -226,10 +226,10 @@ public class ModuleImplTest {
 		Assert.assertTrue(cacheKeyGenerators == module.getCacheKeyGenerators());
 		Assert.assertTrue(module.getKeys().size() == 4 && module.getKeys().containsAll(Arrays.asList(
 				new String[]{
-						"expn:0;sexp:0;sm:0;js:S:1:0:1;has{foo}",
-						"expn:0;sexp:0;sm:0;js:S:1:0:1;has{bar,foo}",
-						"expn:0;sexp:0;sm:0;js:S:1:0:1;has{bar,!foo}",
-						"expn:0;sexp:0;sm:0;js:S:1:0:1;has{!bar,!foo}"
+						"expn:0;sexp:0;js:S:1:0:1;has{foo}",
+						"expn:0;sexp:0;js:S:1:0:1;has{bar,foo}",
+						"expn:0;sexp:0;js:S:1:0:1;has{bar,!foo}",
+						"expn:0;sexp:0;js:S:1:0:1;has{!bar,!foo}"
 				}
 				)));
 		writer = new StringWriter();

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilderTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilderTest.java
@@ -192,7 +192,7 @@ public class JavaScriptModuleBuilderTest extends EasyMock {
 		List<ICacheKeyGenerator> gens = future.get().getCacheKeyGenerators();
 		String s = KeyGenUtil.toString(gens);
 		System.out.println(s);
-		assertEquals("expn;sexp;sm;js:(has:[conditionFalse, conditionTrue])",s);
+		assertEquals("expn;sexp;js:(has:[conditionFalse, conditionTrue])",s);
 
 		// Make sure the content of both has has features is present
 		assertTrue(compiled.contains("has(\"conditionTrue\")"));
@@ -283,11 +283,10 @@ public class JavaScriptModuleBuilderTest extends EasyMock {
 
 		Collection<String> cacheKeys = new TreeSet<String>(p1.getKeys());
 		System.out.println(cacheKeys);
-		assertEquals("[expn:0;sexp:0;sm:0;js:S:0:0:1;has{}, expn:0;sexp:0;sm:0;js:S:1:0:1;has{!conditionFalse,conditionTrue}, expn:0;sexp:0;sm:0;js:S:1:0:1;has{conditionTrue}]",
+		assertEquals("[expn:0;sexp:0;js:S:0:0:1;has{}, expn:0;sexp:0;js:S:1:0:1;has{!conditionFalse,conditionTrue}, expn:0;sexp:0;js:S:1:0:1;has{conditionTrue}]",
 				cacheKeys.toString());
 
 		// Test source maps
-		mockRequest.setAttribute(IHttpTransport.GENERATESOURCEMAPS_REQATTRNAME, true);
 		mockAggregator.getOptions().setOption(IOptions.SOURCE_MAPS, true);
 		p1.clearCached(mockAggregator.getCacheManager());
 		reader = p1.getBuild(mockRequest).get();
@@ -331,7 +330,7 @@ public class JavaScriptModuleBuilderTest extends EasyMock {
 
 		cacheKeys = new TreeSet<String>(p1.getKeys());
 		System.out.println(cacheKeys);
-		assertEquals("[expn:0;sexp:0;sm:0;js:S:1:0:1;has{!conditionFalse,conditionTrue}]",
+		assertEquals("[expn:0;sexp:0;js:S:1:0:1;has{!conditionFalse,conditionTrue}]",
 				cacheKeys.toString());
 
 		Thread.sleep(1500L);   // Wait long enough for systems with coarse grained last-mod
@@ -343,7 +342,7 @@ public class JavaScriptModuleBuilderTest extends EasyMock {
 		p1.getBuild(mockRequest).get().close();
 		cacheKeys = p1.getKeys();
 		System.out.println(cacheKeys);
-		assertEquals("[expn:0;sexp:0;sm:0;js:S:1:0:1;has{!conditionFalse,!conditionTrue}]", cacheKeys.toString());
+		assertEquals("[expn:0;sexp:0;js:S:1:0:1;has{!conditionFalse,!conditionTrue}]", cacheKeys.toString());
 
 		// Test error handling.  In production mode, a js syntax error should throw an excepton
 		TestUtils.createTestFile(new File(tmpdir, "p1"), "err", TestUtils.err);
@@ -481,7 +480,7 @@ public class JavaScriptModuleBuilderTest extends EasyMock {
 		assertTrue(Pattern.compile("IModule: p1/p1\\n").matcher(s).find());
 		assertTrue(Pattern.compile("Source: .*p1.js").matcher(s).find());
 		assertTrue(Pattern.compile("Modified: " + lastModified).matcher(s).find());
-		assertTrue(Pattern.compile("\\texpn:0;sexp:0;sm:0;js:S:0:0:1;has\\{\\} : .*p1\\..*\\.cache").matcher(s).find());
+		assertTrue(Pattern.compile("\\texpn:0;sexp:0;js:S:0:0:1;has\\{\\} : .*p1\\..*\\.cache").matcher(s).find());
 	}
 
 	@Test
@@ -491,37 +490,32 @@ public class JavaScriptModuleBuilderTest extends EasyMock {
 		TestJavaScriptModuleBuilder builder = new TestJavaScriptModuleBuilder();
 		List<ICacheKeyGenerator> keyGens = builder.getCacheKeyGenerators(mockAggregator);
 		requestAttributes.put(IAggregator.AGGREGATOR_REQATTRNAME, mockAggregator);
-		assertEquals("expn:0;sexp:0;sm:0;js:S:0:0:1;has{}", KeyGenUtil.generateKey(mockRequest, keyGens));
+		assertEquals("expn:0;sexp:0;js:S:0:0:1;has{}", KeyGenUtil.generateKey(mockRequest, keyGens));
 		requestAttributes.put(IHttpTransport.OPTIMIZATIONLEVEL_REQATTRNAME, OptimizationLevel.SIMPLE);
-		assertEquals("expn:0;sexp:0;sm:0;js:S:0:0:1;has{}", KeyGenUtil.generateKey(mockRequest, keyGens));
+		assertEquals("expn:0;sexp:0;js:S:0:0:1;has{}", KeyGenUtil.generateKey(mockRequest, keyGens));
 		requestAttributes.put(IHttpTransport.OPTIMIZATIONLEVEL_REQATTRNAME, OptimizationLevel.NONE);
-		assertEquals("expn:0;sexp:0;sm:0;js:N:0:0:1", KeyGenUtil.generateKey(mockRequest, keyGens));
+		assertEquals("expn:0;sexp:0;js:N:0:0:1", KeyGenUtil.generateKey(mockRequest, keyGens));
 		requestAttributes.put(IHttpTransport.OPTIMIZATIONLEVEL_REQATTRNAME, OptimizationLevel.WHITESPACE);
-		assertEquals("expn:0;sexp:0;sm:0;js:W:0:0:1;has{}", KeyGenUtil.generateKey(mockRequest, keyGens));
+		assertEquals("expn:0;sexp:0;js:W:0:0:1;has{}", KeyGenUtil.generateKey(mockRequest, keyGens));
 		requestAttributes.put(IHttpTransport.EXPANDREQUIRELISTS_REQATTRNAME, Boolean.TRUE);
-		assertEquals("expn:0;sexp:0;sm:0;js:W:1:0:1;has{}", KeyGenUtil.generateKey(mockRequest, keyGens));
+		assertEquals("expn:0;sexp:0;js:W:1:0:1;has{}", KeyGenUtil.generateKey(mockRequest, keyGens));
 		Features features = new Features();
 		features.put("foo", true);
 		features.put("bar", false);
 		requestAttributes.put(IHttpTransport.FEATUREMAP_REQATTRNAME, features);
-		assertEquals("expn:0;sexp:0;sm:0;js:W:1:0:1;has{!bar,foo}", KeyGenUtil.generateKey(mockRequest, keyGens));
+		assertEquals("expn:0;sexp:0;js:W:1:0:1;has{!bar,foo}", KeyGenUtil.generateKey(mockRequest, keyGens));
 		Set<String> hasConditionals = new HashSet<String>();
 		keyGens = builder.getCacheKeyGenerators(hasConditionals, true);
-		assertEquals("expn:0;sexp:0;sm:0;js:W:1:0:1;has{}", KeyGenUtil.generateKey(mockRequest, keyGens));
+		assertEquals("expn:0;sexp:0;js:W:1:0:1;has{}", KeyGenUtil.generateKey(mockRequest, keyGens));
 		hasConditionals.add("foo");
 		keyGens = builder.getCacheKeyGenerators(hasConditionals, true);
-		assertEquals("expn:0;sexp:0;sm:0;js:W:1:0:1;has{foo}", KeyGenUtil.generateKey(mockRequest, keyGens));
+		assertEquals("expn:0;sexp:0;js:W:1:0:1;has{foo}", KeyGenUtil.generateKey(mockRequest, keyGens));
 		hasConditionals.add("bar");
 		keyGens = builder.getCacheKeyGenerators(hasConditionals, false);
-		assertEquals("expn:0;sexp:0;sm:0;js:W:0:0:1;has{!bar,foo}", KeyGenUtil.generateKey(mockRequest, keyGens));
+		assertEquals("expn:0;sexp:0;js:W:0:0:1;has{!bar,foo}", KeyGenUtil.generateKey(mockRequest, keyGens));
 		hasConditionals.add("undefined");
 		keyGens = builder.getCacheKeyGenerators(hasConditionals, false);
-		assertEquals("expn:0;sexp:0;sm:0;js:W:0:0:1;has{!bar,foo}", KeyGenUtil.generateKey(mockRequest, keyGens));
-
-		requestAttributes.put(IHttpTransport.GENERATESOURCEMAPS_REQATTRNAME, true);
-		mockAggregator.getOptions().setOption(IOptions.SOURCE_MAPS, true);
-		assertEquals("expn:0;sexp:0;sm:1;js:W:0:0:1;has{!bar,foo}", KeyGenUtil.generateKey(mockRequest, keyGens));
-
+		assertEquals("expn:0;sexp:0;js:W:0:0:1;has{!bar,foo}", KeyGenUtil.generateKey(mockRequest, keyGens));
 	}
 
 


### PR DESCRIPTION
Generate source map data if source maps are enabled in aggregator options, regardless of whether or not they are asked for in the request.  This will avoid caching two version of the same built module (one with and one without source maps) in the module cache.