### PR TITLE
Improve handling of concurrent load requests with server expanded layers

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerBuilder.java
@@ -55,6 +55,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -196,7 +197,11 @@ public class LayerBuilder {
 
 			// Now add the loader requested modules
 			if (sorted.getModules().size() > 0) {
-				addTransportContribution(LayerContributionType.BEGIN_MODULES, null);
+				Set<String> mids = new LinkedHashSet<String>();
+				for (IModule module : sorted.getModules().keySet()) {
+					mids.add(module.getModuleId());
+				}
+				addTransportContribution(LayerContributionType.BEGIN_MODULES, mids);
 				int i = 0;
 				for (Map.Entry<IModule, ModuleBuildReader> entry : sorted.getModules().entrySet()) {
 					writer.append(notifyLayerListeners(EventType.BEGIN_MODULE, request, entry.getKey()));
@@ -206,7 +211,7 @@ public class LayerBuilder {
 					processReader(entry.getKey(), entry.getValue());
 					addTransportContribution(LayerContributionType.AFTER_MODULE, info);
 				}
-				addTransportContribution(LayerContributionType.END_MODULES, null);
+				addTransportContribution(LayerContributionType.END_MODULES, mids);
 			}
 		}
  		writer.append(notifyLayerListeners(EventType.END_LAYER, request, null));

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/DojoHttpTransport.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/transport/DojoHttpTransport.java
@@ -345,12 +345,12 @@ public class DojoHttpTransport extends AbstractHttpTransport implements IHttpTra
 				request.getParameter(REQUESTEDMODULESCOUNT_REQPARAM) != null) {  // it's a loader generated request
 			@SuppressWarnings("unchecked")
 			Set<String> modules = (Set<String>)arg;
-			sb.append("require.combo.beginDefs && require.combo.beginDefs(["); //$NON-NLS-1$
+			sb.append("require.combo.moduleDefines(["); //$NON-NLS-1$
 			int i = 0;
 			for (String module : modules) {
 				sb.append(i++ > 0 ? "," : "").append("'").append(module).append("'"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 			}
-			sb.append("]);\r\n"); //$NON-NLS-1$
+			sb.append("], function(){\r\n"); //$NON-NLS-1$
 		}
 		return sb.toString();
 	}
@@ -359,7 +359,7 @@ public class DojoHttpTransport extends AbstractHttpTransport implements IHttpTra
 		String result = ""; //$NON-NLS-1$
 		if (RequestUtil.isServerExpandedLayers(request) &&
 				request.getParameter(REQUESTEDMODULESCOUNT_REQPARAM) != null) { // it's a loader generated request
-			result = "require.combo.endDefs && require.combo.endDefs();\r\n"; //$NON-NLS-1$
+			result = "});\r\n"; //$NON-NLS-1$
 		}
 		return result;
 	}

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/transport/IHttpTransport.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/transport/IHttpTransport.java
@@ -398,6 +398,14 @@ public interface IHttpTransport extends IExtensionInitializer {
 	 *            <li>{@link LayerContributionType#BEGIN_LAYER_MODULES}</li>
 	 *            <li>{@link LayerContributionType#END_LAYER_MODULES}</li>
 	 *            </ul>
+	 *            For the following values of {@code type}, {@code arg} specifies
+	 *            a {@code Set<String>} of modules that were explicitly requested
+	 *            by the loader (i.e. the modules specified in the {@code modules}
+	 *            or {@code moduleIds} request parameter.
+	 *            <ul>
+	 *            <li>{@link LayerContributionType#BEGIN_MODULES}</li>
+	 *            <li>{@link LayerContributionType#END_MODULES}</li>
+	 *            </ul>
 	 *            For all other values of {@code type}, {@code mid} is null.
 	 *
 	 * @return A string value that is to be added to the layer in the location


### PR DESCRIPTION
This pull request resolves a performance issue with server expanded layers.  The issue arises when the responses to overlapping loader requests arrive out of order (i.e. in different order than they were issued).  Because of the cumulative nature of the module exclude list that is maintained by the loader extension JavaScript, out of order responses can have unresolved dependencies (for dependent modules that were excluded by virtue of being dependent modules of previously issued, but still pending, request).  The loader doesn't know that these unsatisfied dependencies will be satisfied when the pending requests complete because it didn't request them by name.  They are dependent modules of the modules that were requested.  As a result of the undefined modules, additional, often cascading, requests are sent to  load the missing dependencies until the responses for the original pending requests arrive.

This pull request resolves that issue by intercepting and then queuing the define() function calls for out-of-order responses until the responses for all previously issued requests have arrived, and then playing back the define() function calls in request order.