### PR TITLE
Cache key generator for JS modules should not depend on server expanded layers option

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilder.java
@@ -26,7 +26,6 @@ import com.ibm.jaggr.core.NotFoundException;
 import com.ibm.jaggr.core.cachekeygenerator.ExportNamesCacheKeyGenerator;
 import com.ibm.jaggr.core.cachekeygenerator.FeatureSetCacheKeyGenerator;
 import com.ibm.jaggr.core.cachekeygenerator.ICacheKeyGenerator;
-import com.ibm.jaggr.core.cachekeygenerator.ServerExpandLayersCacheKeyGenerator;
 import com.ibm.jaggr.core.deps.ModuleDepInfo;
 import com.ibm.jaggr.core.deps.ModuleDeps;
 import com.ibm.jaggr.core.impl.transport.AbstractHttpTransport;
@@ -134,9 +133,6 @@ public class JavaScriptModuleBuilder implements IModuleBuilder, IExtensionInitia
 
 	private static final ICacheKeyGenerator exportNamesCacheKeyGenerator =
 			new ExportNamesCacheKeyGenerator();
-
-	private static final ICacheKeyGenerator serverExpandLayersCacheKeyGenerator =
-			new ServerExpandLayersCacheKeyGenerator();
 
 	static {
 		Logger.getLogger("com.google.javascript.jscomp.Compiler").setLevel(Level.WARNING); //$NON-NLS-1$
@@ -541,7 +537,6 @@ public class JavaScriptModuleBuilder implements IModuleBuilder, IExtensionInitia
 	protected List<ICacheKeyGenerator> getCacheKeyGenerators(Set<String> dependentFeatures, boolean hasExpandableRequires) {
 		ArrayList<ICacheKeyGenerator> keyGens = new ArrayList<ICacheKeyGenerator>();
 		keyGens.add(exportNamesCacheKeyGenerator);
-		keyGens.add(serverExpandLayersCacheKeyGenerator);
 		keyGens.add(new CacheKeyGenerator(dependentFeatures, hasExpandableRequires, dependentFeatures == null));
 		return keyGens;
 	}


### PR DESCRIPTION
JavaScript modules don't vary based on this option.  It is only used in JavaScriptModuleBuilder.layerBeginEndNotifier() for building the layer and layer cache key generators already accounts for this option