### PR TITLE
Add support for compilerOptions config property

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilder.java
@@ -68,11 +68,13 @@ import org.apache.commons.lang3.mutable.MutableBoolean;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.lang.reflect.AccessibleObject;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Dictionary;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.LinkedHashSet;
@@ -144,7 +146,7 @@ public class JavaScriptModuleBuilder implements IModuleBuilder, IExtensionInitia
 
 	private List<IServiceRegistration> registrations = new LinkedList<IServiceRegistration>();
 
-	private CompilerOptions configCompilerOptions = CompilerUtil.getDefaultOptions();
+	private Map<AccessibleObject, List<Object>> compilerOptionsMap = new HashMap<AccessibleObject, List<Object>>();
 
 	public static CompilationLevel getCompilationLevel(HttpServletRequest request) {
 		CompilationLevel level = CompilationLevel.SIMPLE_OPTIMIZATIONS;
@@ -290,9 +292,9 @@ public class JavaScriptModuleBuilder implements IModuleBuilder, IExtensionInitia
 
 	@Override
 	public void configLoaded(IConfig config, long sequence) {
-		CompilerOptions options = CompilerUtil.getDefaultOptions();
-		CompilerUtil.addCompilerOptionsFromConfig(options, config);
-		configCompilerOptions = options;
+		Map<AccessibleObject, List<Object>> map = new HashMap<AccessibleObject, List<Object>>();
+		CompilerUtil.compilerOptionsMapFromConfig(config, map);
+		compilerOptionsMap = map;
 	}
 
 	@Override
@@ -351,7 +353,8 @@ public class JavaScriptModuleBuilder implements IModuleBuilder, IExtensionInitia
 		String output = null;
 
 		Compiler compiler = new Compiler();
-		CompilerOptions compiler_options = (CompilerOptions) configCompilerOptions.clone();
+		CompilerOptions compiler_options = CompilerUtil.getDefaultOptions();
+		CompilerUtil.applyCompilerOptionsFromMap(compiler_options, compilerOptionsMap);
 		compiler_options.customPasses = HashMultimap.create();
 		if (isHasFiltering && (level != null || keyGens == null)) {
 			// Run has filtering compiler pass if we are doing has filtering, or if this

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/CompilerUtil.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/CompilerUtil.java
@@ -15,14 +15,400 @@
  */
 package com.ibm.jaggr.core.util;
 
+import com.ibm.jaggr.core.config.IConfig;
+
+import com.google.common.collect.ImmutableMap;
 import com.google.javascript.jscomp.CompilerOptions;
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 
-public class CompilerUtil {
+import org.apache.commons.lang3.mutable.MutableObject;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class CompilerUtil {
+	private static final String sourceClass = CompilerUtil.class.getName();
+	private static final Logger log = Logger.getLogger(sourceClass);
+
+	public static final String COMPILEROPTIONS_CONFIGPARAM = "compilerOptions"; //$NON-NLS-1$
+
+	public static final ImmutableMap<Class<?>, Class<?>> PRIMITIVE_TO_CLASS =
+		    new ImmutableMap.Builder<Class<?>, Class<?>>()
+	           .put(boolean.class, Boolean.class)
+	           .put(byte.class, Byte.class)
+	           .put(char.class, Character.class)
+	           .put(short.class, Short.class)
+	           .put(int.class, Integer.class)
+	           .put(long.class, Long.class)
+	           .put(float.class, Float.class)
+	           .put(double.class, Double.class)
+	           .build();
+
+	public static final ImmutableMap<String, Field> FIELD_NAME_MAP;
+
+	static {
+		Field[] fields = CompilerOptions.class.getFields();
+		ImmutableMap.Builder<String, Field> fieldNameMapBuilder = new ImmutableMap.Builder<String, Field>();
+		for (Field field : fields) {
+			fieldNameMapBuilder.put(field.getName(), field);
+		}
+		FIELD_NAME_MAP = fieldNameMapBuilder.build();
+	}
+
+	/**
+	 * Converts and returns the specified class, if it represents a primitive, to the associated
+	 * non-primitive class, or else returns the specified class if it is not a primitive.
+	 *
+	 * @param clazz
+	 *            the input class
+	 * @return the associated non-primitive class, or the input class if it is not a primitive
+	 */
+	private static Class<?> fromPrimitive(Class<?> clazz) {
+		Class<?> clazz2 = PRIMITIVE_TO_CLASS.get(clazz);
+		return clazz2 == null ? clazz : clazz2;
+	}
+
+	/**
+	 * Returns a {@link CompilerOptions} with default settings used by the Aggregator
+	 *
+	 * @return a new object with default settings
+	 */
 	public static CompilerOptions getDefaultOptions() {
+		final String sourceMethod = "getDefaultOptions"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod);
+		}
 		CompilerOptions options = new CompilerOptions();
 		options.setLanguageIn(LanguageMode.ECMASCRIPT5);
+		if (isTraceLogging) {
+			log.exiting(sourceMethod, sourceMethod, options);
+		}
 		return options;
+	}
+
+	/**
+	 * Adds the compiler options specified by the <code>compilerOptions</code> config property to
+	 * the specified {@link CompilerOptions} instance. Returns the number unsuccessful attempts to
+	 * set an option.
+	 * <p>
+	 * Compiler config options are specified using {@link CompilerOptions} defined property
+	 * name/value pairs. The names can be any property which is either declared as a public field or
+	 * has a setter method which can be mapped to the property name using standard JavaBean property
+	 * naming convention. The value is an array who's number of elements matches the number of
+	 * formal parameters defined by the setter method. If the setter method takes exactly one
+	 * parameter, or the property is a public field which has no setter method, then the array
+	 * notation may be dispensed with and the single parameter may be specified directly as in the
+	 * following examples:
+	 * <p>
+	 *
+	 * <pre>
+	 * compilerOptions: {
+	 *    defineToBooleanLiteral:['defineName', true]  // calls setDefineToBooleanLiteral("defineName", true);
+	 * }
+	 *
+	 * compilerOptions: {
+	 *    acceptConstKeyword:true           // this is identical to acceptConstKeyword:[true].  Both
+	 *                                      // will invoke setAcceptConstKeyword(true);
+	 * }
+	 *
+	 * compilerOptions: {
+	 *    aliasableStrings:[['foo', 'bar']] // setAliasableStrings takes a {@link Set}, so need to use a
+	 *                                      // nested array so that the string set will be passed as a single
+	 *                                      // parameter.
+	 * }
+	 * </pre>
+	 * <p>
+	 * This method will perform the following property value conversions when attempting to match
+	 * the provided values to the value types declared by the class:
+	 * <ul>
+	 * <li>Values specified as a JavaScript array will be converted to either a {@link List} or a
+	 * {@link Set} as needed.</li>
+	 * <li>If the declared type is an Enum and the provided value is a string which matches one of
+	 * the Enum named constants, then the matching constant value will be used</li>
+	 * </ul>
+	 * <p>
+	 * <pre>
+	 * compilerOptions: {
+	 *    checkGlobalThisLevel:'WARNING'    // This invokes setCheckGlobalThisLevel(CheckLevel.WARNING);
+	 * }
+	 * </pre>
+	 *
+	 * @param options
+	 *            the {@link CompilerOptions} instance to modify
+	 * @param config
+	 *            the server-side AMD config object
+	 * @return the number of failed attempts to set a config property (primarily for unit testing)
+	 */
+	public static int addCompilerOptionsFromConfig(CompilerOptions options, IConfig config) {
+		final String sourceMethod = "addCompilerOptionsFromConfig"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod, new Object[]{options, config});
+		}
+		int numFailed = 0;
+		Map<?,?> optionsParam = (Map<?,?>)config.getProperty(COMPILEROPTIONS_CONFIGPARAM, Map.class);
+		if (optionsParam != null) {
+			for (Map.Entry<?, ?> entry : optionsParam.entrySet()) {
+				String key = entry.getKey().toString();
+				Object value = entry.getValue();
+
+				List<Object> args = new ArrayList<Object>();
+				if (value instanceof List) {
+					// Add the elements in the array to the args list
+					@SuppressWarnings("unchecked")
+					List<Object> listValue = (List<Object>)value;
+					args.addAll(listValue);
+				} else {
+					args = new ArrayList<Object>();
+					args.add(value);
+				}
+				// find a matching setter in the CompilerOptions class
+				String setterMethodName = "set" + key.substring(0,1).toUpperCase() + key.substring(1); //$NON-NLS-1$
+				Method setterMethod = findSetterMethod(setterMethodName, args);
+				if (setterMethod != null) {
+					try {
+						if (isTraceLogging) {
+							log.logp(Level.FINER, sourceClass, sourceMethod, "Invoking " + formatForDisplay(setterMethodName, args)); //$NON-NLS-1$
+						}
+						setterMethod.invoke(options, args.toArray());
+					} catch (Exception e) {
+						numFailed++;
+						if (log.isLoggable(Level.WARNING)) {
+							log.logp(Level.WARNING, sourceClass, sourceMethod,
+								MessageFormat.format(
+									Messages.CompilerUtil_0, new Object[]{
+										formatForDisplay(setterMethodName, args)
+									}
+								), e
+							);
+						}
+					}
+				} else if (args.size() == 1){
+					// See if there is a public property with the matching name and type
+					MutableObject<Object> valueHolder = new MutableObject<Object>(args.get(0));
+					Field field = findField(key, valueHolder);
+					if (field != null) {
+						try {
+							field.set(options, valueHolder.getValue());
+						} catch (Exception e) {
+							numFailed++;
+							if (log.isLoggable(Level.WARNING)) {
+								log.logp(Level.WARNING, sourceClass, sourceMethod,
+									MessageFormat.format(
+										Messages.CompilerUtil_1, new Object[]{
+											key + "=" + value //$NON-NLS-1$
+										}
+									), e
+								);
+							}
+						}
+					} else {
+						numFailed++;
+						if (log.isLoggable(Level.WARNING)) {
+							log.logp(Level.WARNING, sourceClass, sourceMethod,
+								MessageFormat.format(
+									Messages.CompilerUtil_2, new Object[]{
+										key + "=" + value //$NON-NLS-1$
+									}
+								)
+							);
+						}
+					}
+				}
+			}
+		}
+		if (isTraceLogging) {
+			log.exiting(sourceMethod, sourceMethod, numFailed);
+		}
+		return numFailed;
+	}
+
+	/**
+	 * Returns the field matching the specified name if the type of the value specified in
+	 * <code>valueHolder</code> can be assigned to the field (with conversion if necessary), or
+	 * null.
+	 *
+	 * @param name
+	 *            the field name
+	 * @param valueHolder
+	 *            (input/output) On input, the value being assigned. On output, possibly converted
+	 *            value that will be accepted by the field. See {@link #marshalArg(Class, Object)}
+	 *            for conversion rules.
+	 * @return matching field or null
+	 */
+	private static Field findField(String name, MutableObject<Object> valueHolder) {
+		final String sourceMethod = "findField"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod, new Object[]{name, valueHolder});
+		}
+		Field field = FIELD_NAME_MAP.get(name);
+		if (field != null) {
+			Object arg = marshalArg(field.getType(), valueHolder.getValue());
+			if (arg != null) {
+				valueHolder.setValue(arg);
+			} else {
+				field = null;
+			}
+		}
+		if (isTraceLogging) {
+			log.exiting(sourceMethod, sourceMethod, field);
+		}
+		return field;
+	}
+
+	/**
+	 * Finds and returns the setter method in the {@link CompilerOptions} class that matches the
+	 * specified name and argument types. If no matching method can be found, then returns null.
+	 * <p>
+	 * An input argument type of string will match an Enum argument type if the Enum contains a
+	 * constant who's name matches the string. In this case, the string value will be replaced with
+	 * the Enum constant in the input <code>args</code> list.
+	 *
+	 * @param methodName
+	 *            the setter method name to match
+	 * @param args
+	 *            (input/output) the list of arguments. On input, the list of the arguments provided
+	 *            in the config. On output, the possibly converted list of arguments that may be
+	 *            passed to the setter method. See {@link #marshalArg(Class, Object)} for conversion
+	 *            rules.
+	 * @return the matching method, or null if no match can be found
+	 */
+	private static Method findSetterMethod(String methodName, List<Object> args) {
+		final String sourceMethod = "findSetterMethod"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod, new Object[]{methodName, args});
+		}
+		Method[] methods = CompilerOptions.class.getMethods();
+		Method result = null;
+		for (Method method : methods) {
+			if (method.getName().equals(methodName) && method.getParameterTypes().length == args.size()) {
+				List<Object> marshalledArgs = new ArrayList<Object>(args.size());
+				for (int i = 0; i < args.size(); i++) {
+					Object arg = marshalArg(method.getParameterTypes()[i], args.get(i));
+					if (arg != null) {
+						marshalledArgs.add(arg);
+					} else {
+						break;
+					}
+				}
+				if (marshalledArgs.size() == args.size()) {
+					result = method;
+					args.clear();
+					args.addAll(marshalledArgs);
+					break;
+				}
+			}
+		}
+		if (isTraceLogging) {
+			log.exiting(sourceMethod, sourceMethod, result);
+		}
+		return result;
+	}
+
+	/**
+	 * Marshals the specified argument to the declared type. May involve conversion. The following
+	 * argument conversions may occur:
+	 * <ul>
+	 * <li>List to Set if the argument type is a List (i.e. NativeArray) and the declared type is Set
+	 * </li>
+	 * <li>Sting to Enum constant if the declared type is an Enum and the argument is a string which
+	 * matches one of the Enum constant names.</li>
+	 * </ul>
+	 *
+	 * @param declaredType
+	 *            the type of the argument declared in the class definition
+	 * @param value
+	 *            the argument value provided in the config
+	 * @return the possibly converted argument value, or null if the value cannot be converted to
+	 *         the declared type
+	 */
+	private static Object marshalArg(Class<?> declaredType, Object value) {
+		final String sourceMethod = "marshalArg"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod, new Object[]{declaredType, value});
+		}
+		Object result = null;
+		Class<?> argType = value.getClass();
+		if (!fromPrimitive(declaredType).isAssignableFrom(fromPrimitive(argType))) {
+			if (declaredType.isAssignableFrom(Set.class) && value instanceof List) {
+				// Convert the list to a set
+				Set<?> set = new HashSet<Object>((List<?>)value);
+				result = set;
+			} else if (declaredType.isEnum() && argType.equals(String.class)) {
+				// If the declared type is an enum and the provided type is a string,
+				// then see if the string matches the name of an enum constant in the declared type.
+				@SuppressWarnings("unchecked")
+				Class<? extends Enum<?>> enumType = (Class<? extends Enum<?>>)declaredType;
+				Object enumValue = getEnumNamesMap(enumType).get(value.toString());
+				if (enumValue != null) {
+					result = enumValue;
+				}
+			}
+		} else {
+			result = value;
+		}
+		if (isTraceLogging) {
+			log.exiting(sourceMethod, sourceMethod, result);
+		}
+		return result;
+	}
+
+	/**
+	 * Returns a map of Enum constant name/value pairs for the specified Enum class
+	 *
+	 * @param enumType
+	 *            an Enum class object
+	 * @return the map of Enum constant name/value pairs
+	 */
+	private static Map<String, Object> getEnumNamesMap(Class<? extends Enum<?>> enumType) {
+		final String sourceMethod = "getEnumNameMap"; //$NON-NLS-1$
+		final boolean isTraceLogging = log.isLoggable(Level.FINER);
+		if (isTraceLogging) {
+			log.entering(sourceClass, sourceMethod, new Object[]{enumType});
+		}
+		Map<String, Object> result = new HashMap<String, Object>();
+		Enum<?>[] values = enumType.getEnumConstants();
+		for (Enum<?> value : values) {
+			result.put(value.name(), value);
+		}
+		if (isTraceLogging) {
+			log.exiting(sourceMethod, sourceMethod, result);
+		}
+		return result;
+	}
+
+	/**
+	 * Formats the specified setter method and parameters into a string for display.
+	 * <p>
+	 * For example: <code>setXXX(arg1, ar2)</code>
+	 *
+	 * @param setterMethodName
+	 *            the method name
+	 * @param args
+	 *            the method arguments
+	 * @return the formatted string
+	 */
+	private static String formatForDisplay(String setterMethodName, List<Object> args) {
+		StringBuffer sb = new StringBuffer(CompilerOptions.class.getName());
+		sb.append(".").append(setterMethodName).append("("); //$NON-NLS-1$ //$NON-NLS-2$
+		int i = 0;
+		for (Object arg : args) {
+			sb.append(i++ > 0 ? ", " : "").append(arg.toString()); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+		sb.append(")"); //$NON-NLS-1$
+		return sb.toString();
 	}
 }

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/CompilerUtil.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/CompilerUtil.java
@@ -184,8 +184,9 @@ public class CompilerUtil {
 		CompilerOptions test_options = new CompilerOptions();
 		Map<AccessibleObject, List<Object>> test_map = new HashMap<AccessibleObject, List<Object>>();
 		resultMap.clear();
-		Map<?,?> optionsParam = (Map<?,?>)config.getProperty(COMPILEROPTIONS_CONFIGPARAM, Map.class);
-		if (optionsParam != null) {
+		Object optionsParamObj = config.getProperty(COMPILEROPTIONS_CONFIGPARAM, Map.class);
+		if (optionsParamObj != null && optionsParamObj instanceof Map) {
+			Map<?,?> optionsParam = (Map<?,?>)optionsParamObj;
 			for (Map.Entry<?, ?> entry : optionsParam.entrySet()) {
 				String key = entry.getKey().toString();
 				Object value = entry.getValue();

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/CompilerUtil.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/CompilerUtil.java
@@ -17,6 +17,7 @@ package com.ibm.jaggr.core.util;
 
 import com.ibm.jaggr.core.config.IConfig;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.javascript.jscomp.CompilerOptions;
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
@@ -476,13 +477,9 @@ public class CompilerUtil {
 	 * @return the formatted string
 	 */
 	private static String formatForDisplay(String setterMethodName, List<Object> args) {
-		StringBuffer sb = new StringBuffer(CompilerOptions.class.getName());
+		StringBuilder sb = new StringBuilder(CompilerOptions.class.getName());
 		sb.append(".").append(setterMethodName).append("("); //$NON-NLS-1$ //$NON-NLS-2$
-		int i = 0;
-		for (Object arg : args) {
-			sb.append(i++ > 0 ? ", " : "").append(arg.toString()); //$NON-NLS-1$ //$NON-NLS-2$
-		}
-		sb.append(")"); //$NON-NLS-1$
+		Joiner.on(",").appendTo(sb, args).append(")"); //$NON-NLS-1$ //$NON-NLS-2$
 		return sb.toString();
 	}
 }

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/Messages.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/Messages.java
@@ -27,6 +27,9 @@ public class Messages extends NLS {
 	public static String SignalUtil_0;
 	public static String SignalUtil_1;
 	public static String SignalUtil_2;
+	public static String CompilerUtil_0;
+	public static String CompilerUtil_1;
+	public static String CompilerUtil_2;
 
 	static {
 		// initialize resource bundle

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/messages.properties
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/messages.properties
@@ -28,7 +28,11 @@ DependencyList_3=Recursion cycle detected processing module "{0}".  Stack = {1}.
 # {0} = module name (path type string)
 DependencyList_4=Referenced by {0}
 DependencyList_5=Declared by {0}.
-# {0} and {1} are numbers
+# {0} and {1} are numbers.  {2} is object
 SignalUtil_0=Thread {0} waited {1} seconds for signal on {2}.
 SignalUtil_1=Discontinuing wait logging for thread {0} after waiting {1} seconds on {2}.  A message will be logged if the signal is received in the future.
 SignalUtil_2=Thread {0} received signal on {2} after {1} seconds and is resuming.
+# {0} is method signature
+CompilerUtil_0=Error invoking {0}
+CompilerUtil_1=Error setting field: {0}
+CompilerUtil_2=Property not found: {0} 

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/messages_en.properties
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/messages_en.properties
@@ -32,4 +32,7 @@ DependencyList_5=Declared by {0}.
 SignalUtil_0=Thread {0} waited {1} seconds for signal on {2}.
 SignalUtil_1=Discontinuing wait logging for thread {0} after waiting {1} seconds on {2}.  A message will be logged if the signal is received in the future.
 SignalUtil_2=Thread {0} received signal on {2} after {1} seconds and is resuming.
-
+# {0} is method signature
+CompilerUtil_0=Error invoking {0}
+CompilerUtil_1=Error setting field: {0}
+CompilerUtil_2=Property not found: {0} 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/util/CompilerUtilTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/util/CompilerUtilTest.java
@@ -1,0 +1,170 @@
+/*
+ * (C) Copyright 2012, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.jaggr.core.util;
+
+import com.ibm.jaggr.core.IAggregator;
+import com.ibm.jaggr.core.impl.config.ConfigImpl;
+import com.ibm.jaggr.core.impl.config.ConfigTest.AggregatorProxy;
+import com.ibm.jaggr.core.test.TestUtils;
+
+import com.google.common.io.Files;
+import com.google.javascript.jscomp.CheckLevel;
+import com.google.javascript.jscomp.CompilerOptions;
+
+import org.easymock.EasyMock;
+import org.easymock.IAnswer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.util.Set;
+
+public class CompilerUtilTest {
+
+	File tmpFile = null;
+	URI tmpDir = null;
+	IAggregator mockAggregator;
+
+	@Before
+	public void setup() throws Exception {
+		tmpFile = Files.createTempDir();
+		tmpDir = tmpFile.toURI();
+		IAggregator easyMockAggregator = TestUtils.createMockAggregator(null, null, null, AggregatorProxy.class, null);
+		EasyMock.replay(easyMockAggregator);
+		mockAggregator = new AggregatorProxy(easyMockAggregator);
+	}
+	@After
+	public void tearDown() throws Exception {
+		if (tmpFile != null) {
+			TestUtils.deleteRecursively(tmpFile);
+			tmpFile = null;
+		}
+	}
+	@Test
+	public void testAddCompilerOptionsFromConfig() throws Exception {
+		// Test simple boolean setter
+		String config = "{compilerOptions:{acceptConstKeyword:true}}";
+		ConfigImpl cfg = new ConfigImpl(mockAggregator, tmpDir, config);
+		CompilerOptions mockOptions = EasyMock.createMock(CompilerOptions.class);
+		mockOptions.setAcceptConstKeyword(true);
+		EasyMock.expectLastCall().once();
+		EasyMock.replay(mockOptions);
+		int numFailed = CompilerUtil.addCompilerOptionsFromConfig(mockOptions, cfg);
+		EasyMock.verify(mockOptions);
+		Assert.assertEquals(0,  numFailed);
+
+		// Test setter with multiple paramaters
+		config = "{compilerOptions:{defineToBooleanLiteral:['defineName', true]}}";
+		cfg = new ConfigImpl(mockAggregator, tmpDir, config);
+		mockOptions = EasyMock.createMock(CompilerOptions.class);
+		mockOptions.setDefineToBooleanLiteral("defineName", true);
+		EasyMock.expectLastCall().once();
+		EasyMock.replay(mockOptions);
+		numFailed = CompilerUtil.addCompilerOptionsFromConfig(mockOptions, cfg);
+		EasyMock.verify(mockOptions);
+		Assert.assertEquals(0,  numFailed);
+
+		// Test with enum value as parameter
+		config = "{compilerOptions:{checkGlobalThisLevel:'WARNING'}}";
+		cfg = new ConfigImpl(mockAggregator, tmpDir, config);
+		mockOptions = EasyMock.createMock(CompilerOptions.class);
+		mockOptions.setCheckGlobalThisLevel(CheckLevel.WARNING);
+		EasyMock.expectLastCall().once();
+		EasyMock.replay(mockOptions);
+		numFailed = CompilerUtil.addCompilerOptionsFromConfig(mockOptions, cfg);
+		EasyMock.verify(mockOptions);
+		Assert.assertEquals(0,  numFailed);
+
+
+		// Test with list property (needs to be passed as nested array and gets converted from NativeArray to a Set)
+		config = "{compilerOptions:{aliasableStrings:[['foo', 'bar']]}}";
+		cfg = new ConfigImpl(mockAggregator, tmpDir, config);
+		mockOptions = EasyMock.createMock(CompilerOptions.class);
+		mockOptions.setAliasableStrings(EasyMock.isA(Set.class));
+		EasyMock.expectLastCall().andAnswer(new IAnswer<Object>() {
+			@Override
+			public Object answer() throws Throwable {
+				Set<String> strings = (Set<String>)EasyMock.getCurrentArguments()[0];
+				Assert.assertTrue(strings.contains("foo"));
+				Assert.assertTrue(strings.contains("bar"));
+				return null;
+			}
+		}).once();
+		EasyMock.replay(mockOptions);
+		numFailed = CompilerUtil.addCompilerOptionsFromConfig(mockOptions, cfg);
+		EasyMock.verify(mockOptions);
+		Assert.assertEquals(0,  numFailed);
+
+		// Test setting multiple properties
+		config = "{compilerOptions:{aliasableGlobals:'foo,bar', aliasExternals:true}}";
+		cfg = new ConfigImpl(mockAggregator, tmpDir, config);
+		mockOptions = EasyMock.createMock(CompilerOptions.class);
+		mockOptions.setAliasableGlobals("foo,bar");
+		EasyMock.expectLastCall().once();
+		mockOptions.setAliasExternals(true);
+		EasyMock.expectLastCall().once();
+		EasyMock.replay(mockOptions);
+		numFailed = CompilerUtil.addCompilerOptionsFromConfig(mockOptions, cfg);
+		EasyMock.verify(mockOptions);
+		Assert.assertEquals(0,  numFailed);
+
+		// Test setting non-existant property
+		config = "{compilerOptions:{noExist:true}}";
+		cfg = new ConfigImpl(mockAggregator, tmpDir, config);
+		mockOptions = EasyMock.createMock(CompilerOptions.class);
+		EasyMock.replay(mockOptions);
+		numFailed = CompilerUtil.addCompilerOptionsFromConfig(mockOptions, cfg);
+		EasyMock.verify(mockOptions);
+		Assert.assertEquals(1,  numFailed);
+
+		// Test setting an existing property with wrong parameter type
+		config = "{compilerOptions:{acceptConstKeyword:'foo'}}";
+		cfg = new ConfigImpl(mockAggregator, tmpDir, config);
+		mockOptions = EasyMock.createMock(CompilerOptions.class);
+		EasyMock.replay(mockOptions);
+		numFailed = CompilerUtil.addCompilerOptionsFromConfig(mockOptions, cfg);
+		EasyMock.verify(mockOptions);
+		Assert.assertEquals(1,  numFailed);
+
+		// Test with one failed and one successful property
+		config = "{compilerOptions:{noExist:true,checkGlobalThisLevel:'WARNING'}}";
+		cfg = new ConfigImpl(mockAggregator, tmpDir, config);
+		mockOptions = EasyMock.createMock(CompilerOptions.class);
+		mockOptions.setCheckGlobalThisLevel(CheckLevel.WARNING);
+		EasyMock.expectLastCall().once();
+		EasyMock.replay(mockOptions);
+		numFailed = CompilerUtil.addCompilerOptionsFromConfig(mockOptions, cfg);
+		EasyMock.verify(mockOptions);
+		Assert.assertEquals(1,  numFailed);
+
+		// Throw exception from setter
+		config = "{compilerOptions:{checkGlobalThisLevel:'WARNING'}}";
+		cfg = new ConfigImpl(mockAggregator, tmpDir, config);
+		mockOptions = EasyMock.createMock(CompilerOptions.class);
+		mockOptions.setCheckGlobalThisLevel(CheckLevel.WARNING);
+		EasyMock.expectLastCall().andThrow(new RuntimeException());
+		EasyMock.replay(mockOptions);
+		numFailed = CompilerUtil.addCompilerOptionsFromConfig(mockOptions, cfg);
+		EasyMock.verify(mockOptions);
+		Assert.assertEquals(1,  numFailed);
+
+
+	}
+}


### PR DESCRIPTION
This pull request adds support for setting Closure Compiler options in the Server-Side AMD config.  The options are specified by the <code>compilerOptions</code> config property. 
<p>Compiler config options are specified using [CompilerOptions](http://javadoc.closure-compiler.googlecode.com/git/com/google/javascript/jscomp/CompilerOptions.html) defined property name/value pairs. The names can be any property which is either declared as a public field or has a setter method which can be mapped to the property name using standard JavaBean property naming convention. The value is an array who's number and types of elements matches the number and types of the formal parameters defined by the setter method. If the setter method takes exactly one parameter, or the property is a public field which has no setter method, then the array notation may be dispensed with and the single parameter may be specified directly as in the following examples:
<p>
<pre>
compilerOptions: {
   defineToBooleanLiteral:['defineName', true]  // calls setDefineToBooleanLiteral("defineName", true);
}
compilerOptions: {
   acceptConstKeyword:true           // this is identical to acceptConstKeyword:[true].  Both
                                     // will invoke setAcceptConstKeyword(true);
}
compilerOptions: {
   aliasableStrings:[['foo', 'bar']] // setAliasableStrings takes a java.util.Set, so need to use a
                                     // nested array so that the string set will be passed as a single
                                     // parameter.
}
</pre>
<p>
The following JavaScript to Java property value conversions will be performed when attempting to match the provided values to the value types declared by the class:
<ul>
<li>Values specified as a JavaScript arrays will be converted to either a java.util.List or a java.util.Set as determined by the declared type of the receiving parameter.</li>
<li>If the declared type of the receiving parameter is an Enum and the provided value is a string which matches one of the Enum named constants, then the matching constant value will be used</li>
</ul>
<p>
<pre>
compilerOptions: {
   checkGlobalThisLevel:'WARNING'    // This invokes setCheckGlobalThisLevel(CheckLevel.WARNING);
}
</pre>
