### PR TITLE
Revert Domino workaround and export jaggr-service impl classes

### DIFF
--- a/jaggr-service/pom.xml
+++ b/jaggr-service/pom.xml
@@ -121,11 +121,8 @@
             <Bundle-Activator>${project.groupId}.service.impl.Activator</Bundle-Activator>
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
             <Export-Package>
-              ${project.groupId}.service.impl;version="${project.version}",
-              !${project.groupId}.service.impl.*;version="${project.version}",
               ${project.groupId}.service.*;version="${project.version}"
             </Export-Package>
-            <Private-Package>${project.groupId}.service.impl.*;version="${project.version}"</Private-Package>
             <Require-Bundle>org.eclipse.core.runtime</Require-Bundle>
             <Import-Package>
               ${project.groupId}.core;version="${project.version}",

--- a/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/resource/BundleResourceFactory.java
+++ b/jaggr-service/src/main/java/com/ibm/jaggr/service/impl/resource/BundleResourceFactory.java
@@ -30,7 +30,6 @@ import com.ibm.jaggr.service.impl.Activator;
 import com.ibm.jaggr.service.impl.AggregatorImpl;
 import com.ibm.jaggr.service.util.BundleResolverFactory;
 
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.osgi.service.urlconversion.URLConverter;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -155,9 +154,7 @@ public class BundleResourceFactory extends FileResourceFactory implements IExten
 	@Override
 	public void initialize(IAggregator aggregator, IAggregatorExtension extension, IExtensionRegistrar registrar) {
 		contributingBundle = ((AggregatorImpl)aggregator).getContributingBundle();
-		if (Platform.getBundle("com.ibm.domino.osgi.core") == null) {		// URLConverter is unreliable on Domino
-			urlConverterSR = Activator.getBundleContext().getServiceReference(org.eclipse.osgi.service.urlconversion.URLConverter.class.getName());
-		}
+		urlConverterSR = Activator.getBundleContext().getServiceReference(org.eclipse.osgi.service.urlconversion.URLConverter.class.getName());
 		bundleResolver = BundleResolverFactory.getResolver(contributingBundle);
 	}
 


### PR DESCRIPTION
This will allow the workaround for Domino to be implemented in application specific subclasses.