### PR TITLE
Add lifecycle-mapping to pluginManagment section of pom

### DIFF
--- a/jaggr-sample-dojo/pom.xml
+++ b/jaggr-sample-dojo/pom.xml
@@ -157,6 +157,35 @@
 				</configuration>
 			</plugin>
 		</plugins>
+		<pluginManagement>
+		  <plugins>
+		    <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+		    <plugin>
+		      <groupId>org.eclipse.m2e</groupId>
+		      <artifactId>lifecycle-mapping</artifactId>
+		      <version>1.0.0</version>
+		      <configuration>
+		        <lifecycleMappingMetadata>
+		          <pluginExecutions>
+		            <pluginExecution>
+		              <pluginExecutionFilter>
+		                <groupId>org.apache.maven.plugins</groupId>
+		                <artifactId>maven-dependency-plugin</artifactId>
+		                <versionRange>[2.4,)</versionRange>
+		                <goals>
+		                  <goal>unpack</goal>
+		                </goals>
+		              </pluginExecutionFilter>
+		              <action>
+		                <ignore></ignore>
+		              </action>
+		            </pluginExecution>
+		          </pluginExecutions>
+		        </lifecycleMappingMetadata>
+		      </configuration>
+		    </plugin>
+		  </plugins>
+		</pluginManagement>
 	</build>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
for jaggr-sample-dojo to silence m2e errors.