### PR TITLE
Fix directory does not exist error in clean builds.

### DIFF
--- a/jaggr-core/pom.xml
+++ b/jaggr-core/pom.xml
@@ -383,9 +383,10 @@
               </goals>
               <configuration>
                 <target unless="skipTests">
+                  <mkdir dir="${basedir}/target/WebContent" />
                   <move todir="${basedir}/target/WebContent/dojo">
                     <fileset dir="${basedir}/target/WebContent">
-                      <include name="source_*_dojo/**" />
+                      <include name="dojo-*-src/**" />
                     </fileset>
                     <cutdirsmapper dirs="1" />
                   </move>


### PR DESCRIPTION
@chuckdumont 