### PR TITLE
Use combo.cacheBust before window or script args when building req url

### DIFF
--- a/jaggr-core/WebContent/dojo/_loaderExt.js
+++ b/jaggr-core/WebContent/dojo/_loaderExt.js
@@ -94,9 +94,9 @@ userConfig.has['dojo-combo-api'] = 1;
  * url processor for handling cache bust query arg
  */
 urlProcessors.push(function(url) {
-	cb = windowArgs.cachebust ||
+	cb = combo.cacheBust || windowArgs.cachebust ||
 	     scriptArgs.cachebust || scriptArgs.cb ||
-	     combo.cacheBust || dojo.config.cacheBust;
+	     dojo.config.cacheBust;
 	if (cb) {
 		url += ('&cb=' + cb);
 	}


### PR DESCRIPTION
Allows the cacheBust value in the request URL to be changed under application control for testing purposes.