### PR TITLE
Potential fix for bundle extraction issues on some platforms

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/less/LessModuleBuilder.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/modulebuilder/less/LessModuleBuilder.java
@@ -245,7 +245,7 @@ public class LessModuleBuilder extends CSSModuleBuilder implements IExtensionSin
 			log.entering(sourceClass, sourceMethod, new Object[]{css, resource});
 		}
 		if (resource.getPath().toLowerCase().endsWith(LESS_SUFFIX)) {
-			css = processLess(resource.getURI().toString(), css);
+			css = processLess(resource.getReferenceURI().toString(), css);
 			if (inlineImports) {
 				css = _inlineImports(request, css, resource, ""); //$NON-NLS-1$
 			}

--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/util/rhino/ReadFileExtFunction.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/util/rhino/ReadFileExtFunction.java
@@ -156,8 +156,9 @@ public class ReadFileExtFunction extends FunctionObject implements IConfigListen
 			}
 		}
 		if (res == null || !res.exists()) {
+			fileUri = URI.create(file);
 			// Not and AMD module or resource doesn't exist.  Try resolving against reference URI
-			if (ref != null && ref != Scriptable.NOT_FOUND && ref != Undefined.instance) {
+			if (!fileUri.isAbsolute() && ref != null && ref != Scriptable.NOT_FOUND && ref != Undefined.instance) {
 				URI refUri = URI.create(ref);
 				fileUri = refUri.resolve(file);
 			}


### PR DESCRIPTION
This fix should hopefully help resolve bundle extraction failures that result in LESS import not found exceptions.  This change will cause URLConverter.toFileUrl() to be called for individual LESS imports residing in OSGi bundles identified in the server-side AMD config using the namedbundleresource pseudo protocol.  This will give the framework another chance to extract the file from the bundle if it has not already done so.