### PR TITLE
Add support for LESS variables to be defined by aggregator config.

### DIFF
--- a/jaggr-core/pom.xml
+++ b/jaggr-core/pom.xml
@@ -303,7 +303,7 @@
               <directory>.</directory>
               <includes>
                 <include>lib/**</include>
-                <include>src/main/resources/less*.js</include>
+                <include>src/main/resources/less-rhino-*.js</include>
               </includes>
               <followSymlinks>false</followSymlinks>
             </fileset>

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/config/ConfigImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/config/ConfigImpl.java
@@ -29,10 +29,10 @@ import com.ibm.jaggr.core.options.IOptions;
 import com.ibm.jaggr.core.options.IOptionsListener;
 import com.ibm.jaggr.core.util.CopyUtil;
 import com.ibm.jaggr.core.util.Features;
-import com.ibm.jaggr.core.util.HasFunction;
 import com.ibm.jaggr.core.util.HasNode;
 import com.ibm.jaggr.core.util.PathUtil;
 import com.ibm.jaggr.core.util.TypeUtil;
+import com.ibm.jaggr.core.util.rhino.HasFunction;
 
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/config/ConfigImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/config/ConfigImpl.java
@@ -29,6 +29,7 @@ import com.ibm.jaggr.core.options.IOptions;
 import com.ibm.jaggr.core.options.IOptionsListener;
 import com.ibm.jaggr.core.util.CopyUtil;
 import com.ibm.jaggr.core.util.Features;
+import com.ibm.jaggr.core.util.HasFunction;
 import com.ibm.jaggr.core.util.HasNode;
 import com.ibm.jaggr.core.util.PathUtil;
 import com.ibm.jaggr.core.util.TypeUtil;
@@ -1706,53 +1707,6 @@ public class ConfigImpl implements IConfig, IShutdownListener, IOptionsListener 
 				}
 			}
 			return result;
-		}
-	}
-
-
-	/**
-	 * This class implements the JavaScript has function object used by the Rhino interpreter when
-	 * evaluating regular expressions in config aliases.
-	 * <p>
-	 * In addition to providing the has function, this class also keeps track of which features
-	 * has is called for by the JavaScript in {@code dependentFeatures}
-	 */
-	static private class HasFunction extends FunctionObject {
-		private static final long serialVersionUID = -399399681025813075L;
-		private final Features features;
-		private final Set<String> dependentFeatures;
-
-		static Method hasMethod;
-
-		static {
-			try {
-				hasMethod = HasFunction.class.getMethod("has", Context.class, Scriptable.class, Object[].class, Function.class); //$NON-NLS-1$
-			} catch (SecurityException e) {
-				log.log(Level.SEVERE, e.getMessage(), e);
-			} catch (NoSuchMethodException e) {
-				log.log(Level.SEVERE, e.getMessage(), e);
-			}
-		}
-
-		HasFunction(Scriptable scope, Features features) {
-			super("has", hasMethod, scope); //$NON-NLS-1$
-			this.features = features;
-			this.dependentFeatures = new HashSet<String>();
-		}
-		@SuppressWarnings("unused")
-		public static Object has(Context cx, Scriptable thisObj, Object[] args, Function funObj) {
-			Object result = Context.getUndefinedValue();
-			HasFunction javaThis = (HasFunction)funObj;
-			String feature = (String)args[0];
-			javaThis.dependentFeatures.add(feature);
-			if (javaThis.features.contains(feature)) {
-				result = Boolean.valueOf(javaThis.features.isFeature(feature));
-			}
-			return result;
-		}
-
-		public Set<String> getDependentFeatures() {
-			return dependentFeatures;
 		}
 	}
 

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/deps/DepUtils.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/deps/DepUtils.java
@@ -19,8 +19,8 @@ package com.ibm.jaggr.core.impl.deps;
 import com.ibm.jaggr.core.util.BooleanTerm;
 import com.ibm.jaggr.core.util.Features;
 import com.ibm.jaggr.core.util.HasNode;
-import com.ibm.jaggr.core.util.NodeUtil;
 import com.ibm.jaggr.core.util.PathUtil;
+import com.ibm.jaggr.core.util.rhino.NodeUtil;
 
 import com.google.javascript.rhino.Node;
 import com.google.javascript.rhino.Token;

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/css/CSSModuleBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/css/CSSModuleBuilder.java
@@ -43,6 +43,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.Function;
@@ -100,7 +101,7 @@ import javax.servlet.http.HttpServletRequest;
  * </ul>
  * This module works by extending TextModuleBuilder and processing the text stream
  * associated with the Reader that is returned by the overridden method
- * {@link #getContentReader(String, com.ibm.jaggr.core.resource.IResource, javax.servlet.http.HttpServletRequest, java.util.List)}.
+ * {@link #getContentReader(String, com.ibm.jaggr.core.resource.IResource, javax.servlet.http.HttpServletRequest, MutableObject)}.
  * <h2>Comment removal</h2>
  * <p>
  * Removes comments identified by /* ... *&#047; comment tags
@@ -359,12 +360,12 @@ public class CSSModuleBuilder extends TextModuleBuilder implements  IExtensionIn
 			String mid,
 			IResource resource,
 			HttpServletRequest request,
-			List<ICacheKeyGenerator> keyGens)
+			MutableObject<List<ICacheKeyGenerator>> keyGensRef)
 			throws IOException {
 		final String sourceMethod = "getContentReader"; //$NON-NLS-1$
 		final boolean isTraceLogging = log.isLoggable(Level.FINER);
 		if (isTraceLogging) {
-			log.entering(sourceClass, sourceMethod, new Object[]{mid, resource, request, keyGens});
+			log.entering(sourceClass, sourceMethod, new Object[]{mid, resource, request, keyGensRef});
 		}
 		Reader result = null;
 		SignalUtil.lock(		// If a config update is in progress, wait
@@ -1018,7 +1019,7 @@ public class CSSModuleBuilder extends TextModuleBuilder implements  IExtensionIn
 	/* (non-Javadoc)
 	 * @see com.ibm.jaggr.service.modulebuilder.IModuleBuilder#getCacheKeyGenerator(com.ibm.jaggr.service.IAggregator)
 	 */
-	@Override	public final List<ICacheKeyGenerator> getCacheKeyGenerators(IAggregator aggregator) {
+	@Override	public List<ICacheKeyGenerator> getCacheKeyGenerators(IAggregator aggregator) {
 		return s_cacheKeyGenerators;
 	}
 

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/css/CSSModuleBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/css/CSSModuleBuilder.java
@@ -379,7 +379,7 @@ public class CSSModuleBuilder extends TextModuleBuilder implements  IExtensionIn
 				css = inlineImports(request, css, resource, BLANK);
 			}
 			// PostCSS
-			css = postcss(css, resource);
+			css = postcss(request, css, resource);
 
 			// Inline images
 			css = inlineImageUrls(request, css, resource);
@@ -718,12 +718,13 @@ public class CSSModuleBuilder extends TextModuleBuilder implements  IExtensionIn
 	 * Runs given CSS through PostCSS processor for minification and any other processing
 	 * by configured plugins
 	 * .
+	 * @param request
 	 * @param css
 	 * @param res
 	 * @return The processed CSS.
 	 * @throws IOException
 	 */
-	protected String postcss(String css, IResource res) throws IOException {
+	protected String postcss(HttpServletRequest request, String css, IResource res) throws IOException {
 		if (threadScopes == null) {
 			return css;
 		}
@@ -1153,5 +1154,9 @@ public class CSSModuleBuilder extends TextModuleBuilder implements  IExtensionIn
 			return result.substring(1, result.length()-1);
 		}
 		return result;
+	}
+
+	protected IAggregator getAggregator() {
+		return aggregator;
 	}
 }

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/HasFilteringCompilerPass.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/HasFilteringCompilerPass.java
@@ -17,7 +17,7 @@
 package com.ibm.jaggr.core.impl.modulebuilder.javascript;
 
 import com.ibm.jaggr.core.util.Features;
-import com.ibm.jaggr.core.util.NodeUtil;
+import com.ibm.jaggr.core.util.rhino.NodeUtil;
 
 import com.google.javascript.jscomp.CompilerPass;
 import com.google.javascript.rhino.Node;

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/RequireExpansionCompilerPass.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/RequireExpansionCompilerPass.java
@@ -26,9 +26,9 @@ import com.ibm.jaggr.core.util.BooleanTerm;
 import com.ibm.jaggr.core.util.DependencyList;
 import com.ibm.jaggr.core.util.Features;
 import com.ibm.jaggr.core.util.JSSource;
-import com.ibm.jaggr.core.util.NodeUtil;
 import com.ibm.jaggr.core.util.PathUtil;
 import com.ibm.jaggr.core.util.StringUtil;
+import com.ibm.jaggr.core.util.rhino.NodeUtil;
 
 import com.google.javascript.jscomp.CompilerPass;
 import com.google.javascript.rhino.Node;

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/text/TextModuleBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/text/TextModuleBuilder.java
@@ -29,6 +29,8 @@ import com.ibm.jaggr.core.util.TypeUtil;
 
 import com.google.common.collect.ImmutableList;
 
+import org.apache.commons.lang3.mutable.MutableObject;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringWriter;
@@ -83,18 +85,19 @@ public class TextModuleBuilder implements IModuleBuilder {
 			sb.append("define('"); //$NON-NLS-1$
 		}
 		StringWriter writer = new StringWriter();
+		MutableObject<List<ICacheKeyGenerator>> keyGensRef = new MutableObject<List<ICacheKeyGenerator>>(keyGens);
 		CopyUtil.copy(
 				new JavaScriptEscapingReader(
-						getContentReader(mid, resource, request, keyGens)
+						getContentReader(mid, resource, request, keyGensRef)
 						),
 						writer
 				);
 		sb.append(writer.toString());
 		sb.append(noTextAdorn ? "'" : "');"); //$NON-NLS-1$ //$NON-NLS-2$
-		return new ModuleBuild(sb.toString(), keyGens, null);
+		return new ModuleBuild(sb.toString(), keyGensRef.getValue(), null);
 	}
 
-	protected Reader getContentReader(String mid,	IResource resource,	HttpServletRequest request,	List<ICacheKeyGenerator> keyGens)	throws IOException {
+	protected Reader getContentReader(String mid,	IResource resource,	HttpServletRequest request,	MutableObject<List<ICacheKeyGenerator>> keyGensRef)	throws IOException {
 		return resource.getReader();
 	}
 

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/resource/JsxResourceConverter.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/resource/JsxResourceConverter.java
@@ -602,7 +602,7 @@ public class JsxResourceConverter implements IResourceConverter, IExtensionIniti
 				Scriptable transformInstance = (Scriptable)scope.get(JSXTRANSFORM_INSTANCE, scope);
 				Function transformFunction = (Function) transformInstance.get("transform", scope); //$NON-NLS-1$
 				//Create a native JS object with the desired JSX options
-				Object jsxArgs = ctx.evaluateString(scope, "(function () { return " + jsxOptions + "; })()", "opt", 1, null);
+				Object jsxArgs = ctx.evaluateString(scope, "(function () { return " + jsxOptions + "; })()", "opt", 1, null); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 				NativeObject convertedJSX = (NativeObject) transformFunction.call(ctx, scope, transformInstance, new Object[]{jsx, jsxArgs});
 				jsstring = convertedJSX.get("code").toString();  //$NON-NLS-1$
 			} catch (JavaScriptException e) {

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/HasFunction.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/HasFunction.java
@@ -1,0 +1,97 @@
+/*
+ * (C) Copyright 2014, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.jaggr.core.util;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Function;
+import org.mozilla.javascript.FunctionObject;
+import org.mozilla.javascript.Scriptable;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * This class implements the JavaScript has function object used by the Rhino interpreter when
+ * evaluating regular expressions in config aliases.
+ * <p>
+ * In addition to providing the has function, this class also keeps track of which features
+ * has is called for by the JavaScript in {@code dependentFeatures}
+ */
+public class HasFunction extends FunctionObject {
+	private static final long serialVersionUID = 8795456757297823566L;
+	static final private String sourceClass = HasFunction.class.getName();
+	static final private Logger log = Logger.getLogger(sourceClass);
+	private final Features features;
+	private final Set<String> dependentFeatures;
+
+	static Method hasMethod;
+
+	static {
+		try {
+			hasMethod = HasFunction.class.getMethod("has", Context.class, Scriptable.class, Object[].class, Function.class); //$NON-NLS-1$
+		} catch (SecurityException e) {
+			log.log(Level.SEVERE, e.getMessage(), e);
+		} catch (NoSuchMethodException e) {
+			log.log(Level.SEVERE, e.getMessage(), e);
+		}
+	}
+
+	public HasFunction(Scriptable scope, Features features) {
+		super("has", hasMethod, scope); //$NON-NLS-1$
+		final String sourceMethod = "<ctor>"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod, new Object[]{scope, features});
+		}
+		this.features = features;
+		this.dependentFeatures = new HashSet<String>();
+		if (isTraceLogging) {
+			log.exiting(sourceClass, sourceMethod, this);
+		}
+	}
+
+	public static Object has(Context cx, Scriptable thisObj, Object[] args, Function funObj) {
+		final String sourceMethod = "has"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod, new Object[]{cx, thisObj, args, funObj});
+		}
+		Object result = Context.getUndefinedValue();
+		HasFunction javaThis = (HasFunction)funObj;
+		String feature = (String)args[0];
+		javaThis.dependentFeatures.add(feature);
+		if (javaThis.features.contains(feature)) {
+			result = Boolean.valueOf(javaThis.features.isFeature(feature));
+		}
+		if (isTraceLogging) {
+			log.exiting(sourceClass, sourceMethod, result);
+		}
+		return result;
+	}
+
+	public Set<String> getDependentFeatures() {
+		final String sourceMethod = "getDependentFeatures"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod);
+			log.exiting(sourceClass, sourceMethod, dependentFeatures);
+		}
+		return dependentFeatures;
+	}
+}

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/rhino/HasFunction.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/rhino/HasFunction.java
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.ibm.jaggr.core.util;
+package com.ibm.jaggr.core.util.rhino;
+
+import com.ibm.jaggr.core.util.Features;
 
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/rhino/NodeUtil.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/rhino/NodeUtil.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.ibm.jaggr.core.util;
+package com.ibm.jaggr.core.util.rhino;
 
 import com.google.javascript.rhino.Node;
 import com.google.javascript.rhino.Token;

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/rhino/ReadFileExtFunction.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/rhino/ReadFileExtFunction.java
@@ -1,0 +1,227 @@
+/*
+ * (C) Copyright 2014, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.jaggr.core.util.rhino;
+
+import com.ibm.jaggr.core.IAggregator;
+import com.ibm.jaggr.core.IServiceRegistration;
+import com.ibm.jaggr.core.IShutdownListener;
+import com.ibm.jaggr.core.config.IConfig;
+import com.ibm.jaggr.core.config.IConfigListener;
+import com.ibm.jaggr.core.impl.modulebuilder.css.CSSModuleBuilder;
+import com.ibm.jaggr.core.readers.CommentStrippingReader;
+import com.ibm.jaggr.core.resource.IResource;
+import com.ibm.jaggr.core.util.CopyUtil;
+import com.ibm.jaggr.core.util.TypeUtil;
+
+import com.google.javascript.rhino.head.Undefined;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Function;
+import org.mozilla.javascript.FunctionObject;
+import org.mozilla.javascript.Scriptable;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.Hashtable;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
+/**
+ * Implements the JavaScript readFileExt function used by the LESS module builder to load &#64import
+ * resources. If the config specifies the {@link CSSModuleBuilder#INCLUDEAMDPATHS_CONFIGPARAM}
+ * property, then file names that look like AMD module ids will be resolved as such <b>before</b>
+ * attempting to resolve the filename as a simple relative path. To disambiguate, prefix the import
+ * name with './' to specify a relative path instead of an AMD module name.
+ */
+public class ReadFileExtFunction extends FunctionObject implements IConfigListener, IShutdownListener {
+	private static final long serialVersionUID = 8795456757297823566L;
+	static final private String sourceClass = ReadFileExtFunction.class.getName();
+	static final private Logger log = Logger.getLogger(sourceClass);
+
+	static final public String FUNCTION_NAME = "readFileExt"; //$NON-NLS-1$
+
+	static final private Pattern NON_AMD_PATH_PAT = Pattern.compile("^(?:[a-z-]+:|\\/|\\.)"); //$NON-NLS-1$
+
+	private final IAggregator aggregator;
+	private boolean isIncludeAMDPaths = false;
+	private List<IServiceRegistration> registrations = new LinkedList<IServiceRegistration>();
+
+	static Method readFileExtMethod;
+
+	static {
+		try {
+			readFileExtMethod = ReadFileExtFunction.class.getMethod(FUNCTION_NAME, Context.class,
+					Scriptable.class, Object[].class, Function.class);
+		} catch (SecurityException e) {
+			log.log(Level.SEVERE, e.getMessage(), e);
+		} catch (NoSuchMethodException e) {
+			log.log(Level.SEVERE, e.getMessage(), e);
+		}
+	}
+
+	public ReadFileExtFunction(Scriptable scope, IAggregator aggregator) {
+		super(FUNCTION_NAME, readFileExtMethod, scope);
+		final String sourceMethod = "<ctor>"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod, new Object[] { scope, aggregator });
+		}
+		this.aggregator = aggregator;
+
+		// Register config and shutdown listeners.
+		Hashtable<String, String> props;
+		props = new Hashtable<String, String>();
+		props.put("name", aggregator.getName()); //$NON-NLS-1$
+		registrations.add(aggregator.getPlatformServices().registerService(IConfigListener.class.getName(), this, props));
+		props = new Hashtable<String, String>();
+		props.put("name", aggregator.getName()); //$NON-NLS-1$
+		registrations.add(aggregator.getPlatformServices().registerService(IShutdownListener.class.getName(), this, props));
+		IConfig config = aggregator.getConfig();
+		if (config != null) {
+			configLoaded(config, 1);
+		}
+		if (isTraceLogging) {
+			log.exiting(sourceClass, sourceMethod, this);
+		}
+	}
+
+	/**
+	 * Read file function called by JavaScript code. The JavaScript function has the signature:
+	 *
+	 * <pre>
+	 *    readFileExt({
+	 *       ref: &lt;reference path - usually the fully qualified name of the importing file&gt;
+	 *       file: &lt;the file name as specified in the &#64import statement&gt;
+	 *    });
+	 * </pre>
+	 *
+	 * On return, the ref property is updated with the fully qualified filename (URI) of the
+	 * file that was read, or that was attempted to be read if an exception is thrown.
+	 *
+	 * @param cx
+	 *            the Rhino context
+	 * @param thisObj
+	 *            the reference to the JavaScript context object (e.g. 'this')
+	 * @param args
+	 *            the arguments passed to the JavaScript function
+	 * @param funObj
+	 *            reference to the Java instance of this function object.
+	 * @return The content of the specified file.
+	 * @throws IOException
+	 */
+	public static Object readFileExt(Context cx, Scriptable thisObj, Object[] args, Function funObj)
+			throws IOException {
+		final String sourceMethod = "readFileExt"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod, new Object[] { cx, thisObj, args, funObj });
+		}
+		Object result = Context.getUndefinedValue();
+		ReadFileExtFunction javaThis = (ReadFileExtFunction) funObj;
+		Scriptable params = (Scriptable) args[0];
+		// Retrieve arguments from 'params' property
+		String file = (String) params.get("file", params); //$NON-NLS-1$
+		String ref = (String) params.get("ref", params); //$NON-NLS-1$
+		if (isTraceLogging) {
+			log.logp(Level.FINER, sourceClass, sourceMethod,
+					"JS request args: file = " + file + ", ref = " + ref); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+		URI fileUri = null;
+		IResource res = null;
+		if (javaThis.isIncludeAMDPaths && !NON_AMD_PATH_PAT.matcher(file).find()) {
+			fileUri = javaThis.aggregator.getConfig().locateModuleResource(file);
+			if (fileUri != null) {
+				res = javaThis.aggregator.newResource(fileUri);
+			}
+		}
+		if (res == null || !res.exists()) {
+			// Not and AMD module or resource doesn't exist.  Try resolving against reference URI
+			if (ref != null && ref != Scriptable.NOT_FOUND && ref != Undefined.instance) {
+				URI refUri = URI.create(ref);
+				fileUri = refUri.resolve(file);
+			}
+			res = javaThis.aggregator.newResource(fileUri);
+		}
+		// Update the 'ref' property of the input params with the filename we are going to try to load.
+		params.put("ref", params, res != null ? res.getReferenceURI().toString() : file); //$NON-NLS-1$
+		if (isTraceLogging) {
+			log.logp(Level.FINER, sourceClass, sourceMethod,
+					"Attempting to load file " + ref); //$NON-NLS-1$
+		}
+		if (res == null || !res.exists()) {
+			throw new FileNotFoundException(res != null ? res.getReferenceURI().toString() : file);
+		}
+		Reader in = new CommentStrippingReader(
+				new InputStreamReader(res.getURI().toURL().openStream(), "UTF-8" //$NON-NLS-1$
+		));
+		StringWriter out = new StringWriter();
+		CopyUtil.copy(in, out);
+		result = out.toString();
+
+		if (isTraceLogging) {
+			log.exiting(sourceClass, sourceMethod, result);
+		}
+		return result;
+	}
+
+	/* (non-Javadoc)
+	 * @see com.ibm.jaggr.core.IShutdownListener#shutdown(com.ibm.jaggr.core.IAggregator)
+	 */
+	@Override
+	public void shutdown(IAggregator aggregator) {
+		final String sourceMethod = "shutdown"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod, new Object[] { aggregator });
+		}
+		aggregator = null;
+		for (IServiceRegistration reg : registrations) {
+			reg.unregister();
+		}
+		registrations.clear();
+
+		if (isTraceLogging) {
+			log.exiting(sourceClass, sourceMethod);
+		}
+	}
+
+	/* (non-Javadoc)
+	 * @see com.ibm.jaggr.core.config.IConfigListener#configLoaded(com.ibm.jaggr.core.config.IConfig, long)
+	 */
+	@Override
+	public void configLoaded(IConfig config, long sequence) {
+		final String sourceMethod = "configLoaded"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod, new Object[] { aggregator });
+		}
+		// update the config property
+		isIncludeAMDPaths = TypeUtil.asBoolean(
+				config.getProperty(CSSModuleBuilder.INCLUDEAMDPATHS_CONFIGPARAM, Boolean.class)
+		);
+		if (isTraceLogging) {
+			log.exiting(sourceClass, sourceMethod);
+		}
+	}
+}

--- a/jaggr-core/src/main/resources/lessFileLoader.js
+++ b/jaggr-core/src/main/resources/lessFileLoader.js
@@ -1,0 +1,55 @@
+/*
+ * (C) Copyright 2014, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Implementation of less parser fileLoader function used to load files by @import
+ * statements.  Calls the global readFileExt function implemented in Java by 
+ * JAGGR.
+ */
+less.Parser.fileLoader = function (file, currentFileInfo, callback, env) {
+    currentFileInfo = currentFileInfo || {};
+    var params = {
+    	file: file,
+    	ref: currentFileInfo.filename
+    };
+    
+    var data = null;
+    try {
+    	/*
+    	 * readFileExt() updates params.ref to be the fully qualified file name of the
+    	 * file that was loaded.  In the event of an exception being thrown, params.ref
+    	 * should specify the name of the file that the function attempted to load.
+    	 */
+        data = readFileExt(params);
+    } catch (e) {
+        callback({ type: 'File', message: "'" + params.ref + "' wasn't found" });
+        return;
+    }
+
+    var newFileInfo = {
+        entryPath: currentFileInfo.entryPath,
+        rootFilename: currentFileInfo.rootFilename,
+        rootpath: currentFileInfo.rootpath,
+        currentDirectory: less.modules.path.dirname(params.ref) + '/',
+        filename: params.ref
+    };
+
+    try {
+        callback(null, data, params.ref, newFileInfo, { lastModified: 0 });
+    } catch (e) {
+        callback(e, null, href);
+    }
+};

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/css/CSSModuleBuilderTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/css/CSSModuleBuilderTest.java
@@ -32,6 +32,7 @@ import com.ibm.jaggr.core.transport.IHttpTransport;
 import com.ibm.jaggr.core.util.CopyUtil;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -83,7 +84,7 @@ public class CSSModuleBuilderTest extends EasyMock {
 				String mid,
 				IResource resource,
 				HttpServletRequest request,
-				List<ICacheKeyGenerator> keyGens)
+				MutableObject<List<ICacheKeyGenerator>> keyGens)
 						throws IOException {
 			return super.getContentReader(mid, resource, request, keyGens);
 		}
@@ -635,7 +636,7 @@ public class CSSModuleBuilderTest extends EasyMock {
 	}
 
 	private String buildCss(IResource css) throws Exception {
-		Reader reader = builder.getContentReader("test", css, mockRequest, keyGens);
+		Reader reader = builder.getContentReader("test", css, mockRequest, new MutableObject<List<ICacheKeyGenerator>>(keyGens));
 		StringWriter writer = new StringWriter();
 		CopyUtil.copy(reader, writer);
 		String output = writer.toString();

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/util/JSSourceTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/util/JSSourceTest.java
@@ -15,6 +15,8 @@
  */
 package com.ibm.jaggr.core.util;
 
+import com.ibm.jaggr.core.util.rhino.NodeUtil;
+
 import com.google.javascript.jscomp.Compiler;
 import com.google.javascript.jscomp.JSSourceFile;
 import com.google.javascript.rhino.Node;

--- a/jaggr-sample/WebContent/js/css.js
+++ b/jaggr-sample/WebContent/js/css.js
@@ -340,6 +340,11 @@ define([
 			 * @param  {String} lessText The LESS text to compile.
 			 */
 			function processLess(lessText) {
+				var additionalData;
+				var lessGlobals = window.require.lessGlobals || window.dojoConfig && window.dojoConfig.lessGlobals;
+				if (lessGlobals) {
+					additionalData = {globalVars: lessGlobals};
+				}
 				var pathParts = url.split('?').shift().split('/');
 				require(['lesspp'], function (lesspp) {
 					var parser = new lesspp.Parser({
@@ -353,7 +358,7 @@ define([
 							return load.error(err);
 						}
 						processCss(tree.toCSS());
-					});
+					}, additionalData);
 				});
 			}
 


### PR DESCRIPTION
Supports the `lessGlobals` property in the client-side AMD loader config (used when compiling LESS files on the client as when bypassing the aggregator) and the server-side AMD config.  `lessGlobals` may specify a property map of LESS variable name-value pairs (both the client and server configs), or a function (server config only).  If it specifies a function, then the function returns the property map of LESS variable name-value pairs.  The javascript `has()` function is defined within the scope of the function and may be called to conditionally define properties based on the features specified by the request.  For example:
```
lessGlobals: function() {
   return {
      bidiLeft: has('RtlLanguage') ? 'right' : 'left'
   };
}
```