### PR TITLE
Signal wait logging

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/cache/CacheManagerImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/cache/CacheManagerImpl.java
@@ -33,6 +33,7 @@ import com.ibm.jaggr.core.options.IOptions;
 import com.ibm.jaggr.core.options.IOptionsListener;
 import com.ibm.jaggr.core.util.ConsoleService;
 import com.ibm.jaggr.core.util.CopyUtil;
+import com.ibm.jaggr.core.util.SignalUtil;
 
 import org.apache.commons.io.input.ReaderInputStream;
 import org.apache.commons.lang3.StringUtils;
@@ -64,10 +65,11 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 public class CacheManagerImpl implements ICacheManager, IShutdownListener, IConfigListener, IDependenciesListener, IOptionsListener {
-
-	private static final Logger log = Logger.getLogger(CacheManagerImpl.class.getName());
+	private static final String sourceClass = CacheManagerImpl.class.getName();
+	private static final Logger log = Logger.getLogger(sourceClass);
 
 	private static final String CACHEDIR_NAME = "cache"; //$NON-NLS-1$
+
 	/**
 	 * Reference the cache with an atomic reference so that we don't need to synchronize
 	 * access to it.  The atomic reference is needed for when we swap the cache out with
@@ -285,6 +287,7 @@ public class CacheManagerImpl implements ICacheManager, IShutdownListener, IConf
 	 */
 	@Override
 	public void serializeCache() {
+		final String sourceMethod = "serializeCache"; //$NON-NLS-1$
 
 		// Queue up the serialization behind any pending cache file creations.
 		Future<Void> future = _aggregator.getExecutors().getFileCreateExecutor().submit(new Callable<Void>() {
@@ -314,7 +317,7 @@ public class CacheManagerImpl implements ICacheManager, IShutdownListener, IConf
 
 		// Wait for the serialization to complete before returning.
 		try {
-			future.get(5, TimeUnit.MINUTES);	// time-out after 5 minutes
+			SignalUtil.get(future, sourceClass, sourceMethod);
 		} catch (Exception e) {
 			if (log.isLoggable(Level.SEVERE))
 				log.log(Level.SEVERE, e.getMessage(), e);

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/deps/DepTree.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/deps/DepTree.java
@@ -23,6 +23,7 @@ import com.ibm.jaggr.core.deps.IDependencies;
 import com.ibm.jaggr.core.modulebuilder.IModuleBuilderExtensionPoint;
 import com.ibm.jaggr.core.util.AggregatorUtil;
 import com.ibm.jaggr.core.util.ConsoleService;
+import com.ibm.jaggr.core.util.SignalUtil;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -71,11 +72,13 @@ import java.util.logging.Logger;
 public class DepTree implements Serializable {
 	private static final long serialVersionUID = -8494644438459736244L;
 
-	static final Logger log = Logger.getLogger(DepTree.class.getName());
+	static final String sourceClass = DepTree.class.getName();
+	static final Logger log = Logger.getLogger(sourceClass);
 
 	static final String TREEBUILDER_TGNAME = "treeBuilder"; //$NON-NLS-1$
 	static final String JSPARSER_TGNAME = "jsParser"; //$NON-NLS-1$
 	static final String THREADNAME = "{0} Thread-{1}";  //$NON-NLS-1$
+
 	/**
 	 * Map of directory names to {@link DepTreeNode} objects. Each
 	 * {@link DepTreeNode} mirrors the associated file directory in terms of the
@@ -136,7 +139,7 @@ public class DepTree implements Serializable {
 		final String sourceMethod = "<ctor>"; //$NON-NLS-1$
 		boolean isTraceLogging = log.isLoggable(Level.FINER);
 		if (isTraceLogging) {
-			log.entering(DepTree.class.getName(), sourceMethod, new Object[]{paths, aggregator, stamp, clean, validateDeps});
+			log.entering(sourceClass, sourceMethod, new Object[]{paths, aggregator, stamp, clean, validateDeps});
 		}
 		this.stamp = stamp;
 		IConfig config = aggregator.getConfig();
@@ -330,7 +333,7 @@ public class DepTree implements Serializable {
 		 */
 		while (treeBuilderCount.decrementAndGet() >= 0) {
 			try {
-				DepTreeBuilder.Result result = treeBuilderCs.take().get();
+				DepTreeBuilder.Result result = SignalUtil.take(treeBuilderCs, sourceClass, sourceMethod).get();
 				if (log.isLoggable(Level.INFO)) {
 					log.info(
 							MessageFormat.format(
@@ -397,7 +400,7 @@ public class DepTree implements Serializable {
 			log.info(msg);
 		}
 		if (isTraceLogging) {
-			log.exiting(DepTree.class.getName(), sourceMethod);
+			log.exiting(sourceClass, sourceMethod);
 		}
 	}
 
@@ -505,7 +508,7 @@ public class DepTree implements Serializable {
 		final String sourceMethod = "getNonJSExtensions"; //$NON-NLS-1$
 		boolean isTraceLogging = log.isLoggable(Level.FINER);
 		if (isTraceLogging) {
-			log.entering(DepTree.class.getName(), sourceMethod, new Object[]{aggregator});
+			log.entering(sourceClass, sourceMethod, new Object[]{aggregator});
 		}
 		// Build set of non-js file extensions to include in the dependency names
 		Set<String> result = new HashSet<String>(Arrays.asList(IDependencies.defaultNonJSExtensions));
@@ -524,7 +527,7 @@ public class DepTree implements Serializable {
 				}
 			}
 		}
-		log.exiting(DepTree.class.getName(), sourceMethod, result);
+		log.exiting(sourceClass, sourceMethod, result);
 		return result;
 	}
 }

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/deps/DepTreeBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/deps/DepTreeBuilder.java
@@ -19,6 +19,7 @@ package com.ibm.jaggr.core.impl.deps;
 import com.ibm.jaggr.core.IAggregator;
 import com.ibm.jaggr.core.resource.IResource;
 import com.ibm.jaggr.core.resource.IResourceVisitor;
+import com.ibm.jaggr.core.util.SignalUtil;
 
 import java.io.IOException;
 import java.net.URI;
@@ -39,8 +40,8 @@ import java.util.logging.Logger;
  * I/O bound.
  */
 final class DepTreeBuilder implements Callable<DepTreeBuilder.Result> {
-
-	static final Logger log = Logger.getLogger(DepTreeBuilder.class.getName());
+	static final String sourceClass = DepTreeBuilder.class.getName();
+	static final Logger log = Logger.getLogger(sourceClass);
 
 	private final IAggregator aggregator;
 	/**
@@ -112,7 +113,7 @@ final class DepTreeBuilder implements Callable<DepTreeBuilder.Result> {
 	 * @see java.util.concurrent.Callable#call()
 	 */
 	public Result call() throws Exception {
-
+		final String sourceMethod = "call"; //$NON-NLS-1$
 		IResourceVisitor visitor = new IResourceVisitor() {
 			/* (non-Javadoc)
 			 * @see com.ibm.jaggr.service.modules.ResourceVisitor#visitResource(com.ibm.jaggr.service.modules.Resource)
@@ -212,11 +213,10 @@ final class DepTreeBuilder implements Callable<DepTreeBuilder.Result> {
 		// until all files have been parsed
 		while (parserCount.decrementAndGet() >= 0) {
 			try {
-				parserCs.take().get();
+				SignalUtil.take(parserCs, sourceClass, sourceMethod).get();
 			} catch (Exception e) {
-				e.printStackTrace();
 				if (log.isLoggable(Level.SEVERE))
-					log.log(Level.SEVERE, e.getMessage(), e);
+					log.logp(Level.SEVERE, sourceClass, sourceMethod, e.getMessage(), e);
 			}
 		}
 

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerBuildsAccessor.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerBuildsAccessor.java
@@ -17,6 +17,7 @@
 package com.ibm.jaggr.core.impl.layer;
 
 import com.ibm.jaggr.core.cache.ICacheManager;
+import com.ibm.jaggr.core.util.SignalUtil;
 
 import java.lang.ref.WeakReference;
 import java.util.Collections;
@@ -41,6 +42,7 @@ import java.util.concurrent.locks.ReadWriteLock;
  * {@link LayerBuildsAccessor#entrySet()}).
  */
 class LayerBuildsAccessor {
+	private static final String sourceClass = LayerBuildsAccessor.class.getName();
 
 	private final ConcurrentMap<String, CacheEntry> map;
 	private final ICacheManager cacheMgr;
@@ -100,8 +102,9 @@ class LayerBuildsAccessor {
 	 * @return true if the value was replace
 	 */
 	public boolean replace(String key, CacheEntry oldValue, CacheEntry newValue) {
+		final String sourceMethod = "replace"; //$NON-NLS-1$
 		boolean replaced = false;
-		cloneLock.readLock().lock();
+		SignalUtil.lock(cloneLock.readLock(), sourceClass, sourceMethod);
 		try {
 			replaced = map.replace(keyPrefix + key, oldValue, newValue);
 			if (replaced && oldValue != newValue) {
@@ -136,10 +139,11 @@ class LayerBuildsAccessor {
 	 *         layer has been evicted
 	 */
 	public CacheEntry putIfAbsent(String key, CacheEntry value, boolean update) {
+		final String sourceMethod = "putIfAbsent"; //$NON-NLS-1$
 		key = keyPrefix + key;
 		CacheEntry existingValue = null;
 		boolean incrementCount = false;
-		cloneLock.readLock().lock();
+		SignalUtil.lock(cloneLock.readLock(), sourceClass, sourceMethod);
 		try {
 			while (true) {
 				if (evictionLatch.isLatched()) {
@@ -200,8 +204,10 @@ class LayerBuildsAccessor {
 	 * @return true if the entry was removed
 	 */
 	public boolean remove(String key, CacheEntry value) {
+		final String sourceMethod = "remove"; //$NON-NLS-1$
+
 		boolean removed = false;
-		cloneLock.readLock().lock();
+		SignalUtil.lock(cloneLock.readLock(), sourceClass, sourceMethod);
 		try {
 			if (key != null && value != null) {
 				removed = map.remove(keyPrefix + key, value);
@@ -244,8 +250,10 @@ class LayerBuildsAccessor {
 	 * @return true if the <code>_evicted</code> flag was set
 	 */
 	public boolean cacheEntryEvicted(CacheEntry cacheEntry) {
+		final String sourceMethod = "cacheEntryEvicted"; //$NON-NLS-1$
+
 		boolean evicted = false;
-		cloneLock.readLock().lock();
+		SignalUtil.lock(cloneLock.readLock(), sourceClass, sourceMethod);
 		try {
 			if (cacheEntry.layerId == layerId) {
 				evicted = evictionLatch.decrement();

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerCacheImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerCacheImpl.java
@@ -23,6 +23,7 @@ import com.ibm.jaggr.core.layer.ILayer;
 import com.ibm.jaggr.core.layer.ILayerCache;
 import com.ibm.jaggr.core.transport.IHttpTransport;
 import com.ibm.jaggr.core.util.RequestUtil;
+import com.ibm.jaggr.core.util.SignalUtil;
 import com.ibm.jaggr.core.util.TypeUtil;
 
 import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
@@ -74,6 +75,7 @@ import javax.servlet.http.HttpServletRequest;
  * removed from the layerMap.
  */
 public class LayerCacheImpl extends GenericCacheImpl<ILayer> implements ILayerCache, Serializable {
+	private static final String sourceClass = LayerCacheImpl.class.getName();
 
 	static final int DEFAULT_MAXLAYERCACHECAPACITY_MB = 500;
 
@@ -120,7 +122,8 @@ public class LayerCacheImpl extends GenericCacheImpl<ILayer> implements ILayerCa
 	 */
 	@Override
 	public void clear() {
-		cloneLock.readLock().lock();
+		final String sourceMethod = "clear"; //$NON-NLS-1$
+		SignalUtil.lock(cloneLock.readLock(), sourceClass, sourceMethod);
 		try {
 			cacheMap.clear();
 			layerBuildMap.clear();
@@ -150,7 +153,8 @@ public class LayerCacheImpl extends GenericCacheImpl<ILayer> implements ILayerCa
 
 	@Override
 	public ILayer getLayer(HttpServletRequest request) {
-		cloneLock.readLock().lock();
+		final String sourceMethod = "getLayer"; //$NON-NLS-1$
+		SignalUtil.lock(cloneLock.readLock(), sourceClass, sourceMethod);
 		try {
 			String key = request
 					.getAttribute(IHttpTransport.REQUESTEDMODULENAMES_REQATTRNAME)
@@ -179,7 +183,8 @@ public class LayerCacheImpl extends GenericCacheImpl<ILayer> implements ILayerCa
 	}
 
 	boolean remove(String key, ILayer layer) {
-		cloneLock.readLock().lock();
+		final String sourceMethod = "remove"; //$NON-NLS-1$
+		SignalUtil.lock(cloneLock.readLock(), sourceClass, sourceMethod);
 		try {
 			return cacheMap.remove(key, layer);
 		} finally {
@@ -322,6 +327,7 @@ public class LayerCacheImpl extends GenericCacheImpl<ILayer> implements ILayerCa
 
 	protected static class SerializationProxy implements Serializable {
 		private static final long serialVersionUID = 1626266857238222300L;
+		private static final String sourceClass = SerializationProxy.class.getName();
 
 		private final int newLayerId;
 		private final int maxCapacity;
@@ -331,7 +337,8 @@ public class LayerCacheImpl extends GenericCacheImpl<ILayer> implements ILayerCa
 		private final Map<String, CacheEntry> layerBuildMap;
 
 		protected SerializationProxy(LayerCacheImpl cache) throws InvalidObjectException {
-			cache.cloneLock.writeLock().lock();
+			final String sourceMethod = "<ctor>"; //$NON-NLS-1$
+			SignalUtil.lock(cache.cloneLock.writeLock(), sourceClass, sourceMethod);
 			try {
 				clazz = cache.getClass();
 				newLayerId = cache.newLayerId.get();

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/Messages.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/Messages.java
@@ -26,7 +26,6 @@ public class Messages extends NLS {
 	public static String LayerImpl_4;
 	public static String LayerImpl_5;
 	public static String LayerImpl_6;
-	public static String LayerImpl_7;
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/messages.properties
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/messages.properties
@@ -25,4 +25,3 @@ LayerImpl_4=Explicitly requested modules for server expanded layer
 LayerImpl_5=Expanded modules for server expanded layer (minus excluded dependencies)
 # {0} = request URL
 LayerImpl_6=Expanding modules for server expanded layer requested with URL {0}
-LayerImpl_7=Waited {0} seconds for cache key generator mutex

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/messages_en.properties
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/messages_en.properties
@@ -25,4 +25,3 @@ LayerImpl_4=Explicitly requested modules for server expanded layer
 LayerImpl_5=Expanded modules for server expanded layer (minus excluded dependencies)
 # {0} = request URL
 LayerImpl_6=Expanding modules for server expanded layer requested with URL {0}
-LayerImpl_7=Waited {0} seconds for cache key generator mutex

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/resource/JsxResourceConverter.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/resource/JsxResourceConverter.java
@@ -31,6 +31,7 @@ import com.ibm.jaggr.core.resource.IResource;
 import com.ibm.jaggr.core.resource.IResourceConverter;
 import com.ibm.jaggr.core.resource.IResourceVisitor;
 import com.ibm.jaggr.core.resource.IResourceVisitor.Resource;
+import com.ibm.jaggr.core.util.SignalUtil;
 import com.ibm.jaggr.core.util.TypeUtil;
 
 import org.apache.commons.io.FileUtils;
@@ -539,7 +540,7 @@ public class JsxResourceConverter implements IResourceConverter, IExtensionIniti
 			// now get the results
 			for (int i = 0; i < scopePoolSize; i++) {
 				try {
-					threadScopes.add(cs.take().get());
+					threadScopes.add(SignalUtil.take(cs, sourceClass, sourceMethod).get());
 				} catch (Exception e) {
 					if (log.isLoggable(Level.SEVERE)) {
 						log.logp(Level.SEVERE, JsxConverter.class.getName(), sourceMethod, e.getMessage(), e);

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/Messages.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/Messages.java
@@ -24,7 +24,6 @@ public class Messages extends NLS {
 	public static String AbstractHttpTransport_1;
 	public static String AbstractHttpTransport_2;
 	public static String AbstractHttpTransport_3;
-	public static String AbstractHttpTransport_4;
 	public static String DojoHttpTransport_0;
 	public static String DojoHttpTransport_1;
 	public static String DojoHttpTransport_2;

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/messages.properties
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/messages.properties
@@ -24,8 +24,6 @@ AbstractHttpTransport_0="has" cookie missing from request:{0}, User-Agent:{1}
 AbstractHttpTransport_1=Path attribute not specified for {0}
 AbstractHttpTransport_2=Deprecated use of \\"modules\\" query arg for aggregator boot layer: use \\"scripts\\" instead
 AbstractHttpTransport_3=Deprecated use of \\"required\\" query arg for aggregator boot layer: use \\"deps\\" instead
-# {0} and {1} are numbers
-AbstractHttpTransport_4=Thread {0} waiting for dependencies to be loaded.  Elapsed time = {1} seconds.
 DojoHttpTransport_0=Package definition for dojo not found in config.  Skipping text plugin overrides.
 DojoHttpTransport_1=Aggregator text plugin name not identified in available module builders.  Skipping text plugin overrides.
 DojoHttpTransport_2=Path definition for {0} exists in config.  Skipping text plugin overrides.

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/messages_en.properties
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/messages_en.properties
@@ -24,8 +24,6 @@ AbstractHttpTransport_0="has" cookie missing from request:{0}, User-Agent:{1}
 AbstractHttpTransport_1=Path attribute not specified for {0}
 AbstractHttpTransport_2=Deprecated use of \\"modules\\" query arg for aggregator boot layer: use \\"scripts\\" instead
 AbstractHttpTransport_3=Deprecated use of \\"required\\" query arg for aggregator boot layer: use \\"deps\\" instead
-# {0} and {1} are numbers
-AbstractHttpTransport_4=Thread {0} waiting for dependencies to be loaded.  Elapsed time = {1} seconds.
 DojoHttpTransport_0=Package definition for dojo not found in config.  Skipping text plugin overrides.
 DojoHttpTransport_1=Aggregator text plugin name not identified in available module builders.  Skipping text plugin overrides.
 DojoHttpTransport_2=Path definition for {0} exists in config.  Skipping text plugin overrides.

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/modulebuilder/ModuleBuildFuture.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/modulebuilder/ModuleBuildFuture.java
@@ -20,6 +20,7 @@ import com.ibm.jaggr.core.layer.ILayer;
 import com.ibm.jaggr.core.module.IModule;
 import com.ibm.jaggr.core.module.ModuleSpecifier;
 import com.ibm.jaggr.core.readers.ModuleBuildReader;
+import com.ibm.jaggr.core.util.SignalUtil;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -33,6 +34,7 @@ import java.util.concurrent.TimeoutException;
  * {@link ILayer#BUILDFUTURESQUEUE_REQATTRNAME} request attribute.
  */
 public class ModuleBuildFuture implements Future<ModuleBuildReader> {
+	private static final String sourceClass = ModuleBuildFuture.class.getName();
 
 	private final Future<ModuleBuildReader> future;
 	private final ModuleSpecifier moduleSpecifier;
@@ -62,7 +64,8 @@ public class ModuleBuildFuture implements Future<ModuleBuildReader> {
 	@Override
 	public ModuleBuildReader get() throws InterruptedException,
 	ExecutionException {
-		return future.get();
+		final String sourceMethod = "get"; //$NON-NLS-1$
+		return SignalUtil.get(future, sourceClass, sourceMethod, module);
 	}
 
 	@Override
@@ -77,5 +80,10 @@ public class ModuleBuildFuture implements Future<ModuleBuildReader> {
 
 	public IModule getModule() {
 		return module;
+	}
+
+	@Override
+	public String toString() {
+		return module.toString();
 	}
 }

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/Messages.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/Messages.java
@@ -24,6 +24,10 @@ public class Messages extends NLS {
 	public static String DependencyList_3;
 	public static String DependencyList_4;
 	public static String DependencyList_5;
+	public static String SignalUtil_0;
+	public static String SignalUtil_1;
+	public static String SignalUtil_2;
+
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/SignalUtil.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/SignalUtil.java
@@ -1,0 +1,380 @@
+package com.ibm.jaggr.core.util;
+
+import java.text.Format;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Lock;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Wrappers for signaling methods that wait indefinitely. The wrappers add logging for threads that
+ * appear to be stuck. Stuck threads will periodically output warning messages to the logs
+ * indicating how long the thread has been waiting. Logging for a stuck thread will be quiesced if
+ * the thread remains stuck for an extended period (to avoid overwhelming the logs). If a thread has
+ * been reported as stuck, then a warning level message is logged if and when the stuck thread
+ * finally awakes.
+ * <p>
+ * This can help diagnose deadlocks by identifying the threads involved.
+ */
+public class SignalUtil {
+	private static final String sourceClass = SignalUtil.class.getName();
+	private static final Logger log = Logger.getLogger(sourceClass);
+
+	public static final long LOCK_LOG_INTERVAL_SECONDS = 60;	// 1 minute
+	public static final long LOCK_LOG_QUIESCE_TIMEOUT_MINUTES = 120;	// 2 hours
+
+	/**
+	 * Formats the specified string using the specified arguments. If the argument array contains
+	 * more elements than the format string can accommodate, then the additional arguments are
+	 * appended to the end of the formatted string.
+	 *
+	 * @param fmt
+	 *            the format string
+	 * @param args
+	 *            the argument array for the replaceable parameters in the format string
+	 * @return the formatted string
+	 */
+	static String formatMessage(String fmt, Object[] args) {
+		MessageFormat formatter = new MessageFormat(fmt);
+		Format[] formats = formatter.getFormatsByArgumentIndex();
+		StringBuffer msg = new StringBuffer();
+		formatter.format(args, msg, null);
+		if (args.length > formats.length) {
+			// We have extra arguements that were not included in the format string.
+			// Append them to the result
+			for (int i = formats.length; i < args.length; i++) {
+				msg.append(i == formats.length ? ": " : ", ") //$NON-NLS-1$ //$NON-NLS-2$
+				   .append(args[i].toString());
+			}
+		}
+		return msg.toString();
+	}
+
+	/**
+	 * Logs a warning message. If the elapsed time is greater than
+	 * {@link #LOCK_LOG_QUIESCE_TIMEOUT_MINUTES} then the log message will indicate that wait
+	 * logging for the thread is being quiesced, and a value of true is returned. Otherwise, false
+	 * is returned.
+	 * <p>
+	 * This is a convenience method to call
+	 * {@link #logWaiting(Logger, String, String, Object, long, Object...)} with the default logger.
+	 *
+	 * @param callerClass
+	 *            the class name of the caller
+	 * @param callerMethod
+	 *            the method name of the caller
+	 * @param waitObj
+	 *            the object that is being waited on
+	 * @param start
+	 *            the time that the wait began
+	 * @param extraArgs
+	 *            caller provided extra arguments
+	 * @return true if the elapsed time is greater than {@link #LOCK_LOG_QUIESCE_TIMEOUT_MINUTES}
+	 */
+	static boolean logWaiting(String callerClass, String callerMethod, Object waitObj, long start, Object... extraArgs) {
+		return logWaiting(log, callerClass, callerMethod, waitObj, start, extraArgs);
+	}
+
+	/**
+	 * Logs a warning message. If the elapsed time is greater than
+	 * {@link #LOCK_LOG_QUIESCE_TIMEOUT_MINUTES} then the log message will indicate that wait
+	 * logging for the thread is being quiesced, and a value of true is returned. Otherwise, false
+	 * is returned.
+	 *
+	 * @param log
+	 *            the logger (for unit testing)
+	 * @param callerClass
+	 *            the class name of the caller
+	 * @param callerMethod
+	 *            the method name of the caller
+	 * @param waitObj
+	 *            the object that is being waited on
+	 * @param start
+	 *            the time that the wait began
+	 * @param extraArgs
+	 *            caller provided extra arguments
+	 * @return true if the elapsed time is greater than {@link #LOCK_LOG_QUIESCE_TIMEOUT_MINUTES}
+	 */
+	static boolean logWaiting(Logger log, String callerClass, String callerMethod, Object waitObj, long start, Object... extraArgs) {
+		long elapsed = (System.currentTimeMillis() - start)/1000;
+		boolean quiesced = false;
+		if (elapsed <= LOCK_LOG_QUIESCE_TIMEOUT_MINUTES * 60) {
+			ArrayList<Object> args = new ArrayList<Object>();
+			args.add(Thread.currentThread().getId());
+			args.add(elapsed);
+			args.add(waitObj);
+			if (extraArgs != null) {
+				args.addAll(Arrays.asList(extraArgs));
+			}
+			String msg = SignalUtil.formatMessage(Messages.SignalUtil_0, args.toArray(new Object[args.size()]));
+			log.logp(Level.WARNING, callerClass, callerMethod, msg.toString());
+		} else {
+			if (!quiesced) {
+				quiesced = true;
+				log.logp(Level.WARNING, callerClass, callerMethod,
+						MessageFormat.format(
+								Messages.SignalUtil_1,
+								new Object[]{Thread.currentThread().getId(), elapsed, waitObj}
+						)
+				);
+			}
+		}
+		return quiesced;
+	}
+
+	/**
+	 * Logs a warning level message indicating that a thread which has previously been reported
+	 * as stuck is now resuming.
+	 *
+	 * @param callerClass
+	 *            the class name of the caller
+	 * @param callerMethod
+	 *            the method name of the caller
+	 * @param waitObj
+	 *            the object that is being waited on
+	 * @param start
+	 *            the time that the wait began
+	 */
+	static void logResuming(String callerClass, String callerMethod, Object waitObj, long start) {
+		long elapsed = (System.currentTimeMillis() - start)/1000;
+		log.logp(Level.WARNING, callerClass, callerMethod,
+				Messages.SignalUtil_2, new Object[]{Thread.currentThread().getId(), elapsed, waitObj});
+	}
+
+	/**
+	 * Implements the same semantics as {@link Lock#lock()}, except that the wait will periodically
+	 * time out within this method to log a warning message that the thread appears stuck. This
+	 * cycle will be repeated until the lock is obtained. If the thread has waited for an extended
+	 * period, then wait logging is quiesced to avoid overwhelming the logs. If and when a thread
+	 * that has been reported as being stuck finally does obtain the lock, then a warning level
+	 * message is logged to indicate that the thread is resuming.
+	 *
+	 * @param lock
+	 *            the Lock object to wait on
+	 * @param callerClass
+	 *            the caller class
+	 * @param callerMethod
+	 *            the caller method
+	 * @param args
+	 *            extra arguments to be appended to the log message
+	 */
+	public static void lock(Lock lock, String callerClass, String callerMethod, Object... args) {
+		final String sourceMethod = "lock"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod, new Object[]{Thread.currentThread(), lock, callerClass, callerMethod, args});
+		}
+		long start = System.currentTimeMillis();
+		boolean quiesced = false, logged = false;
+		try {
+			while (!lock.tryLock(LOCK_LOG_INTERVAL_SECONDS, TimeUnit.SECONDS)) {
+				if (!quiesced) {
+					quiesced = logWaiting(callerClass, callerMethod, lock, start, args);
+					logged = true;
+				}
+			}
+		} catch (InterruptedException ex) {
+			// InterruptedException is not thrown by Lock.lock() so convert to a
+			// RuntimeException.
+			throw new RuntimeException(ex);
+		}
+		if (logged) {
+			logResuming(callerClass, callerMethod, lock, start);
+		}
+		if (isTraceLogging) {
+			log.exiting(sourceClass, sourceMethod, Arrays.asList(Thread.currentThread(), lock, callerClass, callerMethod));
+		}
+		return;
+	}
+
+	/**
+	 * Implements the same semantics as {@link CompletionService#take()}, except that the wait will
+	 * periodically time out within this method to log a warning message that the thread appears
+	 * stuck. This cycle will be repeated until a {@link Future} is obtained. If the thread has
+	 * waited for an extended period, then wait logging is quiesced to avoid overwhelming the logs.
+	 * If and when a thread that has been reported as being stuck finally does obtain a
+	 * {@link Future}, then a warning level message is logged to indicate that the thread is
+	 * resuming.
+	 *
+	 * @param <T>
+	 *            Generic type of the Future result
+	 * @param cs
+	 *            the CompletionService to wait on
+	 * @param callerClass
+	 *            the caller class
+	 * @param callerMethod
+	 *            the caller method
+	 * @param args
+	 *            extra arguments to be appended to the log message
+	 * @return the Future<T> obtained from the CompletionService
+	 * @throws InterruptedException
+	 */
+	public static <T> Future<T> take(CompletionService<T> cs, String callerClass, String callerMethod, Object... args)
+	throws InterruptedException {
+		final String sourceMethod = "take"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod, new Object[]{Thread.currentThread(), cs, callerClass, callerMethod, args});
+		}
+		long start = System.currentTimeMillis();
+		boolean quiesced = false, logged = false;
+		Future<T> future = null;
+		while ((future = cs.poll(LOCK_LOG_INTERVAL_SECONDS, TimeUnit.SECONDS)) == null) {
+			if (!quiesced) {
+				quiesced = logWaiting(callerClass, callerMethod, cs, start, args);
+				logged = true;
+			}
+		}
+		if (logged) {
+			logResuming(callerClass, callerMethod, cs, start);
+		}
+		if (isTraceLogging) {
+			log.exiting(sourceClass, sourceMethod, Arrays.asList(Thread.currentThread(), cs, callerClass, callerMethod, future));
+		}
+		return future;
+	}
+
+	/**
+	 * Implements the same semantics as {@link CountDownLatch#await()}, except that the wait will
+	 * periodically time out within this method to log a warning message that the thread appears
+	 * stuck. This cycle will be repeated until the latch has counted down to zero. If the thread
+	 * has waited for an extended period, then wait logging is quiesced to avoid overwhelming the
+	 * logs. If and when a thread that has been reported as being stuck and the latch is finally
+	 * counted down to zero, then a warning level message is logged to indicate that the thread is
+	 * resuming.
+	 *
+	 * @param latch
+	 *            the CountDownLatch object to wait on
+	 * @param callerClass
+	 *            the caller class
+	 * @param callerMethod
+	 *            the caller method
+	 * @param args
+	 *            extra arguments to be appended to the log message
+	 * @throws InterruptedException
+	 */
+	public static void await(CountDownLatch latch, String callerClass, String callerMethod, Object... args)
+	throws InterruptedException {
+		final String sourceMethod = "await"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod, new Object[]{Thread.currentThread(), latch, callerClass, callerMethod, args});
+		}
+		long start = System.currentTimeMillis();
+		boolean quiesced = false, logged = false;
+		while (!latch.await(SignalUtil.LOCK_LOG_INTERVAL_SECONDS, TimeUnit.SECONDS)) {
+			if (!quiesced) {
+				quiesced = logWaiting(callerClass, callerMethod, latch, start, args);
+				logged = true;
+			}
+		}
+		if (logged) {
+			logResuming(callerClass, callerMethod, latch, start);
+		}
+		if (isTraceLogging) {
+			log.exiting(sourceClass, sourceMethod, Arrays.asList(Thread.currentThread(), latch, callerClass, callerMethod));
+		}
+	}
+
+	/**
+	 * Implements the same semantics as {@link Future#get()}, except that the wait will periodically
+	 * time out within this method to log a warning message that the thread appears stuck. This
+	 * cycle will be repeated until the result is available. If the thread has waited for an extended
+	 * period, then wait logging is quiesced to avoid overwhelming the logs. If and when a thread
+	 * that has been reported as being stuck finally does obtain the result, then a warning level
+	 * message is logged to indicate that the thread is resuming.
+	 *
+	 * @param <T>
+	 *            Generic for the type of the result
+	 * @param future
+	 *            the Future to obtain the result from
+	 * @param callerClass
+	 *            the caller class
+	 * @param callerMethod
+	 *            the caller method
+	 * @param args
+	 *            extra arguments to be appended to the log message
+	 * @return the result from the future
+	 * @throws InterruptedException
+	 * @throws ExecutionException
+	 */
+	public static <T> T get(Future<T> future, String callerClass, String callerMethod, Object... args)
+	throws InterruptedException, ExecutionException {
+		final String sourceMethod = "get"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod, new Object[]{Thread.currentThread(), future, callerClass, callerMethod, args});
+		}
+		T result = null;
+		long start = System.currentTimeMillis();
+		boolean quiesced = false, logged = false;
+		while (true) {
+			try {
+				result = future.get(SignalUtil.LOCK_LOG_INTERVAL_SECONDS, TimeUnit.SECONDS);
+				break;
+			} catch (TimeoutException tex) {
+				if (!quiesced) {
+					quiesced = logWaiting(callerClass, callerMethod, future, start, args);
+					logged = true;
+				}
+			}
+		}
+		if (logged) {
+			logResuming(callerClass, callerMethod, future, start);
+		}
+		if (isTraceLogging) {
+			log.exiting(sourceClass, sourceMethod, Arrays.asList(Thread.currentThread(), future, callerClass, callerMethod, result));
+		}
+		return result;
+	}
+
+	/**
+	 * Implements the same semantics as {@link Semaphore#acquire()}, except that the wait will
+	 * periodically time out within this method to log a warning message that the thread appears
+	 * stuck. This cycle will be repeated until the semaphore is acquired. If the thread has waited
+	 * for an extended period, then wait logging is quiesced to avoid overwhelming the logs. If and
+	 * when a thread that has been reported as being stuck and the semaphore is finally acquired,
+	 * then a warning level message is logged to indicate that the thread is resuming.
+	 *
+	 * @param sem
+	 *            the semaphore to wait on
+	 * @param callerClass
+	 *            the caller class
+	 * @param callerMethod
+	 *            the caller method
+	 * @param args
+	 *            extra arguments to be appended to the log message
+	 * @throws InterruptedException
+	 */
+	public static void aquire(Semaphore sem, String callerClass, String callerMethod, Object... args)
+	throws InterruptedException {
+		final String sourceMethod = "aquire"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod, new Object[]{Thread.currentThread(), sem, callerClass, callerMethod, args});
+		}
+		long start = System.currentTimeMillis();
+		boolean quiesced = false, logged = false;
+		while (!sem.tryAcquire(SignalUtil.LOCK_LOG_INTERVAL_SECONDS, TimeUnit.SECONDS)) {
+			if (!quiesced) {
+				quiesced = logWaiting(callerClass, callerMethod, sem, start, args);
+				logged = true;
+			}
+		}
+		if (logged) {
+			logResuming(callerClass, callerMethod, sem, start);
+		}
+		if (isTraceLogging) {
+			log.exiting(sourceClass, sourceMethod, Arrays.asList(Thread.currentThread(), sem, callerClass, callerMethod));
+		}
+	}
+}

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/SignalUtil.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/SignalUtil.java
@@ -1,3 +1,18 @@
+/*
+ * (C) Copyright 2012, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.ibm.jaggr.core.util;
 
 import java.text.Format;
@@ -29,8 +44,8 @@ public class SignalUtil {
 	private static final String sourceClass = SignalUtil.class.getName();
 	private static final Logger log = Logger.getLogger(sourceClass);
 
-	public static final long LOCK_LOG_INTERVAL_SECONDS = 60;	// 1 minute
-	public static final long LOCK_LOG_QUIESCE_TIMEOUT_MINUTES = 120;	// 2 hours
+	public static final long SIGNAL_LOG_INTERVAL_SECONDS = 60;	// 1 minute
+	public static final long SIGNAL_LOG_QUIESCE_TIMEOUT_MINUTES = 120;	// 2 hours
 
 	/**
 	 * Formats the specified string using the specified arguments. If the argument array contains
@@ -61,7 +76,7 @@ public class SignalUtil {
 
 	/**
 	 * Logs a warning message. If the elapsed time is greater than
-	 * {@link #LOCK_LOG_QUIESCE_TIMEOUT_MINUTES} then the log message will indicate that wait
+	 * {@link #SIGNAL_LOG_QUIESCE_TIMEOUT_MINUTES} then the log message will indicate that wait
 	 * logging for the thread is being quiesced, and a value of true is returned. Otherwise, false
 	 * is returned.
 	 * <p>
@@ -78,7 +93,7 @@ public class SignalUtil {
 	 *            the time that the wait began
 	 * @param extraArgs
 	 *            caller provided extra arguments
-	 * @return true if the elapsed time is greater than {@link #LOCK_LOG_QUIESCE_TIMEOUT_MINUTES}
+	 * @return true if the elapsed time is greater than {@link #SIGNAL_LOG_QUIESCE_TIMEOUT_MINUTES}
 	 */
 	static boolean logWaiting(String callerClass, String callerMethod, Object waitObj, long start, Object... extraArgs) {
 		return logWaiting(log, callerClass, callerMethod, waitObj, start, extraArgs);
@@ -86,7 +101,7 @@ public class SignalUtil {
 
 	/**
 	 * Logs a warning message. If the elapsed time is greater than
-	 * {@link #LOCK_LOG_QUIESCE_TIMEOUT_MINUTES} then the log message will indicate that wait
+	 * {@link #SIGNAL_LOG_QUIESCE_TIMEOUT_MINUTES} then the log message will indicate that wait
 	 * logging for the thread is being quiesced, and a value of true is returned. Otherwise, false
 	 * is returned.
 	 *
@@ -102,12 +117,12 @@ public class SignalUtil {
 	 *            the time that the wait began
 	 * @param extraArgs
 	 *            caller provided extra arguments
-	 * @return true if the elapsed time is greater than {@link #LOCK_LOG_QUIESCE_TIMEOUT_MINUTES}
+	 * @return true if the elapsed time is greater than {@link #SIGNAL_LOG_QUIESCE_TIMEOUT_MINUTES}
 	 */
 	static boolean logWaiting(Logger log, String callerClass, String callerMethod, Object waitObj, long start, Object... extraArgs) {
 		long elapsed = (System.currentTimeMillis() - start)/1000;
 		boolean quiesced = false;
-		if (elapsed <= LOCK_LOG_QUIESCE_TIMEOUT_MINUTES * 60) {
+		if (elapsed <= SIGNAL_LOG_QUIESCE_TIMEOUT_MINUTES * 60) {
 			ArrayList<Object> args = new ArrayList<Object>();
 			args.add(Thread.currentThread().getId());
 			args.add(elapsed);
@@ -176,7 +191,7 @@ public class SignalUtil {
 		long start = System.currentTimeMillis();
 		boolean quiesced = false, logged = false;
 		try {
-			while (!lock.tryLock(LOCK_LOG_INTERVAL_SECONDS, TimeUnit.SECONDS)) {
+			while (!lock.tryLock(SIGNAL_LOG_INTERVAL_SECONDS, TimeUnit.SECONDS)) {
 				if (!quiesced) {
 					quiesced = logWaiting(callerClass, callerMethod, lock, start, args);
 					logged = true;
@@ -228,7 +243,7 @@ public class SignalUtil {
 		long start = System.currentTimeMillis();
 		boolean quiesced = false, logged = false;
 		Future<T> future = null;
-		while ((future = cs.poll(LOCK_LOG_INTERVAL_SECONDS, TimeUnit.SECONDS)) == null) {
+		while ((future = cs.poll(SIGNAL_LOG_INTERVAL_SECONDS, TimeUnit.SECONDS)) == null) {
 			if (!quiesced) {
 				quiesced = logWaiting(callerClass, callerMethod, cs, start, args);
 				logged = true;
@@ -271,7 +286,7 @@ public class SignalUtil {
 		}
 		long start = System.currentTimeMillis();
 		boolean quiesced = false, logged = false;
-		while (!latch.await(SignalUtil.LOCK_LOG_INTERVAL_SECONDS, TimeUnit.SECONDS)) {
+		while (!latch.await(SignalUtil.SIGNAL_LOG_INTERVAL_SECONDS, TimeUnit.SECONDS)) {
 			if (!quiesced) {
 				quiesced = logWaiting(callerClass, callerMethod, latch, start, args);
 				logged = true;
@@ -319,7 +334,7 @@ public class SignalUtil {
 		boolean quiesced = false, logged = false;
 		while (true) {
 			try {
-				result = future.get(SignalUtil.LOCK_LOG_INTERVAL_SECONDS, TimeUnit.SECONDS);
+				result = future.get(SignalUtil.SIGNAL_LOG_INTERVAL_SECONDS, TimeUnit.SECONDS);
 				break;
 			} catch (TimeoutException tex) {
 				if (!quiesced) {
@@ -364,7 +379,7 @@ public class SignalUtil {
 		}
 		long start = System.currentTimeMillis();
 		boolean quiesced = false, logged = false;
-		while (!sem.tryAcquire(SignalUtil.LOCK_LOG_INTERVAL_SECONDS, TimeUnit.SECONDS)) {
+		while (!sem.tryAcquire(SignalUtil.SIGNAL_LOG_INTERVAL_SECONDS, TimeUnit.SECONDS)) {
 			if (!quiesced) {
 				quiesced = logWaiting(callerClass, callerMethod, sem, start, args);
 				logged = true;

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/messages.properties
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/messages.properties
@@ -28,3 +28,7 @@ DependencyList_3=Recursion cycle detected processing module "{0}".  Stack = {1}.
 # {0} = module name (path type string)
 DependencyList_4=Referenced by {0}
 DependencyList_5=Declared by {0}.
+# {0} and {1} are numbers
+SignalUtil_0=Thread {0} waited {1} seconds for signal on {2}.
+SignalUtil_1=Discontinuing wait logging for thread {0} after waiting {1} seconds on {2}.  A message will be logged if the signal is received in the future.
+SingalUtil_2=Thread {0} received signal on {2} after {1} seconds and is resuming.

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/messages_en.properties
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/messages_en.properties
@@ -28,3 +28,8 @@ DependencyList_3=Recursion cycle detected processing module "{0}".  Stack = {1}.
 # {0} = module name (path type string)
 DependencyList_4=Referenced by {0}
 DependencyList_5=Declared by {0}.
+# {0} and {1} are numbers.  {2} is object
+SignalUtil_0=Thread {0} waited {1} seconds for signal on {2}.
+SignalUtil_1=Discontinuing wait logging for thread {0} after waiting {1} seconds on {2}.  A message will be logged if the signal is received in the future.
+SingalUtil_2=Thread {0} received signal on {2} after {1} seconds and is resuming.
+

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/util/SignalUtilTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/util/SignalUtilTest.java
@@ -1,0 +1,96 @@
+package com.ibm.jaggr.core.util;
+
+import org.easymock.EasyMock;
+import org.easymock.IAnswer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.concurrent.locks.Lock;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import junit.framework.Assert;
+
+public class SignalUtilTest {
+
+	@Before
+	public void setUp() throws Exception {}
+
+	@After
+	public void tearDown() throws Exception {}
+
+	@Test
+	public void testFormatMessage() {
+		String result = SignalUtil.formatMessage("{0}, {1}", new Object[]{"1", "2"});
+		Assert.assertEquals("1, 2", result);
+
+		result = SignalUtil.formatMessage("{0}, {1}", new Object[]{"1", "2", "3"});
+		Assert.assertEquals("1, 2: 3", result);
+
+		result = SignalUtil.formatMessage("{0}, {1}", new Object[]{"1", "2", "3", "4"});
+		Assert.assertEquals("1, 2: 3, 4", result);
+	}
+
+	@Test
+	public void testLogging() {
+		Logger mockLogger = EasyMock.createMock(Logger.class);
+		final ArrayList<String> logged = new ArrayList<String>();
+		String sourceClass = "testClass";
+		mockLogger.logp(EasyMock.eq(Level.WARNING), EasyMock.eq(sourceClass), EasyMock.isA(String.class), EasyMock.isA(String.class));
+		EasyMock.expectLastCall().andAnswer(new IAnswer<Void>() {
+			@Override
+			public Void answer() throws Throwable {
+				logged.add(
+						EasyMock.getCurrentArguments()[1].toString() +
+						" - " +
+						EasyMock.getCurrentArguments()[2].toString() +
+						" - " +
+						EasyMock.getCurrentArguments()[3].toString()
+				);
+				return null;
+			}
+		}).anyTimes();
+		EasyMock.expect(mockLogger.isLoggable(Level.WARNING)).andReturn(Boolean.TRUE).anyTimes();
+		Object mockLock = new Object() {
+			@Override public String toString() {
+				return "MockLock";
+			}
+		};
+		EasyMock.replay(mockLogger);
+
+		long start = System.currentTimeMillis() - SignalUtil.LOCK_LOG_INTERVAL_SECONDS * 1000;
+		boolean result = SignalUtil.logWaiting(mockLogger, sourceClass, "method1", mockLock, start);
+		String expected = sourceClass + " - " + "method1" + " - " + MessageFormat.format(
+				com.ibm.jaggr.core.util.Messages.SignalUtil_0,
+				new Object[]{Thread.currentThread().getId(), SignalUtil.LOCK_LOG_INTERVAL_SECONDS, mockLock});
+		System.out.println(logged.get(0));
+		Assert.assertEquals(expected, logged.get(0));
+		Assert.assertFalse(result);
+
+		// Make sure extra parameters not specified in format string are appended to log message
+		start = System.currentTimeMillis() - SignalUtil.LOCK_LOG_INTERVAL_SECONDS * 1000;
+		result = SignalUtil.logWaiting(mockLogger, sourceClass, "method2", mockLock, start, "extraParam1", 3);
+		expected = sourceClass + " - " + "method2" + " - " + MessageFormat.format(
+				com.ibm.jaggr.core.util.Messages.SignalUtil_0,
+				new Object[]{Thread.currentThread().getId(), SignalUtil.LOCK_LOG_INTERVAL_SECONDS, mockLock})
+				+ ": extraParam1, 3";
+		System.out.println(logged.get(1));
+		Assert.assertEquals(expected, logged.get(1));
+		Assert.assertFalse(result);
+
+		// Test quiescence
+		start = System.currentTimeMillis() - SignalUtil.LOCK_LOG_QUIESCE_TIMEOUT_MINUTES * 1000 * 61;
+		result = SignalUtil.logWaiting(mockLogger, sourceClass, "method3", mockLock, start);
+		expected = sourceClass + " - " + "method3" + " - " + MessageFormat.format(
+				com.ibm.jaggr.core.util.Messages.SignalUtil_1,
+				new Object[]{Thread.currentThread().getId(), (SignalUtil.LOCK_LOG_QUIESCE_TIMEOUT_MINUTES)*61, mockLock});
+		System.out.println(logged.get(2));
+		Assert.assertEquals(expected, logged.get(2));
+		Assert.assertTrue(result);
+
+
+	}
+}

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/util/SignalUtilTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/util/SignalUtilTest.java
@@ -1,3 +1,18 @@
+/*
+ * (C) Copyright 2012, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.ibm.jaggr.core.util;
 
 import org.easymock.EasyMock;
@@ -61,32 +76,32 @@ public class SignalUtilTest {
 		};
 		EasyMock.replay(mockLogger);
 
-		long start = System.currentTimeMillis() - SignalUtil.LOCK_LOG_INTERVAL_SECONDS * 1000;
+		long start = System.currentTimeMillis() - SignalUtil.SIGNAL_LOG_INTERVAL_SECONDS * 1000;
 		boolean result = SignalUtil.logWaiting(mockLogger, sourceClass, "method1", mockLock, start);
 		String expected = sourceClass + " - " + "method1" + " - " + MessageFormat.format(
 				com.ibm.jaggr.core.util.Messages.SignalUtil_0,
-				new Object[]{Thread.currentThread().getId(), SignalUtil.LOCK_LOG_INTERVAL_SECONDS, mockLock});
+				new Object[]{Thread.currentThread().getId(), SignalUtil.SIGNAL_LOG_INTERVAL_SECONDS, mockLock});
 		System.out.println(logged.get(0));
 		Assert.assertEquals(expected, logged.get(0));
 		Assert.assertFalse(result);
 
 		// Make sure extra parameters not specified in format string are appended to log message
-		start = System.currentTimeMillis() - SignalUtil.LOCK_LOG_INTERVAL_SECONDS * 1000;
+		start = System.currentTimeMillis() - SignalUtil.SIGNAL_LOG_INTERVAL_SECONDS * 1000;
 		result = SignalUtil.logWaiting(mockLogger, sourceClass, "method2", mockLock, start, "extraParam1", 3);
 		expected = sourceClass + " - " + "method2" + " - " + MessageFormat.format(
 				com.ibm.jaggr.core.util.Messages.SignalUtil_0,
-				new Object[]{Thread.currentThread().getId(), SignalUtil.LOCK_LOG_INTERVAL_SECONDS, mockLock})
+				new Object[]{Thread.currentThread().getId(), SignalUtil.SIGNAL_LOG_INTERVAL_SECONDS, mockLock})
 				+ ": extraParam1, 3";
 		System.out.println(logged.get(1));
 		Assert.assertEquals(expected, logged.get(1));
 		Assert.assertFalse(result);
 
 		// Test quiescence
-		start = System.currentTimeMillis() - SignalUtil.LOCK_LOG_QUIESCE_TIMEOUT_MINUTES * 1000 * 61;
+		start = System.currentTimeMillis() - SignalUtil.SIGNAL_LOG_QUIESCE_TIMEOUT_MINUTES * 1000 * 61;
 		result = SignalUtil.logWaiting(mockLogger, sourceClass, "method3", mockLock, start);
 		expected = sourceClass + " - " + "method3" + " - " + MessageFormat.format(
 				com.ibm.jaggr.core.util.Messages.SignalUtil_1,
-				new Object[]{Thread.currentThread().getId(), (SignalUtil.LOCK_LOG_QUIESCE_TIMEOUT_MINUTES)*61, mockLock});
+				new Object[]{Thread.currentThread().getId(), (SignalUtil.SIGNAL_LOG_QUIESCE_TIMEOUT_MINUTES)*61, mockLock});
 		System.out.println(logged.get(2));
 		Assert.assertEquals(expected, logged.get(2));
 		Assert.assertTrue(result);


### PR DESCRIPTION
Replace calls to signaling methods that wait indefinitely with calls to wrapper functions that will log warning messages when threads are blocked for too long.  This can help to diagnose deadlocks. 