### PR TITLE
Fix repeating dependency verification exception bug

### DIFF
--- a/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/deps/DepTreeNode.java
+++ b/jaggr-core/src/main/java/com/ibm/jaggr/core/impl/deps/DepTreeNode.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -587,10 +588,12 @@ public class DepTreeNode implements Cloneable, Serializable {
 	 */
 	void normalizeDependencies() {
 		if (defineDependencies != null) {
-			defineDependencies = PathUtil.normalizePaths(getParentPath(), defineDependencies);
+			LinkedHashSet<String> temp =  new LinkedHashSet<String>(Arrays.asList(PathUtil.normalizePaths(getParentPath(), defineDependencies)));		// normalize and remove dups
+			defineDependencies = temp.toArray(new String[temp.size()]);
 		}
 		if (requireDependencies != null) {
-			requireDependencies = PathUtil.normalizePaths(getParentPath(), requireDependencies);
+			LinkedHashSet<String> temp =  new LinkedHashSet<String>(Arrays.asList(PathUtil.normalizePaths(getParentPath(), requireDependencies)));		// normalize and remove dups
+			requireDependencies = temp.toArray(new String[temp.size()]);
 		}
 		if (children != null) {
 			for (Entry<String, DepTreeNode> entry : children.entrySet()) {


### PR DESCRIPTION
If an AMD module includes the same dependency twice but the module ids are not identical, then when development mode and verify dependencies are both enabled, a DependencyVerificationException response will occur that does not resolve when dependencies are verified.

Example:
```
define(['a/foo', './foo'], function(foo) {
});
```
where both module ids resolve to the same module.