### PR TITLE
Fix unit test performance issue caused by excessive thread creation

### DIFF
--- a/jaggr-core/pom.xml
+++ b/jaggr-core/pom.xml
@@ -459,15 +459,5 @@
       <artifactId>powermock-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-easymock</artifactId>
-      <scope>test</scope>
-    </dependency>
-     <dependency>
-       <groupId>org.powermock</groupId>
-       <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-     </dependency>
   </dependencies>
 </project>

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/CompletedFuture.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/CompletedFuture.java
@@ -29,9 +29,16 @@ import java.util.concurrent.TimeoutException;
 public class CompletedFuture<T> implements Future<T> {
 
 	private final T _t;
+	private final ExecutionException _error;
 
 	public CompletedFuture(T t) {
 		_t = t;
+		_error = null;
+	}
+
+	public CompletedFuture(ExecutionException error) {
+		_t = null;
+		_error = error;
 	}
 
 	/* (non-Javadoc)
@@ -47,6 +54,9 @@ public class CompletedFuture<T> implements Future<T> {
 	 */
 	@Override
 	public T get() throws InterruptedException, ExecutionException {
+		if (_error != null) {
+			throw _error;
+		}
 		return _t;
 	}
 
@@ -56,6 +66,9 @@ public class CompletedFuture<T> implements Future<T> {
 	@Override
 	public T get(long timeout, TimeUnit unit) throws InterruptedException,
 	ExecutionException, TimeoutException {
+		if (_error != null) {
+			throw _error;
+		}
 		return _t;
 	}
 

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerImpl.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/layer/LayerImpl.java
@@ -835,7 +835,7 @@ public class LayerImpl implements ILayer {
 						}
 					}
 					if (RequestUtil.isServerExpandedLayers(request)) {
-						moduleList = new DependencyList(
+						moduleList = newDependencyList(
 								DEPSOURCE_MODULEDEPS,
 								requestedModuleNames.getModules(),
 								aggr,
@@ -877,7 +877,7 @@ public class LayerImpl implements ILayer {
 
 					// If there's a required module, then add it and its dependencies
 					// to the module list.
-					requiredList = new DependencyList(
+					requiredList = newDependencyList(
 							DEPSOURCE_REQDEPS,
 							requestedModuleNames.getDeps(),
 							aggr,
@@ -895,7 +895,7 @@ public class LayerImpl implements ILayer {
 					combined.addAll(requiredList.getExpandedDeps());
 				}
 				if (!requestedModuleNames.getPreloads().isEmpty()) {
-					preloadList = new DependencyList(
+					preloadList = newDependencyList(
 							DEPSOURCE_REQPRELOADS,
 							requestedModuleNames.getPreloads(),
 							aggr,
@@ -911,7 +911,7 @@ public class LayerImpl implements ILayer {
 					combined.addAll(preloadList.getExpandedDeps());
 				}
 				if (!requestedModuleNames.getExcludes().isEmpty()) {
-					excludeList = new DependencyList(
+					excludeList = newDependencyList(
 							DEPSOURCE_EXCLUDES,
 							requestedModuleNames.getExcludes(),
 							aggr,
@@ -1054,6 +1054,19 @@ public class LayerImpl implements ILayer {
 		return result;
 
 	}
+
+	protected DependencyList newDependencyList(
+		String source,
+		Iterable<String> names,
+		IAggregator aggr,
+		Features features,
+		boolean resolveAliases,
+		boolean includeDetails,
+		boolean includeRequireDeps
+	) {
+		return new DependencyList(source, names, aggr, features, resolveAliases, includeDetails, includeRequireDeps);
+	}
+
 
 	/**
 	 * Called by the layer cache manager when a layer build is evicted from the

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilder.java
@@ -208,7 +208,7 @@ public class JavaScriptModuleBuilder implements IModuleBuilder, IExtensionInitia
 				}
 				IAggregator aggr = (IAggregator)request.getAttribute(IAggregator.AGGREGATOR_REQATTRNAME);
 				Features features = (Features)request.getAttribute(IHttpTransport.FEATUREMAP_REQATTRNAME);
-				DependencyList excludeList = new DependencyList(
+				DependencyList excludeList = newDependencyList(
 						DEPSOURCE_REQEXPEXCLUDES,
 						excludeIds,
 						aggr,
@@ -216,7 +216,7 @@ public class JavaScriptModuleBuilder implements IModuleBuilder, IExtensionInitia
 						true,	// resolveAliases
 						isReqExpLogging);
 
-				DependencyList layerDepList = new DependencyList(
+				DependencyList layerDepList = newDependencyList(
 						DEPSOURCE_LAYER,
 						moduleIds,
 						aggr,
@@ -516,7 +516,7 @@ public class JavaScriptModuleBuilder implements IModuleBuilder, IExtensionInitia
 			}
 		}
 		Object build = expandedDepsList == null || expandedDepsList.size() == 0 ?
-				output : new JavaScriptBuildRenderer(mid, output, expandedDepsList, isReqExpLogging);
+				output : newJavaScriptBuildRenderer(mid, output, expandedDepsList, isReqExpLogging);
 
 		if (isSourceMaps && sourceMap != null && !(build instanceof IModuleBuilder)) {
 			// If we need to include a source map in the build output, then return an
@@ -774,6 +774,13 @@ public class JavaScriptModuleBuilder implements IModuleBuilder, IExtensionInitia
 		return sb.toString();
 	}
 
+	protected DependencyList newDependencyList(String source, Iterable<String> names, IAggregator aggr, Features features,  boolean resolveAliases, boolean includeDetails) {
+		return new DependencyList(source, names, aggr, features, resolveAliases, includeDetails);
+	}
+
+	protected JavaScriptBuildRenderer newJavaScriptBuildRenderer(String mid, String content, List<ModuleDeps> depsList, boolean isReqExpLogging) {
+		return new JavaScriptBuildRenderer(mid, content, depsList, isReqExpLogging);
+	}
 
 	/* (non-Javadoc)
 	 * @see com.ibm.jaggr.core.modulebuilder.IModuleBuilder#isScript(javax.servlet.http.HttpServletRequest)

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/less/LessModuleBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/less/LessModuleBuilder.java
@@ -51,6 +51,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
@@ -104,8 +105,8 @@ public class LessModuleBuilder extends CSSModuleBuilder implements IExtensionSin
 	}
 
 	// for unit tests
-	protected LessModuleBuilder(IAggregator aggregator) {
-		super(aggregator);
+	protected LessModuleBuilder(IAggregator aggregator, ExecutorService es, int scopePoolSize) {
+		super(aggregator, es, scopePoolSize);
 		init();
 	}
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/deps/ModuleDepInfoTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/deps/ModuleDepInfoTest.java
@@ -16,11 +16,11 @@
 
 package com.ibm.jaggr.core.deps;
 
-import com.ibm.jaggr.core.deps.ModuleDepInfo;
 import com.ibm.jaggr.core.util.BooleanTerm;
 
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -28,8 +28,6 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-
-import junit.framework.Assert;
 
 
 public class ModuleDepInfoTest {

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/deps/ModuleDepsTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/deps/ModuleDepsTest.java
@@ -16,20 +16,17 @@
 
 package com.ibm.jaggr.core.deps;
 
-import com.ibm.jaggr.core.deps.ModuleDepInfo;
-import com.ibm.jaggr.core.deps.ModuleDeps;
 import com.ibm.jaggr.core.util.BooleanTerm;
 
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
-
-import junit.framework.Assert;
 
 public class ModuleDepsTest {
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/ForcedErrorResponseTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/ForcedErrorResponseTest.java
@@ -15,12 +15,11 @@
  */
 package com.ibm.jaggr.core.impl;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-
-import junit.framework.Assert;
 
 public class ForcedErrorResponseTest {
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/cache/CacheManagerImplTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/cache/CacheManagerImplTest.java
@@ -24,6 +24,7 @@ import com.ibm.jaggr.core.test.TestUtils;
 import com.google.common.io.Files;
 
 import org.easymock.EasyMock;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,8 +36,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.regex.Pattern;
-
-import junit.framework.Assert;
 
 public class CacheManagerImplTest {
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/cache/GzipCacheImplTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/cache/GzipCacheImplTest.java
@@ -255,7 +255,7 @@ public class GzipCacheImplTest {
 		cacheEntry = impl.get("key");
 		// validate the data
 		Assert.assertEquals(newTestData2, unzipInputStream(is, retLength.getValue()));
-		Assert.assertEquals(tempfile.lastModified(), Whitebox.getInternalState(cacheEntry, "lastModified"));
+		Assert.assertEquals(tempfile.lastModified(), ((Long)Whitebox.getInternalState(cacheEntry, "lastModified")).longValue());
 
 		// now write the cache file to disk
 		// now release the cache file writer thread and wait for it to complete

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/cache/ResourceConverterCacheImplTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/cache/ResourceConverterCacheImplTest.java
@@ -15,11 +15,11 @@
  */
 package com.ibm.jaggr.core.impl.cache;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertSame;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/deps/BooleanFormulaTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/deps/BooleanFormulaTest.java
@@ -22,11 +22,10 @@ import com.ibm.jaggr.core.util.Features;
 
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import junit.framework.Assert;
 
 
 public class BooleanFormulaTest {

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/deps/DepTreeTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/deps/DepTreeTest.java
@@ -30,6 +30,7 @@ import com.ibm.jaggr.core.test.TestUtils;
 
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
@@ -41,8 +42,6 @@ import java.util.Properties;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
-
-import junit.framework.Assert;
 
 public class DepTreeTest {
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/deps/HasNodeTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/deps/HasNodeTest.java
@@ -24,16 +24,15 @@ import com.ibm.jaggr.core.util.HasNode;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashSet;
 
-import junit.framework.Assert;
-
 public class HasNodeTest extends EasyMock {
-	Capture<String> containsFeature = new Capture<String>();
-	Capture<String> isFeature = new Capture<String>();
+	Capture<String> containsFeature = EasyMock.newCapture();
+	Capture<String> isFeature = EasyMock.newCapture();
 	Features chooser = createMock(Features.class);
 	HashSet<String> depFeatures;
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/CacheEntryTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/CacheEntryTest.java
@@ -28,6 +28,7 @@ import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -40,8 +41,6 @@ import java.io.InputStream;
 import java.io.ObjectOutputStream;
 
 import javax.servlet.http.HttpServletRequest;
-
-import junit.framework.Assert;
 
 public class CacheEntryTest {
 
@@ -105,7 +104,7 @@ public class CacheEntryTest {
 		in = entry.getInputStream(mockRequest, null);
 		Assert.assertEquals(TEST_LAYER_CONTENT.getBytes().length, entry.getSize());
 		Assert.assertEquals(TEST_LAYER_CONTENT, IOUtils.toString(in));
-		Assert.assertEquals(0,  Whitebox.getInternalState(entry, "sourceMapSize"));
+		Assert.assertEquals(0,  ((Integer)Whitebox.getInternalState(entry, "sourceMapSize")).intValue());
 
 		// with a source map reference
 		MutableObject<byte[]> sourceMap = new MutableObject<byte[]>();
@@ -119,7 +118,7 @@ public class CacheEntryTest {
 		Assert.assertEquals(TEST_LAYER_CONTENT, IOUtils.toString(in));
 		Assert.assertEquals(TEST_SOURCEMAP_CONTENT, new String(sourceMap.getValue()));
 		Assert.assertEquals(TEST_LAYER_CONTENT.getBytes().length, entry.getSize());
-		Assert.assertEquals(TEST_SOURCEMAP_CONTENT.getBytes().length,  Whitebox.getInternalState(entry, "sourceMapSize"));
+		Assert.assertEquals(TEST_SOURCEMAP_CONTENT.getBytes().length,  ((Integer)Whitebox.getInternalState(entry, "sourceMapSize")).intValue());
 	}
 
 	@Test

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerBuilderTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerBuilderTest.java
@@ -61,6 +61,7 @@ import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -84,9 +85,6 @@ import java.util.concurrent.Future;
 import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
-
-import junit.framework.Assert;
-import junit.framework.AssertionFailedError;
 
 public class LayerBuilderTest {
 	public static final Pattern moduleNamePat = Pattern.compile("^module[0-9]$");
@@ -114,7 +112,7 @@ public class LayerBuilderTest {
 				(LayerContributionType)EasyMock.anyObject(LayerContributionType.class),
 				EasyMock.anyObject()
 				)).andAnswer(new IAnswer<String>() {
-					@SuppressWarnings("unused")
+					@SuppressWarnings({ "unused", "unchecked" })
 					public String answer() throws Throwable {
 						HttpServletRequest request = (HttpServletRequest)EasyMock.getCurrentArguments()[0];
 						LayerContributionType type = (LayerContributionType)EasyMock.getCurrentArguments()[1];
@@ -711,7 +709,7 @@ public class LayerBuilderTest {
 		try {
 			result = builder.notifyLayerListeners(EventType.BEGIN_MODULE, mockRequest, module1);
 			Assert.fail();
-		} catch (AssertionFailedError e) {
+		} catch (AssertionError e) {
 		}
 		// verifies that bundleContext.getService()/ungetService()
 		// are matched even though exception was thrown by listener

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerCacheTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerCacheTest.java
@@ -40,6 +40,7 @@ import com.googlecode.concurrentlinkedhashmap.Weighers;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -60,8 +61,6 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import junit.framework.Assert;
 
 public class LayerCacheTest {
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/LayerTest.java
@@ -32,7 +32,6 @@ import com.ibm.jaggr.core.config.IConfigScopeModifier;
 import com.ibm.jaggr.core.deps.IDependencies;
 import com.ibm.jaggr.core.impl.AggregatorLayerListener;
 import com.ibm.jaggr.core.impl.config.ConfigImpl;
-import com.ibm.jaggr.core.impl.module.NotFoundModule;
 import com.ibm.jaggr.core.impl.transport.AbstractHttpTransport;
 import com.ibm.jaggr.core.layer.ILayer;
 import com.ibm.jaggr.core.layer.ILayerListener;
@@ -59,12 +58,10 @@ import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -73,7 +70,6 @@ import java.io.FileFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
-import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URI;
@@ -92,10 +88,6 @@ import java.util.zip.Deflater;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import junit.framework.Assert;
-
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(LayerImpl.class)
 public class LayerTest extends EasyMock {
 
 	static int id = 0;

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/SortedReadersTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/layer/SortedReadersTest.java
@@ -25,6 +25,7 @@ import com.ibm.jaggr.core.transport.IHttpTransport;
 
 import org.easymock.EasyMock;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.URI;
@@ -34,8 +35,6 @@ import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
-
-import junit.framework.Assert;
 
 public class SortedReadersTest {
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/i18n/I18nModuleBuilderTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/i18n/I18nModuleBuilderTest.java
@@ -35,6 +35,7 @@ import org.apache.wink.json4j.JSONObject;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -51,8 +52,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import javax.servlet.http.HttpServletRequest;
-
-import junit.framework.Assert;
 
 public class I18nModuleBuilderTest extends EasyMock {
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/ExportModuleNameCompilerPassTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/ExportModuleNameCompilerPassTest.java
@@ -23,9 +23,8 @@ import com.google.javascript.jscomp.Compiler.CodeBuilder;
 import com.google.javascript.jscomp.JSSourceFile;
 import com.google.javascript.rhino.Node;
 
+import org.junit.Assert;
 import org.junit.Test;
-
-import junit.framework.Assert;
 
 public class ExportModuleNameCompilerPassTest {
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/IdentitySourceMapGeneratorTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/IdentitySourceMapGeneratorTest.java
@@ -17,27 +17,18 @@
 package com.ibm.jaggr.core.impl.modulebuilder.javascript;
 
 import com.ibm.jaggr.core.util.CompilerUtil;
-import com.ibm.jaggr.core.util.JSSource;
 
 import com.google.debugging.sourcemap.SourceMapConsumerV3;
 import com.google.debugging.sourcemap.proto.Mapping.OriginalMapping;
-import com.google.javascript.jscomp.Compiler;
 import com.google.javascript.jscomp.CompilerOptions;
-import com.google.javascript.jscomp.JSSourceFile;
 
+import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-
-import junit.framework.Assert;
 
 public class IdentitySourceMapGeneratorTest {
-	private static final List<JSSourceFile> externs = Collections.emptyList();
-
 	static final String source =
 			"/**\n" +
 			" * Comment\n" +

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptBuildRendererTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptBuildRendererTest.java
@@ -22,6 +22,7 @@ import com.ibm.jaggr.core.test.TestUtils;
 import com.ibm.jaggr.core.util.ConcurrentListBuilder;
 
 import org.easymock.EasyMock;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -32,8 +33,6 @@ import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
-
-import junit.framework.Assert;
 
 public class JavaScriptBuildRendererTest {
 	static final String content = "define([],function() {require([\"foo\"].concat(" +

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilderTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/javascript/JavaScriptModuleBuilderTest.java
@@ -60,13 +60,10 @@ import org.apache.wink.json4j.JSONObject;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -99,10 +96,6 @@ import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
 
-import junit.framework.Assert;
-
-@RunWith(PowerMockRunner.class)
-@PrepareForTest( JavaScriptModuleBuilder.class )
 public class JavaScriptModuleBuilderTest extends EasyMock {
 
 	File tmpdir = null;
@@ -559,11 +552,15 @@ public class JavaScriptModuleBuilderTest extends EasyMock {
 		Assert.assertTrue(TypeUtil.asBoolean(mockRequest.getAttribute(IHttpTransport.EXPORTMODULENAMES_REQATTRNAME)));
 	}
 
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testLayerBeginEndNotifier_exportModuleNames() throws Exception {
 		List<IModule> modules = new ArrayList<IModule>();
 		Set<String> dependentFeatures = new HashSet<String>();
-		JavaScriptModuleBuilder builder = new JavaScriptModuleBuilder();
+		JavaScriptModuleBuilder builder = EasyMock.createMockBuilder(TestJavaScriptModuleBuilder.class)
+				.addMockedMethod("newDependencyList", String.class, Iterable.class, IAggregator.class, Features.class, boolean.class, boolean.class)
+				.createMock();
+
 		String result = builder.layerBeginEndNotifier(EventType.BEGIN_LAYER, mockRequest, modules, dependentFeatures);
 		Assert.assertEquals("", result);
 		Assert.assertNull(mockRequest.getAttribute(JavaScriptModuleBuilder.EXPANDED_DEPENDENCIES));
@@ -604,10 +601,9 @@ public class JavaScriptModuleBuilderTest extends EasyMock {
 		expectedDeps.addAll(layerExplicitDeps);
 		expectedDeps.addAll(layerExpandedDeps);
 
-		PowerMock.expectNew(DependencyList.class, isA(String.class), isA(List.class), isA(IAggregator.class), eq(features), anyBoolean(), eq(false))
+		EasyMock.expect(builder.newDependencyList(isA(String.class), isA(List.class), isA(IAggregator.class), eq(features), anyBoolean(), eq(false)))
 		.andAnswer(new IAnswer<DependencyList>() {
 			@Override public DependencyList answer() throws Throwable {
-				@SuppressWarnings("unchecked")
 				List<String> modules = (List<String>)getCurrentArguments()[1];
 				if (Arrays.asList(new String[]{"exclude"}).equals(modules)) {
 					return mockConfigDeps;
@@ -618,7 +614,7 @@ public class JavaScriptModuleBuilderTest extends EasyMock {
 				return null;
 			}
 		}).anyTimes();
-		PowerMock.replay(mockConfigDeps, mockLayerDeps, DependencyList.class);
+		EasyMock.replay(mockConfigDeps, mockLayerDeps, builder);
 
 		modules = Arrays.asList(new IModule[]{
 				new ModuleImpl("foo", new URI("file://foo.js")),
@@ -648,11 +644,14 @@ public class JavaScriptModuleBuilderTest extends EasyMock {
 	}
 
 	private static final String loggingOutput = "console.log(\"%cEnclosing dependencies for require list expansion (these modules will be omitted from subsequent expanded require lists):\", \"color:blue;background-color:yellow\");console.log(\"%cExpanded dependencies for config deps:\", \"color:blue\");console.log(\"%c	exclude (exclude detail)\\r\\n	excludedep (excludedep detail)\\r\\n\", \"font-size:x-small\");console.log(\"%cExpanded dependencies for layer deps:\", \"color:blue\");console.log(\"%c	foo (foo detail)\\r\\n	bar (bar detail)\\r\\n	foodep (foodep detail)\\r\\n	bardep (bardep detail)\\r\\n\", \"font-size:x-small\");";
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testLayerBeginEndNotifier_exportModuleNamesWithDetails() throws Exception {
 		List<IModule> modules = new ArrayList<IModule>();
 		Set<String> dependentFeatures = new HashSet<String>();
-		JavaScriptModuleBuilder builder = new JavaScriptModuleBuilder();
+		JavaScriptModuleBuilder builder = EasyMock.createMockBuilder(TestJavaScriptModuleBuilder.class)
+				.addMockedMethod("newDependencyList", String.class, Iterable.class, IAggregator.class, Features.class, boolean.class, boolean.class)
+				.createMock();
 		String result = builder.layerBeginEndNotifier(EventType.BEGIN_LAYER, mockRequest, modules, dependentFeatures);
 		Assert.assertEquals("", result);
 		Assert.assertNull(mockRequest.getAttribute(JavaScriptModuleBuilder.EXPANDED_DEPENDENCIES));
@@ -694,10 +693,9 @@ public class JavaScriptModuleBuilderTest extends EasyMock {
 		expectedDeps.addAll(layerExplicitDeps);
 		expectedDeps.addAll(layerExpandedDeps);
 
-		PowerMock.expectNew(DependencyList.class, isA(String.class), isA(List.class), isA(IAggregator.class), eq(features), anyBoolean(), anyBoolean())
+		EasyMock.expect(builder.newDependencyList(isA(String.class), isA(List.class), isA(IAggregator.class), eq(features), anyBoolean(), anyBoolean()))
 		.andAnswer(new IAnswer<DependencyList>() {
 			@Override public DependencyList answer() throws Throwable {
-				@SuppressWarnings("unchecked")
 				List<String> modules = (List<String>)getCurrentArguments()[1];
 				if (Arrays.asList(new String[]{"exclude"}).equals(modules)) {
 					return mockConfigDeps;
@@ -708,7 +706,7 @@ public class JavaScriptModuleBuilderTest extends EasyMock {
 				return null;
 			}
 		}).anyTimes();
-		PowerMock.replay(mockConfigDeps, mockLayerDeps, DependencyList.class);
+		EasyMock.replay(mockConfigDeps, mockLayerDeps, builder);
 
 		modules = Arrays.asList(new IModule[]{
 				new ModuleImpl("foo", new URI("file://foo.js")),

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/text/TxtModuleContentProviderTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/modulebuilder/text/TxtModuleContentProviderTest.java
@@ -28,6 +28,7 @@ import com.google.common.io.Files;
 
 import org.easymock.EasyMock;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -38,8 +39,6 @@ import java.io.Writer;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
-
-import junit.framework.Assert;
 
 public class TxtModuleContentProviderTest extends EasyMock {
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/resource/FileResourceFactoryTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/resource/FileResourceFactoryTest.java
@@ -19,14 +19,13 @@ import com.google.common.collect.ImmutableList;
 
 import org.easymock.EasyMock;
 import org.easymock.IMocksControl;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.lang.reflect.Constructor;
 import java.net.URI;
 import java.util.List;
-
-import junit.framework.Assert;
 
 public class FileResourceFactoryTest {
 	private IMocksControl control;

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/resource/FileResourceTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/resource/FileResourceTest.java
@@ -20,12 +20,11 @@ import com.ibm.jaggr.core.resource.IResource;
 
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
 import java.net.URI;
-
-import junit.framework.Assert;
 
 public class FileResourceTest {
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/resource/JsxResourceConverterTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/resource/JsxResourceConverterTest.java
@@ -31,6 +31,7 @@ import com.ibm.jaggr.core.resource.IResource;
 import com.ibm.jaggr.core.resource.IResourceVisitor;
 import com.ibm.jaggr.core.resource.IResourceVisitor.Resource;
 import com.ibm.jaggr.core.resource.StringResource;
+import com.ibm.jaggr.core.test.SynchronousExecutor;
 import com.ibm.jaggr.core.test.TestUtils;
 
 import com.google.common.io.Files;
@@ -41,6 +42,7 @@ import org.apache.commons.lang3.mutable.MutableObject;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.lesscss.deps.org.apache.commons.io.FileUtils;
@@ -59,8 +61,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.List;
-
-import junit.framework.Assert;
 
 public class JsxResourceConverterTest {
 
@@ -110,7 +110,7 @@ public class JsxResourceConverterTest {
 					}
 				});
 		EasyMock.replay(mockAggregator, mockPlatformServices);
-		JsxResourceConverter converter = new JsxResourceConverter() {
+		JsxResourceConverter converter = new JsxResourceConverter(new SynchronousExecutor(), 1) {
 			@Override protected IResourceConverterCache newCache(IConverter converter, String prefix, String suffix) {
 				Assert.assertTrue(converter instanceof JsxResourceConverter.JsxConverter);
 				Assert.assertTrue("jsx.".equals(prefix));
@@ -287,8 +287,8 @@ public class JsxResourceConverterTest {
 		URI converterUri = JsxResourceConverterTest.class.getClassLoader().getResource("JSXTransformer.js").toURI();
 		File tmpdir = Files.createTempDir();
 		File cacheFile = new File(tmpdir, "test.js");
-		JsxResourceConverter.JsxConverter jsxConverter = new JsxResourceConverter.JsxConverter(converterUri);
-		jsxConverter.initialize(converterUri);
+		JsxResourceConverter.JsxConverter jsxConverter = new JsxResourceConverter.JsxConverter(1, null);
+		jsxConverter.initialize(new SynchronousExecutor(), converterUri);
 		IResource res = new StringResource(jsxSource, new URI("test.jsx"));
 		jsxConverter.generateCacheContent(res, cacheFile);
 		Assert.assertEquals(transpiledJs, FileUtils.readFileToString(cacheFile));
@@ -300,7 +300,7 @@ public class JsxResourceConverterTest {
 		os.close();
 		ObjectInputStream is = new ObjectInputStream(new FileInputStream(file));
 		jsxConverter = (JsxResourceConverter.JsxConverter)is.readObject();
-		jsxConverter.initialize(converterUri);
+		jsxConverter.initialize(new SynchronousExecutor(), converterUri);
 		is.close();
 		jsxConverter.generateCacheContent(res, cacheFile);
 		Assert.assertEquals(transpiledJs, FileUtils.readFileToString(cacheFile));

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/transport/AbstractDojoHttpTransportTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/impl/transport/AbstractDojoHttpTransportTest.java
@@ -31,6 +31,7 @@ import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -47,8 +48,6 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
-
-import junit.framework.Assert;
 
 public class AbstractDojoHttpTransportTest {
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/test/SynchronousExecutor.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/test/SynchronousExecutor.java
@@ -16,19 +16,113 @@
 
 package com.ibm.jaggr.core.test;
 
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import com.ibm.jaggr.core.impl.layer.CompletedFuture;
 
-public class SynchronousExecutor extends ThreadPoolExecutor {
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class SynchronousExecutor implements ExecutorService {
+
+	private boolean isShutdown = false;
 
 	public SynchronousExecutor() {
-		super(0, 1, 0, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>());
 	}
 
 	@Override
 	public void execute(Runnable command) {
 		command.run();
+	}
+
+	@Override
+	public void shutdown() {
+		isShutdown = true;
+	}
+
+	@Override
+	public List<Runnable> shutdownNow() {
+		isShutdown = true;
+		return Collections.emptyList();
+	}
+
+	@Override
+	public boolean isShutdown() {
+		return isShutdown;
+	}
+
+	@Override
+	public boolean isTerminated() {
+		return isShutdown;
+	}
+
+	@Override
+	public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+		return true;
+	}
+
+	@Override
+	public <T> Future<T> submit(Callable<T> task) {
+		try {
+			T result = task.call();
+			return new CompletedFuture<T>(result);
+		} catch (Throwable t) {
+			return new CompletedFuture<T>(new ExecutionException(t));
+		}
+	}
+
+	@Override
+	public <T> Future<T> submit(Runnable task, T result) {
+		try {
+			task.run();
+			return new CompletedFuture<T>(result);
+		} catch (Throwable t) {
+			return new CompletedFuture<T>(new ExecutionException(t));
+		}
+	}
+
+	@Override
+	public Future<?> submit(Runnable task) {
+		try {
+			task.run();
+			return new CompletedFuture<Object>(null);
+		} catch (Throwable t) {
+			return new CompletedFuture<Object>(new ExecutionException(t));
+		}
+	}
+
+	@Override
+	public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+			throws InterruptedException {
+		List<Future<T>> results = new ArrayList<Future<T>>();
+		for (Callable<T> task : tasks) {
+			results.add(submit(task));
+		}
+		return results;
+	}
+
+	@Override
+	public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout,
+			TimeUnit unit) throws InterruptedException {
+		return invokeAll(tasks);
+	}
+
+	@Override
+	public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+			throws InterruptedException, ExecutionException {
+		throw new UnsupportedOperationException("Not supported");
+	}
+
+	@Override
+	public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+			throws InterruptedException, ExecutionException, TimeoutException {
+		throw new UnsupportedOperationException("Not supported");
 	}
 
 }

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/test/SynchronousScheduledExecutor.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/test/SynchronousScheduledExecutor.java
@@ -16,15 +16,23 @@
 
 package com.ibm.jaggr.core.test;
 
+import com.ibm.jaggr.core.impl.layer.CompletedFuture;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
-import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
+import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.RunnableScheduledFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Subclasses ScheduledThreadPoolExecutor and provides for synchronous execution
@@ -36,55 +44,199 @@ public class SynchronousScheduledExecutor extends ScheduledThreadPoolExecutor {
 	public SynchronousScheduledExecutor() {
 		super(0);
 	}
-	public Future<?> submit(Runnable task) {
-		if (task == null) throw new NullPointerException();
-		RunnableFuture<Object> ftask = newTaskFor(task, null);
-		execute(ftask);
-		return ftask;
+
+	@Override
+	protected <V> RunnableScheduledFuture<V> decorateTask(Runnable runnable,
+			RunnableScheduledFuture<V> task) {
+		throw new UnsupportedOperationException("Not implemented");
 	}
 
-	public <T> Future<T> submit(Runnable task, T result) {
-		if (task == null) throw new NullPointerException();
-		RunnableFuture<T> ftask = newTaskFor(task, result);
-		execute(ftask);
-		return ftask;
+	@Override
+	protected <V> RunnableScheduledFuture<V> decorateTask(Callable<V> callable,
+			RunnableScheduledFuture<V> task) {
+		throw new UnsupportedOperationException("Not implemented");
 	}
 
-	public <T> Future<T> submit(Callable<T> task) {
-		if (task == null) throw new NullPointerException();
-		RunnableFuture<T> ftask = newTaskFor(task);
-		execute(ftask);
-		return ftask;
+	@Override
+	public void setContinueExistingPeriodicTasksAfterShutdownPolicy(boolean value) {
+		throw new UnsupportedOperationException("Not implemented");
 	}
 
-	public ScheduledFuture<?> schedule(Runnable command,
-			long delay,
-			TimeUnit unit) {
-		if (command == null || unit == null)
-			throw new NullPointerException();
-		if (delay <= 0) {
-			RunnableScheduledFuture<?> t = decorateTask(command,
-					new ScheduledFutureTask<Boolean>(command, null));
-			t.run();
-			return t;
-		} else {
-			return super.schedule(command, delay, unit);
-		}
+	@Override
+	public boolean getContinueExistingPeriodicTasksAfterShutdownPolicy() {
+		throw new UnsupportedOperationException("Not implemented");
 	}
 
-	public <V> ScheduledFuture<V> schedule(Callable<V> callable,
-			long delay,
-			TimeUnit unit) {
-		if (callable == null || unit == null)
-			throw new NullPointerException();
-		if (delay <= 0) {
-			RunnableScheduledFuture<V> t = decorateTask(callable,
-					new ScheduledFutureTask<V>(callable));
-			t.run();
-			return t;
-		} else {
-			return super.schedule(callable, delay, unit);
-		}
+	@Override
+	public void setExecuteExistingDelayedTasksAfterShutdownPolicy(boolean value) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public boolean getExecuteExistingDelayedTasksAfterShutdownPolicy() {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public BlockingQueue<Runnable> getQueue() {
+		return super.getQueue();
+	}
+
+	@Override
+	public boolean isTerminating() {
+		return super.isTerminating();
+	}
+
+	@Override
+	protected void finalize() {
+		super.finalize();
+	}
+
+	@Override
+	public void setThreadFactory(ThreadFactory threadFactory) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public ThreadFactory getThreadFactory() {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public void setRejectedExecutionHandler(RejectedExecutionHandler handler) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public RejectedExecutionHandler getRejectedExecutionHandler() {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public void setCorePoolSize(int corePoolSize) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public int getCorePoolSize() {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public boolean prestartCoreThread() {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public int prestartAllCoreThreads() {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public boolean allowsCoreThreadTimeOut() {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public void allowCoreThreadTimeOut(boolean value) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public void setMaximumPoolSize(int maximumPoolSize) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public int getMaximumPoolSize() {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public void setKeepAliveTime(long time, TimeUnit unit) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public long getKeepAliveTime(TimeUnit unit) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public boolean remove(Runnable task) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public void purge() {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public int getPoolSize() {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public int getActiveCount() {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public int getLargestPoolSize() {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public long getTaskCount() {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public long getCompletedTaskCount() {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public String toString() {
+		return super.toString();
+	}
+
+	@Override
+	protected void beforeExecute(Thread t, Runnable r) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	protected void afterExecute(Runnable r, Throwable t) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	protected void terminated() {
+		super.terminated();
+	}
+
+	@Override
+	protected <T> RunnableFuture<T> newTaskFor(Runnable runnable, T value) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	protected <T> RunnableFuture<T> newTaskFor(Callable<T> callable) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+			throws InterruptedException, ExecutionException {
+		throw new UnsupportedOperationException("Not supported");
+	}
+
+	@Override
+	public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+			throws InterruptedException, ExecutionException, TimeoutException {
+		throw new UnsupportedOperationException("Not supported");
 	}
 
 	@Override
@@ -92,34 +244,105 @@ public class SynchronousScheduledExecutor extends ScheduledThreadPoolExecutor {
 		command.run();
 	}
 
-	static private class ScheduledFutureTask<V> extends FutureTask<V> implements RunnableScheduledFuture<V> {
-
-		public ScheduledFutureTask(Callable<V> callable) {
-			super(callable);
-		}
-
-		public ScheduledFutureTask(Runnable runnable, V result) {
-			super(runnable, result);
-		}
-
-		@Override
-		public long getDelay(TimeUnit unit) {
-			return 0;
-		}
-
-		@Override
-		public int compareTo(Delayed other) {
-			long d = (getDelay(TimeUnit.NANOSECONDS) -
-					other.getDelay(TimeUnit.NANOSECONDS));
-			return (d == 0)? 0 : ((d < 0)? -1 : 1);
-		}
-
-		@Override
-		public boolean isPeriodic() {
-			return false;
-		}
-
+	@Override
+	public void shutdown() {
+		super.shutdown();
 	}
+
+	@Override
+	public List<Runnable> shutdownNow() {
+		return super.shutdownNow();
+	}
+
+	@Override
+	public boolean isShutdown() {
+		return super.isShutdown();
+	}
+
+	@Override
+	public boolean isTerminated() {
+		return super.isTerminated();
+	}
+
+	@Override
+	public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+		return true;
+	}
+
+	@Override
+	public <T> Future<T> submit(Callable<T> task) {
+		try {
+			T result = task.call();
+			return new CompletedFuture<T>(result);
+		} catch (Throwable t) {
+			return new CompletedFuture<T>(new ExecutionException(t));
+		}
+	}
+
+	@Override
+	public <T> Future<T> submit(Runnable task, T result) {
+		try {
+			task.run();
+			return new CompletedFuture<T>(result);
+		} catch (Throwable t) {
+			return new CompletedFuture<T>(new ExecutionException(t));
+		}
+	}
+
+	@Override
+	public Future<?> submit(Runnable task) {
+		try {
+			task.run();
+			return new CompletedFuture<Object>(null);
+		} catch (Throwable t) {
+			return new CompletedFuture<Object>(new ExecutionException(t));
+		}
+	}
+
+	@Override
+	public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+			throws InterruptedException {
+		List<Future<T>> results = new ArrayList<Future<T>>();
+		for (Callable<T> task : tasks) {
+			results.add(submit(task));
+		}
+		return results;
+	}
+
+	@Override
+	public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout,
+			TimeUnit unit) throws InterruptedException {
+		return invokeAll(tasks);
+	}
+
+	@Override
+	public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+		command.run();
+		return null;
+	}
+
+	@Override
+	public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+		try {
+			callable.call();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+		return null;
+	}
+
+	@Override
+	public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period,
+			TimeUnit unit) {
+		return null;
+	}
+
+	@Override
+	public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay,
+			long delay, TimeUnit unit) {
+		return null;
+	}
+
 
 
 }

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/test/TestUtils.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/test/TestUtils.java
@@ -238,7 +238,7 @@ public class TestUtils {
 		final Ref<IHttpTransport> transportRef = new Ref<IHttpTransport>(transport == null ? new TestDojoHttpTransport() : transport);
 		final Ref<IExecutors> executorsRef = new Ref<IExecutors>(new ExecutorsImpl(
 				new SynchronousExecutor(),
-				null,
+				new SynchronousExecutor(),
 				new SynchronousScheduledExecutor(),
 				new SynchronousScheduledExecutor()));
 		final File workdir = workingDirectory;

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/util/AggregatorUtilTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/util/AggregatorUtilTest.java
@@ -21,9 +21,8 @@ import com.ibm.jaggr.core.options.IOptions;
 
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
+import org.junit.Assert;
 import org.junit.Test;
-
-import junit.framework.Assert;
 
 public class AggregatorUtilTest {
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/util/CompilerUtilTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/util/CompilerUtilTest.java
@@ -61,6 +61,7 @@ public class CompilerUtilTest {
 			tmpFile = null;
 		}
 	}
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testAddCompilerOptionsFromConfig() throws Exception {
 		Map<AccessibleObject, List<Object>> map = new HashMap<AccessibleObject, List<Object>>();

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/util/ConcurrentAddOnlyListTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/util/ConcurrentAddOnlyListTest.java
@@ -15,13 +15,12 @@
  */
 package com.ibm.jaggr.core.util;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
 import java.util.Arrays;
 import java.util.List;
-
-import junit.framework.Assert;
 
 public class ConcurrentAddOnlyListTest {
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/util/HasNodeTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/util/HasNodeTest.java
@@ -15,14 +15,13 @@
  */
 package com.ibm.jaggr.core.util;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-
-import junit.framework.Assert;
 
 public class HasNodeTest {
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/util/JSSourceTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/util/JSSourceTest.java
@@ -21,11 +21,10 @@ import com.google.javascript.jscomp.Compiler;
 import com.google.javascript.jscomp.JSSourceFile;
 import com.google.javascript.rhino.Node;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-
-import junit.framework.Assert;
 
 public class JSSourceTest {
 

--- a/jaggr-core/src/test/java/com/ibm/jaggr/core/util/SignalUtilTest.java
+++ b/jaggr-core/src/test/java/com/ibm/jaggr/core/util/SignalUtilTest.java
@@ -18,6 +18,7 @@ package com.ibm.jaggr.core.util;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,8 +26,6 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import junit.framework.Assert;
 
 public class SignalUtilTest {
 

--- a/jaggr-service/pom.xml
+++ b/jaggr-service/pom.xml
@@ -329,11 +329,6 @@
       <scope>test</scope>
     </dependency>
      <dependency>
-       <groupId>org.powermock</groupId>
-       <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-     </dependency>
-     <dependency>
       <groupId>com.ibm.jaggr</groupId>
       <artifactId>jaggr-sample-dojo</artifactId>
       <scope>test</scope>

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/config/BundleVersionsHash.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/config/BundleVersionsHash.java
@@ -22,6 +22,7 @@ import com.ibm.jaggr.core.IServiceRegistration;
 import com.ibm.jaggr.core.NotFoundException;
 import com.ibm.jaggr.core.config.IConfigScopeModifier;
 
+import com.ibm.jaggr.service.IBundleResolver;
 import com.ibm.jaggr.service.impl.AggregatorImpl;
 import com.ibm.jaggr.service.util.BundleVersionsHashBase;
 
@@ -72,6 +73,14 @@ public class BundleVersionsHash extends BundleVersionsHashBase implements IExten
 
 
 	private String propName = null;		// the name of the function (specified by plugin.xml)
+
+	public BundleVersionsHash() {
+	}
+
+	// For unit tests
+	public BundleVersionsHash(IBundleResolver resolver) {
+		super(resolver);
+	}
 
 	/* (non-Javadoc)
 	 * @see com.ibm.jaggr.core.config.IConfigScopeModifier#modifyScope(com.ibm.jaggr.core.IAggregator, org.mozilla.javascript.Context, org.mozilla.javascript.Scriptable)

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/resource/BundleResourceFactory.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/resource/BundleResourceFactory.java
@@ -65,7 +65,7 @@ public class BundleResourceFactory extends FileResourceFactory implements IExten
 
 	@Override
 	public IResource newResource(URI uri) {
-		BundleContext context = Activator.getBundleContext();
+		BundleContext context = getBundleContext();
 		IResource result = null;
 		String scheme = uri.getScheme();
 		if ("bundleresource".equals(scheme) || "bundleentry".equals(scheme)) { //$NON-NLS-1$ //$NON-NLS-2$
@@ -220,5 +220,9 @@ public class BundleResourceFactory extends FileResourceFactory implements IExten
 	 */
 	protected Bundle getBundle(String bundleName) {
 		return bundleResolver.getBundle(bundleName);
+	}
+
+	protected BundleContext getBundleContext() {
+		return Activator.getBundleContext();
 	}
 }

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/util/BundleVersionsHashBase.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/util/BundleVersionsHashBase.java
@@ -49,6 +49,10 @@ public class BundleVersionsHashBase {
 		bundleResolver = BundleResolverFactory.getResolver(null);
 	}
 
+	public BundleVersionsHashBase(IBundleResolver bundleResolver) {
+		this.bundleResolver = bundleResolver;
+	}
+
 	/**
 	 * @param contributingBundle
 	 */
@@ -79,7 +83,7 @@ public class BundleVersionsHashBase {
 	 * @return the bundle headers for the bundle.
 	 * @throws NotFoundException if no matching bundle is found.
 	 */
-	private Dictionary<?, ?> getBundleHeaders(String bundleName) throws NotFoundException {
+	protected Dictionary<?, ?> getBundleHeaders(String bundleName) throws NotFoundException {
 		final String sourceMethod = "getBundleHeaders"; //$NON-NLS-1$
 		boolean isTraceLogging = log.isLoggable(Level.FINER);
 		if (isTraceLogging) {

--- a/pom.xml
+++ b/pom.xml
@@ -529,26 +529,21 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.10</version>
+        <version>4.12</version>
       </dependency>
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>3.1</version>
+        <version>3.4</version>
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-core</artifactId>
-        <version>1.5.2</version>
+        <version>1.6.5</version>
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-api-easymock</artifactId>
-        <version>1.5.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-module-junit4</artifactId>
         <version>1.5.2</version>
       </dependency>
     </dependencies>


### PR DESCRIPTION
The test utils SynchronousExecutor and SynchronousScheduledExecutor were not implemented correctly and were creating threads each time a test case that used them was run.  Fixed that and also fixed LESS and CSS builders to be more efficient when unit testing (avoid creating thread pools for each test).
