### PR TITLE
Don't run formula simplifier when building server-expanded layers

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/deps/ModuleDepInfo.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/deps/ModuleDepInfo.java
@@ -201,6 +201,24 @@ public class ModuleDepInfo implements Serializable {
 	}
 
 	/**
+	 * Returns a Boolean value indicating the value of the formula expression, or null if
+	 * the formula expression contains undefined features.  The formula is NOT simplified
+	 * prior to returning the result for performance reasons, so some expressions that may
+	 * simplify to TRUE can return a null value.
+	 *
+	 * @return the value of the formula or null.
+	 */
+	public Boolean getIncludeStatus() {
+		if (formula.isTrue()) {
+			return Boolean.TRUE;
+		} else if (formula.isFalse()) {
+			return Boolean.FALSE;
+		}
+		return null;
+	}
+
+
+	/**
 	 * Returns true if the specified term is logically included by the formula
 	 * for this object.
 	 * <p>

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerImpl.java
@@ -57,7 +57,6 @@ import java.io.ObjectInputStream;
 import java.io.StringReader;
 import java.net.URI;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -947,9 +946,9 @@ public class LayerImpl implements ILayer {
 								name = name.substring(idx+1);
 							}
 						}
-						Collection<String> prefixes = info.getHasPluginPrefixes();
-						if (prefixes == null ||		// condition is TRUE
-								RequestUtil.isIncludeUndefinedFeatureDeps(request) && !prefixes.isEmpty()) {
+						Boolean includeStatus = info.getIncludeStatus();
+						if (includeStatus == Boolean.TRUE ||		// condition is TRUE
+								RequestUtil.isIncludeUndefinedFeatureDeps(request) && includeStatus == null) {
 							IModule module = newModule(request, name);
 							if (!explicit.containsKey(name) && aggr.getResourceFactory(new MutableObject<URI>(module.getURI())) == null) {
 								// Module is server-expanded and it's not a server resource type that we


### PR DESCRIPTION
The boolean formula simplifier is needed when doing require list expansion, but not when doing server-side expansion of dependencies, but it was still getting invoked when the layer builder called ModuleDepInfo.getPluginPrefixes() for the purpose of determining whether to include a module in a server-expanded layer.  Because of the poor performance characteristics of the Quinne-Mcluskey algorithm used by the boolean formula simplifier when there are a large number of expressions, it is desirable to avoid the boolean formula simplifier when doing server-side expansion. 